### PR TITLE
Various functions to allow xbps and perl to compile

### DIFF
--- a/options/posix/generic/netdb-stubs.cpp
+++ b/options/posix/generic/netdb-stubs.cpp
@@ -7,6 +7,14 @@
 #include <stdlib.h>
 #include <stddef.h>
 
+#undef h_errno
+__thread int __mlibc_h_errno;
+
+// This function is from musl
+int *__h_errno_location(void) {
+	return &__mlibc_h_errno;
+}
+
 void endhostent(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -120,6 +128,11 @@ struct netent *getnetent(void) {
 
 struct hostent *gethostbyname(const char *) {
 	__ensure(!"gethostbyname() not implemented");
+	__builtin_unreachable();
+}
+
+struct hostent *gethostbyaddr(const void *, socklen_t, int) {
+	__ensure(!"gethostbyaddr() not implemented");
 	__builtin_unreachable();
 }
 

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -24,6 +24,16 @@ long random(void) {
 	__builtin_unreachable();
 }
 
+double drand48(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+void srand48(long int seedval) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
 // ----------------------------------------------------------------------------
 // Path handling.
 // ----------------------------------------------------------------------------

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -648,6 +648,10 @@ pid_t gettid(void) {
 	return mlibc::sys_getpid();
 }
 
+int getentropy(void *, size_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
 
 ssize_t write(int fd, const void *buf, size_t count) {
 	ssize_t bytes_written;

--- a/options/posix/include/bits/posix/posix_stdlib.h
+++ b/options/posix/include/bits/posix/posix_stdlib.h
@@ -7,6 +7,8 @@ extern "C" {
 #endif
 
 long random(void);
+double drand48(void);
+void srand48(long int);
 
 // ----------------------------------------------------------------------------
 // Environment.

--- a/options/posix/include/netdb.h
+++ b/options/posix/include/netdb.h
@@ -45,6 +45,9 @@
 extern "C" {
 #endif
 
+int *__h_errno_location(void);
+#define h_errno (*__h_errno_location())
+
 struct hostent {
 	char *h_name;
 	char **h_aliases;
@@ -96,6 +99,7 @@ int getaddrinfo(const char *__restrict, const char *__restrict,
 		const struct addrinfo *__restrict, struct addrinfo **__restrict);
 struct hostent *gethostent(void);
 struct hostent *gethostbyname(const char *);
+struct hostent *gethostbyaddr(const void *, socklen_t, int);
 int getnameinfo(const struct sockaddr *__restrict, socklen_t,
 		char *__restrict, socklen_t, char *__restrict, socklen_t, int);
 struct netent *getnetbyaddr(uint32_t, int);

--- a/options/posix/include/sys/ipc.h
+++ b/options/posix/include/sys/ipc.h
@@ -1,6 +1,10 @@
 #ifndef _SYS_IPC_H
 #define _SYS_IPC_H
 
+#include <bits/posix/uid_t.h>
+#include <bits/posix/gid_t.h>
+#include <bits/posix/mode_t.h>
+
 #define IPC_CREAT 01000
 #define IPC_EXCL 02000
 #define IPC_NOWAIT 04000
@@ -13,5 +17,15 @@
 #define IPC_PRIVATE ((key_t) 0)
 
 typedef int key_t;
+
+struct ipc_perm {
+	key_t __ipc_perm_key;
+	uid_t uid;
+	gid_t gid;
+	uid_t cuid;
+	gid_t cgid;
+	mode_t mode;
+	int __ipc_perm_seq;
+};
 
 #endif

--- a/options/posix/include/sys/shm.h
+++ b/options/posix/include/sys/shm.h
@@ -46,6 +46,17 @@ extern "C" {
 
 typedef unsigned long shmatt_t;
 
+struct shmid_ds {
+	struct ipc_perm shm_perm;
+	size_t shm_segsz;
+	time_t shm_atime;
+	time_t shm_dtime;
+	time_t shm_ctime;
+	pid_t shm_cpid;
+	pid_t shm_lpid;
+	unsigned long shm_nattch;
+};
+
 void *shmat(int, const void *, int);
 int shmctl(int, int, struct shmid_ds *);
 int shmdt(const void *);

--- a/options/posix/include/syslog.h
+++ b/options/posix/include/syslog.h
@@ -2,6 +2,8 @@
 #ifndef _SYSLOG_H
 #define _SYSLOG_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,6 +58,9 @@ void closelog(void);
 void openlog(const char *, int, int);
 int setlogmask(int);
 void syslog(int, const char *, ...);
+
+// This is a linux extension
+void vsyslog(int, const char *, va_list);
 
 #ifdef __cplusplus
 }

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -201,6 +201,7 @@ int chroot(const char *);
 
 // This is a Linux extension
 pid_t gettid(void);
+int getentropy(void *, size_t);
 
 int pipe2(int *pipefd, int flags);
 


### PR DESCRIPTION
This adds the following functions and definitions

For `xbps`:
- `getentropy()`, stubbed
- `vsyslog()`, stubbed

For `perl`:
- `h_errno`
- `gethostbyaddr()`, stubbed
- `drand48()`, stubbed
- `srand48()`, stubbed
- `struct ipc_perm`
- `struct shmid_ds`