### PR TITLE
Various fixes for man-db

### DIFF
--- a/options/ansi/generic/ctype-stubs.cpp
+++ b/options/ansi/generic/ctype-stubs.cpp
@@ -283,13 +283,19 @@ int toupper(int nc) {
 // wchar_t conversion functions.
 // --------------------------------------------------------------------------------------
 
-wint_t towlower(wint_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+wint_t towlower(wint_t wc) {
+	auto cc = mlibc::platform_wide_charcode();
+	mlibc::codepoint cp;
+	if(auto e = cc->promote(wc, cp); e != mlibc::charcode_error::null)
+		return wc;
+	return mlibc::current_charset()->to_lower(cp);
 }
 
-wint_t towupper(wint_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+wint_t towupper(wint_t wc) {
+	auto cc = mlibc::platform_wide_charcode();
+	mlibc::codepoint cp;
+	if(auto e = cc->promote(wc, cp); e != mlibc::charcode_error::null)
+		return wc;
+	return mlibc::current_charset()->to_upper(cp);
 }
 

--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -578,6 +578,15 @@ long ftell(FILE *file_base) {
 }
 
 int fflush_unlocked(FILE *file_base) {
+	if(file_base == NULL) {
+		// Only flush the files but do not close them.
+    	for(auto it : mlibc::global_file_list) {
+			if(int e = it->flush(); e)
+				mlibc::infoLogger() << "mlibc warning: Failed to flush file"
+						<< frg::endlog;
+		}
+		return 0;
+	}
 	auto file = static_cast<mlibc::abstract_file *>(file_base);
 	if(file->flush())
 		return EOF;

--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdio.h>
 
 #include <frg/random.hpp>
 #include <mlibc/debug.hpp>


### PR DESCRIPTION
This PR implements the following:

- `towlower()` and `towupper()` char converters.
-  the flushing of all files when `fflush(NULL)` is called and on `exit()`