### PR TITLE
Implement recursive pthread mutexes

### DIFF
--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -36,6 +36,7 @@ enum class fsfd_target {
 void sys_libc_log(const char *message);
 [[noreturn]] void sys_libc_panic();
 
+[[gnu::weak]] int sys_futex_tid();
 int sys_futex_wait(int *pointer, int expected);
 int sys_futex_wake(int *pointer);
 


### PR DESCRIPTION
This patch implements recursive mutexes in `pthread_mutex_lock` and `pthread_mutex_unlock`.