### PR TITLE
options/ansi: Implemented renameat()

### DIFF
--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -199,8 +199,16 @@ int rename(const char *path, const char *new_path) {
 	return 0;
 }
 int renameat(int olddirfd, const char *old_path, int newdirfd, const char *new_path) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	if(!mlibc::sys_renameat) {
+        MLIBC_MISSING_SYSDEP();
+        errno = ENOSYS;
+        return -1;
+    }
+    if(int e = mlibc::sys_renameat(olddirfd, old_path, newdirfd, new_path); e) {
+        errno = e;
+        return -1;
+    }
+    return 0;
 }
 FILE *tmpfile(void) {
 	__ensure(!"Not implemented");

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -117,6 +117,7 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_mkdirat(int dirfd, const char *path, mode_t mode);
 	[[gnu::weak]] int sys_symlink(const char *target_path, const char *link_path);
 	[[gnu::weak]] int sys_rename(const char *path, const char *new_path);
+	[[gnu::weak]] int sys_renameat(int olddirfd, const char *old_path, int newdirfd, const char *new_path);
 	[[gnu::weak]] int sys_fcntl(int fd, int request, va_list args, int *result);
 	[[gnu::weak]] int sys_ttyname(int fd, char *buf, size_t size);
 	[[gnu::weak]] int sys_fadvise(int fd, off_t offset, off_t length, int advice);

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -248,14 +248,20 @@ int sys_symlink(const char *target_path, const char *link_path) {
 }
 
 int sys_rename(const char *path, const char *new_path) {
+	return sys_renameat(AT_FDCWD, path, AT_FDCWD, new_path);
+}
+
+int sys_renameat(int olddirfd, const char *old_path, int newdirfd, const char *new_path) {
 	SignalGuard sguard;
 	HelAction actions[3];
 	globalQueue.trim();
 
 	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-	req.set_request_type(managarm::posix::CntReqType::RENAME);
-	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), path));
+	req.set_request_type(managarm::posix::CntReqType::RENAMEAT);
+	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), old_path));
 	req.set_target_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), new_path));
+	req.set_fd(olddirfd);
+	req.set_newfd(newdirfd);
 
 	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 	req.SerializeToString(&ser);


### PR DESCRIPTION
This change allows `mv` to work.
This closes issue #42 