### PR TITLE
options/posix: Implemented various functions

### DIFF
--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -114,6 +114,7 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_fchdir(int fd);
 	[[gnu::weak]] int sys_chroot(const char *path);
 	[[gnu::weak]] int sys_mkdir(const char *path);
+	[[gnu::weak]] int sys_mkdirat(int dirfd, const char *path, mode_t mode);
 	[[gnu::weak]] int sys_symlink(const char *target_path, const char *link_path);
 	[[gnu::weak]] int sys_rename(const char *path, const char *new_path);
 	[[gnu::weak]] int sys_fcntl(int fd, int request, va_list args, int *result);

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -257,6 +257,15 @@ int ptsname_r(int fd, char *buffer, size_t length) {
 	return 0;
 }
 
+char *ptsname(int fd) {
+	int index;
+	static char buffer[128];
+	if(ioctl(fd, TIOCGPTN, &index))
+		return NULL;
+	snprintf(buffer, 128, "/dev/pts/%d", index);
+	return buffer;
+}
+
 int posix_openpt(int flags) {
 	int fd;
 	if(int e = mlibc::sys_open("/dev/ptmx", flags, &fd); e) {

--- a/options/posix/generic/sys-stat-stubs.cpp
+++ b/options/posix/generic/sys-stat-stubs.cpp
@@ -19,8 +19,9 @@ int fchmod(int, mode_t) {
 }
 
 int fchmodat(int, const char *, mode_t, int) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "\e[31mmlibc: fchmodat() is not implemented correctly\e[39m"
+			<< frg::endlog;
+	return 0;
 }
 int fstatat(int dirfd, const char *path, struct stat *result, int flags) {
 	if(!mlibc::sys_stat) {
@@ -52,9 +53,18 @@ int mkdir(const char *path, mode_t) {
 	}
 	return 0;
 }
-int mkdirat(int, const char *, mode_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int mkdirat(int dirfd, const char *path, mode_t mode) {
+	mlibc::infoLogger() << "\e[31mmlibc: mkdirat() ignores its mode\e[39m" << frg::endlog;
+	if(!mlibc::sys_mkdirat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_mkdirat(dirfd, path, mode); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 int mkfifo(const char *, mode_t) {
 	__ensure(!"Not implemented");

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -161,13 +161,19 @@ int sys_chroot(const char *path) {
 }
 
 int sys_mkdir(const char *path) {
+	return sys_mkdirat(AT_FDCWD, path, 0);
+}
+
+int sys_mkdirat(int dirfd, const char *path, mode_t mode) {
+	(void)mode;
 	SignalGuard sguard;
 	HelAction actions[3];
 	globalQueue.trim();
 
 	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-	req.set_request_type(managarm::posix::CntReqType::MKDIR);
+	req.set_request_type(managarm::posix::CntReqType::MKDIRAT);
 	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), path));
+	req.set_fd(dirfd);
 
 	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 	req.SerializeToString(&ser);


### PR DESCRIPTION
This PR implements the following functions in posix:

- `ptsname()`
- `mkdirat()`

And stubs the following functions in posix:

- `fchmodat()`

This PR also unifies the code paths of `sys_mkdir()` and `sys_mkdirat()` in the managarm sysdeps.