### PR TITLE
internal: Report sysdeps errors in return value

### DIFF
--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -152,8 +153,10 @@ int remove(const char *filename) {
 	__builtin_unreachable();
 }
 int rename(const char *path, const char *new_path) {
-	if(mlibc::sys_rename(path, new_path))
+	if(int e = mlibc::sys_rename(path, new_path); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 int renameat(int olddirfd, const char *old_path, int newdirfd, const char *new_path) {

--- a/options/glibc/generic/sys-ioctl.cpp
+++ b/options/glibc/generic/sys-ioctl.cpp
@@ -1,11 +1,17 @@
 
+#include <errno.h>
 #include <sys/ioctl.h>
+
 #include <bits/ensure.h>
 #include <mlibc/debug.hpp>
-
 #include <mlibc/sysdeps.hpp>
 
 int ioctl(int fd, unsigned long request, void *arg) {
-	return mlibc::sys_ioctl(fd, request, arg);
+	int result;
+	if(int e = mlibc::sys_ioctl(fd, request, arg, &result); e) {
+		errno = e;
+		return -1;
+	}
+	return result;
 }
 

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -57,7 +57,9 @@ int sys_close(int fd);
 	int sys_access(const char *path, int mode);
 	int sys_dup(int fd, int flags, int *newfd);
 	int sys_dup2(int fd, int flags, int newfd);
-	int sys_isatty(int fd, int *ptr);
+	// In contrast to the isatty() library function, the sysdep function uses return value
+	// zero (and not one) to indicate that the file is a terminal.
+	int sys_isatty(int fd);
 	int sys_stat(const char *path, struct stat *statbuf);
 	int sys_lstat(const char *path, struct stat *statbuf);
 	int sys_fstat(int fd, struct stat *statbuf);
@@ -77,7 +79,7 @@ int sys_close(int fd);
 	void sys_yield();
 	int sys_sleep(time_t *secs, long *nanos);
 	int sys_fork(pid_t *child);
-	void sys_execve(const char *path, char *const argv[], char *const envp[]);
+	int sys_execve(const char *path, char *const argv[], char *const envp[]);
 	int sys_timerfd_create(int flags, int *fd);
 	int sys_timerfd_settime(int fd, int flags,
 			const struct itimerspec *value);
@@ -86,7 +88,7 @@ int sys_close(int fd);
 	int sys_mkdir(const char *path);
 	int sys_symlink(const char *target_path, const char *link_path);
 	int sys_rename(const char *path, const char *new_path);
-	int sys_fcntl(int fd, int request, va_list args);
+	int sys_fcntl(int fd, int request, va_list args, int *result);
 	int sys_ttyname(int fd, char *buf, size_t size);
 #endif // !defined(MLIBC_BUILDING_RTDL)
 
@@ -106,9 +108,9 @@ int sys_vm_unmap(void *pointer, size_t size);
 	int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events);
 	int sys_epoll_create(int flags, int *fd);
 	int sys_epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev);
-	int sys_epoll_wait(int epfd, struct epoll_event *evnts, int n, int timeout);
+	int sys_epoll_wait(int epfd, struct epoll_event *evnts, int n, int timeout, int *raised);
 	int sys_inotify_create(int flags, int *fd);
-	int sys_ioctl(int fd, unsigned long request, void *arg);
+	int sys_ioctl(int fd, unsigned long request, void *arg, int *result);
 	int sys_getsockopt(int fd, int layer, int number,
 			void *__restrict buffer, socklen_t *__restrict size);
 	int sys_setsockopt(int fd, int layer, int number,

--- a/options/linux/generic/poll-stubs.cpp
+++ b/options/linux/generic/poll-stubs.cpp
@@ -1,14 +1,17 @@
 
-#include <bits/ensure.h>
+#include <errno.h>
 #include <poll.h>
 
+#include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/sysdeps.hpp>
 
 int poll(struct pollfd *fds, nfds_t count, int timeout) {
 	int num_events;
-	if(mlibc::sys_poll(fds, count, timeout, &num_events))
+	if(int e = mlibc::sys_poll(fds, count, timeout, &num_events); e) {
+		errno = e;
 		return -1;
+	}
 	return num_events;
 }
 

--- a/options/linux/generic/sys-epoll.cpp
+++ b/options/linux/generic/sys-epoll.cpp
@@ -1,13 +1,16 @@
 
+#include <errno.h>
 #include <sys/epoll.h>
-#include <bits/ensure.h>
 
+#include <bits/ensure.h>
 #include <mlibc/sysdeps.hpp>
 
 int epoll_create(int) {
 	int fd;
-	if(mlibc::sys_epoll_create(0, &fd))
+	if(int e = mlibc::sys_epoll_create(0, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 
@@ -18,16 +21,27 @@ int epoll_pwait(int, struct epoll_event *, int, int, const sigset_t *) {
 
 int epoll_create1(int flags) {
 	int fd;
-	if(mlibc::sys_epoll_create(flags, &fd))
+	if(int e = mlibc::sys_epoll_create(flags, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 
 int epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev) {
-	return mlibc::sys_epoll_ctl(epfd, mode, fd, ev);
+	if(int e = mlibc::sys_epoll_ctl(epfd, mode, fd, ev); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int epoll_wait(int epfd, struct epoll_event *evnts, int n, int timeout) {
-	return mlibc::sys_epoll_wait(epfd, evnts, n, timeout);
+	int raised;
+	if(int e = mlibc::sys_epoll_wait(epfd, evnts, n, timeout, &raised)) {
+		errno = e;
+		return -1;
+	}
+	return raised;
 }
 

--- a/options/linux/generic/sys-inotify-stubs.cpp
+++ b/options/linux/generic/sys-inotify-stubs.cpp
@@ -1,21 +1,26 @@
 
-#include <bits/ensure.h>
+#include <errno.h>
 #include <sys/inotify.h>
 
+#include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/sysdeps.hpp>
 
 int inotify_init(void) {
 	int fd;
-	if(mlibc::sys_inotify_create(0, &fd))
+	if(int e = mlibc::sys_inotify_create(0, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 
 int inotify_init1(int flags) {
 	int fd;
-	if(mlibc::sys_inotify_create(0, &fd))
+	if(int e = mlibc::sys_inotify_create(0, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 

--- a/options/linux/generic/sys-mount.cpp
+++ b/options/linux/generic/sys-mount.cpp
@@ -1,12 +1,17 @@
 
+#include <errno.h>
 #include <sys/mount.h>
-#include <bits/ensure.h>
 
+#include <bits/ensure.h>
 #include <mlibc/sysdeps.hpp>
 
 int mount(const char *source, const char *target,
 		const char *fstype, unsigned long flags, const void *data) {
-	return mlibc::sys_mount(source, target, fstype, flags, data);
+	if(int e = mlibc::sys_mount(source, target, fstype, flags, data); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 

--- a/options/linux/generic/sys-signalfd.cpp
+++ b/options/linux/generic/sys-signalfd.cpp
@@ -1,13 +1,16 @@
 
-#include <bits/ensure.h>
+#include <errno.h>
 #include <sys/signalfd.h>
 
+#include <bits/ensure.h>
 #include <mlibc/sysdeps.hpp>
 
 int signalfd(int fd, const sigset_t *mask, int flags) {
 	__ensure(fd == -1);
-	if(mlibc::sys_signalfd_create(*mask, flags, &fd))
+	if(int e = mlibc::sys_signalfd_create(*mask, flags, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 

--- a/options/linux/generic/sys-timerfd.cpp
+++ b/options/linux/generic/sys-timerfd.cpp
@@ -1,14 +1,17 @@
 
-#include <bits/ensure.h>
+#include <errno.h>
 #include <sys/timerfd.h>
 
+#include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/sysdeps.hpp>
 
 int timerfd_create(int, int flags) {
 	int fd;
-	if(mlibc::sys_timerfd_create(flags, &fd))
+	if(int e = mlibc::sys_timerfd_create(flags, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 
@@ -16,8 +19,10 @@ int timerfd_settime(int fd, int flags, const struct itimerspec *value,
 		struct itimerspec *oldvalue) {
 	__ensure(!oldvalue);
 
-	if(mlibc::sys_timerfd_settime(fd, flags, value))
+	if(int e = mlibc::sys_timerfd_settime(fd, flags, value); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/options/posix/generic/dirent-stubs.cpp
+++ b/options/posix/generic/dirent-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <dirent.h>
 #include <unistd.h>
 
@@ -30,7 +31,8 @@ DIR *opendir(const char *path) {
 	dir->__ent_next = 0;
 	dir->__ent_limit = 0;
 
-	if(mlibc::sys_open_dir(path, &dir->__handle)) {
+	if(int e = mlibc::sys_open_dir(path, &dir->__handle); e) {
+		errno = e;
 		frg::destruct(getAllocator(), dir);
 		return nullptr;
 	}else{
@@ -40,7 +42,7 @@ DIR *opendir(const char *path) {
 struct dirent *readdir(DIR *dir) {
 	__ensure(dir->__ent_next <= dir->__ent_limit);
 	if(dir->__ent_next == dir->__ent_limit) {
-		if(mlibc::sys_read_entries(dir->__handle, dir->__ent_buffer, 2048, &dir->__ent_limit))
+		if(int e = mlibc::sys_read_entries(dir->__handle, dir->__ent_buffer, 2048, &dir->__ent_limit); e)
 			__ensure(!"mlibc::sys_read_entries() failed");
 		dir->__ent_next = 0;
 		if(!dir->__ent_limit)

--- a/options/posix/generic/fcntl-stubs.cpp
+++ b/options/posix/generic/fcntl-stubs.cpp
@@ -14,9 +14,13 @@ int creat(const char *, mode_t) {
 int fcntl(int fd, int command, ...) {
 	va_list args;
 	va_start(args, command);
-	int val = mlibc::sys_fcntl(fd, command, args);
+	int result;
+	if(int e = mlibc::sys_fcntl(fd, command, args, &result); e) {
+		errno = e;
+		return -1;
+	}
 	va_end(args);
-	return val;
+	return result;
 }
 
 int openat(int, const char *, int, ...) {
@@ -42,8 +46,10 @@ int posix_fallocate(int fd, off_t offset, off_t size) {
 
 	error_guard guard;
 
-	if(mlibc::sys_fallocate(fd, offset, size))
-		return errno;
+	if(int e = mlibc::sys_fallocate(fd, offset, size); e) {
+		errno = e;
+		return -1;
+	}
 	return 0;
 }
 
@@ -60,8 +66,10 @@ int open_by_handle_at(int, struct file_handle *, int) {
 
 int open(const char *pathname, int flags, ...) {
 	int fd;
-	if(mlibc::sys_open(pathname, flags, &fd))
+	if(int e = mlibc::sys_open(pathname, flags, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 
 }

--- a/options/posix/generic/posix_signal.cpp
+++ b/options/posix/generic/posix_signal.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <signal.h>
 #include <bits/ensure.h>
 
@@ -40,20 +41,26 @@ int pthread_sigmask(int, const sigset_t *__restrict, sigset_t *__restrict) {
 }
 
 int sigprocmask(int how, const sigset_t *__restrict set, sigset_t *__restrict retrieve) {
-	if(mlibc::sys_sigprocmask(how, set, retrieve))
+	if(int e = mlibc::sys_sigprocmask(how, set, retrieve); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 
 int sigaction(int signum, const struct sigaction *__restrict act, struct sigaction *__restrict oldact) {
-	if(mlibc::sys_sigaction(signum, act, oldact))
+	if(int e = mlibc::sys_sigaction(signum, act, oldact); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 
 int kill(pid_t pid, int number) {
-	if(mlibc::sys_kill(pid, number))
+	if(int e = mlibc::sys_kill(pid, number); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -42,13 +42,15 @@ int mkstemp(char *pattern) {
 
 		// TODO: Add a mode argument to sys_open().
 		int fd;
-		if(!mlibc::sys_open(pattern, O_RDWR | O_CREAT | O_EXCL, /*S_IRUSR | S_IWUSR,*/ &fd))
+		if(int e = mlibc::sys_open(pattern, O_RDWR | O_CREAT | O_EXCL, /*S_IRUSR | S_IWUSR,*/ &fd); !e) {
 			return fd;
-		if(errno != EEXIST)
+		}else if(e != EEXIST) {
+			errno = e;
 			return -1;
+		}
 	}
 
-	__ensure(errno == EEXIST);
+	errno = EEXIST;
 	return -1;
 }
 

--- a/options/posix/generic/sys-mman-stubs.cpp
+++ b/options/posix/generic/sys-mman-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <sys/mman.h>
 #include <bits/ensure.h>
 
@@ -46,8 +47,10 @@ void *mremap(void *pointer, size_t size, size_t new_size, int flags, ...) {
 	__ensure(flags == MREMAP_MAYMOVE);
 
 	void *window;
-	if(mlibc::sys_vm_remap(pointer, size, new_size, &window))
+	if(int e = mlibc::sys_vm_remap(pointer, size, new_size, &window); e) {
+		errno = e;
 		return (void *)-1;
+	}
 	return window;
 }
 
@@ -58,14 +61,18 @@ int remap_file_pages(void *, size_t, int, size_t, int) {
 
 void *mmap(void *hint, size_t size, int prot, int flags, int fd, off_t offset) {
 	void *window;
-	if(mlibc::sys_vm_map(hint, size, prot, flags, fd, offset, &window))
+	if(int e = mlibc::sys_vm_map(hint, size, prot, flags, fd, offset, &window); e) {
+		errno = e;
 		return (void *)-1;
+	}
 	return window;
 }
 
 int munmap(void *pointer, size_t size) {
-	if(mlibc::sys_vm_unmap(pointer, size))
+	if(int e = mlibc::sys_vm_unmap(pointer, size); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/options/posix/generic/sys-socket-stubs.cpp
+++ b/options/posix/generic/sys-socket-stubs.cpp
@@ -1,7 +1,8 @@
 
-#include <bits/ensure.h>
+#include <errno.h>
 #include <sys/socket.h>
 
+#include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/sysdeps.hpp>
 
@@ -10,20 +11,26 @@ int accept(int fd, struct sockaddr *__restrict addr_ptr, socklen_t *__restrict a
 		mlibc::infoLogger() << "\e[35mmlibc: accept() does not fill struct sockaddr\e[39m"
 				<< frg::endlog;
 	int newfd;
-	if(mlibc::sys_accept(fd, &newfd))
+	if(int e = mlibc::sys_accept(fd, &newfd); e) {
+		errno = e;
 		return -1;
+	}
 	return newfd;
 }
 
 int bind(int fd, const struct sockaddr *addr_ptr, socklen_t addr_len) {
-	if(mlibc::sys_bind(fd, addr_ptr, addr_len))
+	if(int e = mlibc::sys_bind(fd, addr_ptr, addr_len); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 
 int connect(int fd, const struct sockaddr *addr_ptr, socklen_t addr_len) {
-	if(mlibc::sys_connect(fd, addr_ptr, addr_len))
+	if(int e = mlibc::sys_connect(fd, addr_ptr, addr_len); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 
@@ -34,8 +41,10 @@ int getpeername(int, struct sockaddr *__restrict, socklen_t *__restrict) {
 
 int getsockname(int fd, struct sockaddr *__restrict addr_ptr, socklen_t *__restrict addr_length) {
 	socklen_t actual_length;
-	if(mlibc::sys_sockname(fd, addr_ptr, *addr_length, &actual_length))
+	if(int e = mlibc::sys_sockname(fd, addr_ptr, *addr_length, &actual_length); e) {
+		errno = e;
 		return -1;
+	}
 	*addr_length = actual_length;
 	return 0;
 }
@@ -62,8 +71,10 @@ ssize_t recvfrom(int, void *__restrict, size_t, int, struct sockaddr *__restrict
 
 ssize_t recvmsg(int fd, struct msghdr *hdr, int flags) {
 	ssize_t length;
-	if(mlibc::sys_msg_recv(fd, hdr, flags, &length))
+	if(int e = mlibc::sys_msg_recv(fd, hdr, flags, &length); e) {
+		errno = e;
 		return -1;
+	}
 	return length;
 }
 
@@ -74,8 +85,10 @@ ssize_t send(int, const void *, size_t, int) {
 
 ssize_t sendmsg(int fd, const struct msghdr *hdr, int flags) {
 	ssize_t length;
-	if(mlibc::sys_msg_send(fd, hdr, flags, &length))
+	if(int e = mlibc::sys_msg_send(fd, hdr, flags, &length); e) {
+		errno = e;
 		return -1;
+	}
 	return length;
 }
 
@@ -101,14 +114,18 @@ int sockatmark(int) {
 
 int socket(int family, int type, int protocol) {
 	int fd;
-	if(mlibc::sys_socket(family, type, protocol, &fd))
+	if(int e = mlibc::sys_socket(family, type, protocol, &fd); e) {
+		errno = e;
 		return -1;
+	}
 	return fd;
 }
 
 int socketpair(int domain, int type, int protocol, int sv[2]) {
-	if(mlibc::sys_socketpair(domain, type, protocol, sv))
+	if(int e = mlibc::sys_socketpair(domain, type, protocol, sv); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/options/posix/generic/sys-stat-stubs.cpp
+++ b/options/posix/generic/sys-stat-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <bits/ensure.h>
 #include <sys/stat.h>
 
@@ -29,8 +30,10 @@ int futimens(int fd, const struct timespec times[2]) {
 }
 int mkdir(const char *path, mode_t) {
 	mlibc::infoLogger() << "\e[31mmlibc: mkdir() ignore the mode\e[39m" << frg::endlog;
-	if(mlibc::sys_mkdir(path))
+	if(int e = mlibc::sys_mkdir(path); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 int mkdirat(int, const char *, mode_t) {
@@ -66,14 +69,26 @@ int utimensat(int, const char *, const struct timespec times[2], int) {
 
 
 int stat(const char *__restrict path, struct stat *__restrict result) {
-	return mlibc::sys_stat(path, result);
+	if(int e = mlibc::sys_stat(path, result); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int lstat(const char *__restrict path, struct stat *__restrict result) {
-	return mlibc::sys_lstat(path, result);
+	if(int e = mlibc::sys_lstat(path, result); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int fstat(int fd, struct stat *result) {
-	return mlibc::sys_fstat(fd, result);
+	if(int e = mlibc::sys_fstat(fd, result); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 

--- a/options/posix/generic/sys-time-stubs.cpp
+++ b/options/posix/generic/sys-time-stubs.cpp
@@ -1,8 +1,9 @@
 
+#include <errno.h>
 #include <sys/time.h>
 #include <time.h>
-#include <bits/ensure.h>
 
+#include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/sysdeps.hpp>
 
@@ -11,8 +12,10 @@ int gettimeofday(struct timeval *__restrict result, void *__restrict unused) {
 
 	if(result) {
 		long nanos;
-		if(mlibc::sys_clock_get(CLOCK_REALTIME, &result->tv_sec, &nanos))
+		if(int e = mlibc::sys_clock_get(CLOCK_REALTIME, &result->tv_sec, &nanos); e) {
+			errno = e;
 			return -1;
+		}
 		result->tv_usec = nanos / 1000;
 	}
 	return 0;

--- a/options/posix/generic/sys-wait-stubs.cpp
+++ b/options/posix/generic/sys-wait-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <sys/wait.h>
 #include <bits/ensure.h>
 
@@ -15,8 +16,10 @@ int waitid(idtype_t idtype, id_t id, siginfo_t *siginfo, int flags) {
 }
 
 pid_t waitpid(pid_t pid, int *status, int flags) {
-	if(mlibc::sys_waitpid(pid, status, flags))
+	if(int e = mlibc::sys_waitpid(pid, status, flags); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/options/posix/generic/termios-stubs.cpp
+++ b/options/posix/generic/termios-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <termios.h>
 
 #include <bits/ensure.h>
@@ -34,8 +35,10 @@ int tcflush(int, int) {
 }
 
 int tcgetattr(int fd, struct termios *attr) {
-	if(mlibc::sys_tcgetattr(fd, attr))
+	if(int e = mlibc::sys_tcgetattr(fd, attr); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 
@@ -49,8 +52,10 @@ int tcsendbreak(int, int) {
 }
 
 int tcsetattr(int fd, int opts, const struct termios *attr) {
-	if(mlibc::sys_tcsetattr(fd, opts, attr))
+	if(int e = mlibc::sys_tcsetattr(fd, opts, attr); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <stdarg.h>
 #include <bits/ensure.h>
 #include <string.h>
@@ -104,8 +105,10 @@ int fsync(int) {
 	__builtin_unreachable();
 }
 int ftruncate(int fd, off_t size) {
-	if(mlibc::sys_ftruncate(fd, size))
+	if(int e = mlibc::sys_ftruncate(fd, size); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 char *getcwd(char *, size_t) {
@@ -181,8 +184,10 @@ int pause(void) {
 	__builtin_unreachable();
 }
 int pipe(int *fds) {
-	if(mlibc::sys_pipe(fds))
+	if(int e = mlibc::sys_pipe(fds); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 ssize_t pread(int, void *, size_t, off_t) {
@@ -195,8 +200,10 @@ ssize_t pwrite(int, const void *, size_t, off_t) {
 }
 ssize_t readlink(const char *__restrict path, char *__restrict buffer, size_t max_size) {
 	ssize_t length;
-	if(mlibc::sys_readlink(path, buffer, max_size, &length))
+	if(int e = mlibc::sys_readlink(path, buffer, max_size, &length); e) {
+		errno = e;
 		return -1;
+	}
 	return length;
 }
 ssize_t readlinkat(int, const char *__restrict, char *__restrict, size_t) {
@@ -247,8 +254,10 @@ void swab(const void *__restrict, void *__restrict, ssize_t) {
 	__ensure(!"Not implemented");
 }
 int symlink(const char *target_path, const char *link_path) {
-	if(mlibc::sys_symlink(target_path, link_path))
+	if(int e = mlibc::sys_symlink(target_path, link_path); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 int symlinkat(const char *, int, const char *) {
@@ -283,8 +292,10 @@ int truncate(const char *, off_t) {
 char *ttyname(int fd) {
 	const size_t size = 128;
 	static thread_local char buf[size];
-	if(mlibc::sys_ttyname(fd, buf, size))
+	if(int e = mlibc::sys_ttyname(fd, buf, size); e) {
+		errno = e;
 		return nullptr;
+	}
 	return buf;
 }
 
@@ -293,8 +304,10 @@ int ttyname_r(int, char *, size_t) {
 	__builtin_unreachable();
 }
 int unlink(const char *path) {
-	if(mlibc::sys_unlink(path))
+	if(int e = mlibc::sys_unlink(path); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 int unlinkat(int, const char *, int) {
@@ -322,22 +335,28 @@ pid_t gettid(void) {
 
 ssize_t write(int fd, const void *buf, size_t count) {
 	ssize_t bytes_written;
-	if(mlibc::sys_write(fd, buf, count, &bytes_written))
+	if(int e = mlibc::sys_write(fd, buf, count, &bytes_written); e) {
+		errno = e;
 		return (ssize_t)-1;
+	}
 	return bytes_written;
 }
 
 ssize_t read(int fd, void *buf, size_t count) {
 	ssize_t bytes_read;
-	if(mlibc::sys_read(fd, buf, count, &bytes_read))
+	if(int e = mlibc::sys_read(fd, buf, count, &bytes_read); e) {
+		errno = e;
 		return (ssize_t)-1;
+	}
 	return bytes_read;
 }
 
 off_t lseek(int fd, off_t offset, int whence) {
 	off_t new_offset;
-	if(mlibc::sys_seek(fd, offset, whence, &new_offset))
+	if(int e = mlibc::sys_seek(fd, offset, whence, &new_offset); e) {
+		errno = e;
 		return (off_t)-1;
+	}
 	return new_offset;
 }
 
@@ -361,26 +380,34 @@ int usleep(useconds_t usecs) {
 
 int dup(int fd) {
 	int newfd;
-	if(mlibc::sys_dup(fd, 0, &newfd))
+	if(int e = mlibc::sys_dup(fd, 0, &newfd); e) {
+		errno = e;
 		return -1;
+	}
 	return newfd;
 }
 
 int dup2(int fd, int newfd) {
-	if(mlibc::sys_dup2(fd, 0, newfd))
+	if(int e = mlibc::sys_dup2(fd, 0, newfd); e) {
+		errno = e;
 		return -1;
+	}
 	return newfd;
 }
 
 pid_t fork(void) {
 	pid_t child;
-	if(mlibc::sys_fork(&child))
+	if(int e = mlibc::sys_fork(&child); e) {
+		errno = e;
 		return -1;
+	}
 	return child;
 }
 
 int execve(const char *path, char *const argv[], char *const envp[]) {
-	mlibc::sys_execve(path, argv, envp);
+	int e = mlibc::sys_execve(path, argv, envp);
+	__ensure(e && "sys_execve() is expected to fail if it returns");
+	errno = e;
 	return -1;
 }
 
@@ -411,11 +438,11 @@ int access(const char *path, int mode) {
 }
 
 int isatty(int fd) {
-	int val;
-	if(mlibc::sys_isatty(fd, &val)) {
+	if(int e = mlibc::sys_isatty(fd); e) {
+		errno = e;
 		return 0;
 	}
-	return val;
+	return 1;
 }
 
 int pipe2(int *pipefd, int flags) {
@@ -424,8 +451,10 @@ int pipe2(int *pipefd, int flags) {
 }
 
 int chroot(const char *ptr) {
-	if(mlibc::sys_chroot(ptr))
+	if(int e = mlibc::sys_chroot(ptr); e) {
+		errno = e;
 		return -1;
+	}
 	return 0;
 }
 

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -135,7 +135,7 @@ int sys_fork(pid_t *child) {
 	return 0;
 }
 
-void sys_execve(const char *path, char *const argv[], char *const envp[]) {
+int sys_execve(const char *path, char *const argv[], char *const envp[]) {
 	frigg::String<MemoryAllocator> args_area(getAllocator());
 	for(auto it = argv; *it; ++it)
 		args_area += frigg::StringView{*it, strlen(*it) + 1};


### PR DESCRIPTION
Before this patch, sysdeps functions reported their errors in errno. Now, the error is reported in the return value and updating errno is done by the wrapper function that calls into sysdeps.

This approach has the advantage that mlibc can call sysdeps without having to worry about clobbering errno. Previously, annoying errno save/restore boilerplate would have been necessary.

Fixes #3.