### PR TITLE
options/posix: Implemented pthread_equal

### DIFF
--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -114,10 +114,12 @@ pthread_t pthread_self(void) {
 	return reinterpret_cast<pthread_t>(mlibc::get_current_tcb());
 }
 
-int pthread_equal(pthread_t, pthread_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int pthread_equal(pthread_t t1, pthread_t t2) {
+	if(t1 == t2)
+		return 1;
+	return 0;
 }
+
 int pthread_exit(void *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/include/bits/posix/posix_stdlib.h
+++ b/options/posix/include/bits/posix/posix_stdlib.h
@@ -33,6 +33,7 @@ char *realpath(const char *__restrict, char *__restrict);
 int posix_openpt(int flags);
 int grantpt(int fd);
 int unlockpt(int fd);
+char *ptsname(int fd);
 int ptsname_r(int fd, char *buf, size_t len);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR also fixes a missing declaration of `ptsname`