### PR TITLE
Implementing various functions and a bugfix

### DIFF
--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -218,7 +218,7 @@ FILE *freopen(const char *__restrict filename, const char *__restrict mode, FILE
 	__builtin_unreachable();
 }
 void setbuf(FILE *__restrict stream, char *__restrict buffer) {
-	__ensure(!"Not implemented");
+	setvbuf(stream, buffer, buffer ? _IOFBF : _IONBF, BUFSIZ);
 }
 // setvbuf() is provided by the POSIX sublibrary
 

--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -203,6 +203,8 @@ char *strtok_r(char *__restrict s, const char *__restrict del, char **__restrict
 	}else{
 		*m = nullptr;
 	}
+	if(p == tok)
+		return nullptr;
 	return tok;
 }
 char *strtok(char *__restrict s, const char *__restrict delimiter) {

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -63,6 +63,7 @@ int sys_read(int fd, void *buf, size_t count, ssize_t *bytes_read);
 
 #ifndef MLIBC_BUILDING_RTDL
 	int sys_write(int fd, const void *buf, size_t count, ssize_t *bytes_written);
+	int sys_pread(int fd, void *buf, size_t n, off_t off, ssize_t *bytes_read);
 #endif // !defined(MLIBC_BUILDING_RTDL)
 
 int sys_seek(int fd, off_t offset, int whence, off_t *new_offset);

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -389,9 +389,19 @@ int pipe2(int *fds, int flags) {
 	return 0;
 }
 
-ssize_t pread(int, void *, size_t, off_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+ssize_t pread(int fd, void *buf, size_t n, off_t off) {
+	ssize_t num_read;
+
+	if(!mlibc::sys_pread) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_pread(fd, buf, n, off, &num_read); e) {
+		errno = e;
+		return -1;
+	}
+	return num_read;
 }
 ssize_t pwrite(int, const void *, size_t, off_t) {
 	__ensure(!"Not implemented");


### PR DESCRIPTION
This PR adds the following:

- An implementation of the `setbuf()` function,
- An implementation of the `pread()` function,
- And a small bug fix to `strtok()`, related to strings which end on the requested delimiter.