### PR TITLE
Added required functions for GNU Tar

### DIFF
--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -82,6 +82,7 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_fallocate(int fd, off_t offset, size_t size);
 	[[gnu::weak]] int sys_unlink(const char *path);
 	[[gnu::weak]] int sys_unlinkat(int fd, const char *path, int flags);
+	[[gnu::weak]] int sys_openat(int dirfd, const char *path, int flags, int *fd);
 	[[gnu::weak]] int sys_socket(int family, int type, int protocol, int *fd);
 	[[gnu::weak]] int sys_msg_send(int fd, const struct msghdr *hdr, int flags, ssize_t *length);
 	[[gnu::weak]] int sys_msg_recv(int fd, struct msghdr *hdr, int flags, ssize_t *length);

--- a/options/posix/generic/fcntl-stubs.cpp
+++ b/options/posix/generic/fcntl-stubs.cpp
@@ -7,9 +7,8 @@
 #include <mlibc/debug.hpp>
 #include <mlibc/sysdeps.hpp>
 
-int creat(const char *, mode_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int creat(const char *pathname, mode_t mode) {
+	return open(pathname, O_CREAT|O_WRONLY|O_TRUNC, mode);
 }
 
 int fcntl(int fd, int command, ...) {

--- a/options/posix/generic/fcntl-stubs.cpp
+++ b/options/posix/generic/fcntl-stubs.cpp
@@ -28,9 +28,18 @@ int fcntl(int fd, int command, ...) {
 	return result;
 }
 
-int openat(int, const char *, int, ...) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int openat(int dirfd, const char *pathname, int flags, ...) {
+	int fd;
+	if(!mlibc::sys_openat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_openat(dirfd, pathname, flags, &fd); e) {
+		errno = e;
+		return -1;
+	}
+	return fd;
 }
 
 int posix_fadvise(int fd, off_t offset, off_t length, int advice) {

--- a/options/posix/generic/pwd-stubs.cpp
+++ b/options/posix/generic/pwd-stubs.cpp
@@ -72,9 +72,26 @@ struct passwd *getpwent(void) {
 	__builtin_unreachable();
 }
 
-struct passwd *getpwnam(const char *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+struct passwd *getpwnam(const char *name) {
+	auto file = fopen("/etc/passwd", "r");
+	if(!file)
+		return nullptr;
+
+	clear_entry(&global_entry);
+
+	char line[512];
+	while(fgets(line, 512, file)) {
+		if(!extract_entry(line, &global_entry))
+			continue;
+		if(global_entry.pw_name == name) {
+			fclose(file);
+			return &global_entry;
+		}
+	}
+
+	fclose(file);
+	errno = ESRCH;
+	return nullptr;
 }
 
 int getpwnam_r(const char *, struct passwd *, char *, size_t, struct passwd **) {

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -163,10 +163,13 @@ int faccessat(int, const char *, int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int fchown(int fd, uid_t uid, gid_t gid) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "\e[31mmlibc: fchown() is not implemented correctly\e[39m"
+			<< frg::endlog;
+	return 0;
 }
+
 int fchownat(int fd, const char *path, uid_t uid, gid_t gid, int flags) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -3543,14 +3543,20 @@ int sys_fallocate(int fd, off_t offset, size_t size) {
 }
 
 int sys_unlink(const char *path) {
+	return sys_unlinkat(AT_FDCWD, path, 0);
+}
+
+int sys_unlinkat(int fd, const char *path, int flags) {
 	SignalGuard sguard;
 	HelAction actions[3];
 
 	globalQueue.trim();
 
 	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-	req.set_request_type(managarm::posix::CntReqType::UNLINK);
+	req.set_request_type(managarm::posix::CntReqType::UNLINKAT);
+	req.set_fd(fd);
 	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), path));
+	req.set_flags(flags);
 
 	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 	req.SerializeToString(&ser);

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2988,6 +2988,66 @@ int sys_open(const char *path, int flags, int *fd) {
 	}
 }
 
+int sys_openat(int dirfd, const char *path, int flags, int *fd) {
+	SignalGuard sguard;
+	HelAction actions[3];
+
+	globalQueue.trim();
+
+	uint32_t proto_flags = 0;
+	if(flags & __MLIBC_O_CREAT)
+		proto_flags |= managarm::posix::OpenFlags::OF_CREATE;
+	if(flags & __MLIBC_O_EXCL)
+		proto_flags |= managarm::posix::OpenFlags::OF_EXCLUSIVE;
+	if(flags & __MLIBC_O_NONBLOCK) {
+		mlibc::infoLogger() << "mlibc: openat() has O_NONBLOCK set but ignored" << frg::endlog;
+		//proto_flags |= managarm::posix::OpenFlags::OF_NONBLOCK;
+	}
+
+	if(flags & __MLIBC_O_CLOEXEC)
+		proto_flags |= managarm::posix::OpenFlags::OF_CLOEXEC;
+
+	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
+	req.set_request_type(managarm::posix::CntReqType::OPENAT);
+	req.set_fd(dirfd);
+	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), path));
+	req.set_flags(proto_flags);
+
+	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
+	req.SerializeToString(&ser);
+	actions[0].type = kHelActionOffer;
+	actions[0].flags = kHelItemAncillary;
+	actions[1].type = kHelActionSendFromBuffer;
+	actions[1].flags = kHelItemChain;
+	actions[1].buffer = ser.data();
+	actions[1].length = ser.size();
+	actions[2].type = kHelActionRecvInline;
+	actions[2].flags = 0;
+	HEL_CHECK(helSubmitAsync(getPosixLane(), actions, 3,
+			globalQueue.getQueue(), 0, 0));
+
+	auto element = globalQueue.dequeueSingle();
+	auto offer = parseSimple(element);
+	auto send_req = parseSimple(element);
+	auto recv_resp = parseInline(element);
+
+	HEL_CHECK(offer->error);
+	HEL_CHECK(send_req->error);
+	HEL_CHECK(recv_resp->error);
+	
+	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+	resp.ParseFromArray(recv_resp->data, recv_resp->length);
+	if(resp.error() == managarm::posix::Errors::FILE_NOT_FOUND) {
+		return ENOENT;
+	}else if(resp.error() == managarm::posix::Errors::ALREADY_EXISTS) {
+		return EEXIST;
+	}else{
+		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
+		*fd = resp.fd();
+		return 0;
+	}
+}
+
 int sys_read(int fd, void *data, size_t max_size, ssize_t *bytes_read) {
 	SignalGuard sguard;
 	HelAction actions[5];


### PR DESCRIPTION
GNU Tar wants this function when making tar files.
However, it also fails on openat, getpwnam and maybe others which I haven't found yet.
I tried looking into that but I am not quite sure what to do with those functions, so I leave those up to the more experienced.
According to creat(2) the creat call is nothing more then a call to open with these 3 flags set.