### PR TITLE
Implemented and stubbed various functions

### DIFF
--- a/abis/mlibc/errno.h
+++ b/abis/mlibc/errno.h
@@ -84,4 +84,5 @@
 #define ENOKEY 1078
 #define ESHUTDOWN 1079
 #define EHOSTDOWN 1080
+#define EBADFD 1081
 #endif // _ABIBITS_ERRNO_H

--- a/abis/mlibc/stat.h
+++ b/abis/mlibc/stat.h
@@ -38,6 +38,10 @@
 #define S_ISGID 02000
 #define S_ISVTX 01000
 
+#define S_IREAD  S_IRUSR
+#define S_IWRITE S_IWUSR
+#define S_IEXEC  S_IXUSR
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/options/ansi/generic/errno-stubs.cpp
+++ b/options/ansi/generic/errno-stubs.cpp
@@ -3,4 +3,6 @@ int __thread __mlibc_errno;
 
 char *program_invocation_name = nullptr;
 char *program_invocation_short_name = nullptr;
+char *__progname = program_invocation_short_name;
+char *__progname_full = program_invocation_name;
 

--- a/options/ansi/generic/errno-stubs.cpp
+++ b/options/ansi/generic/errno-stubs.cpp
@@ -3,6 +3,6 @@ int __thread __mlibc_errno;
 
 char *program_invocation_name = nullptr;
 char *program_invocation_short_name = nullptr;
-char *__progname = program_invocation_short_name;
-char *__progname_full = program_invocation_name;
+extern char *__progname __attribute__ ((weak, alias ("program_invocation_short_name")));
+extern char *__progname_full __attribute__ ((weak, alias ("program_invocation_name")));
 

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -230,6 +230,10 @@ void setbuf(FILE *__restrict stream, char *__restrict buffer) {
 }
 // setvbuf() is provided by the POSIX sublibrary
 
+void setlinebuf(FILE *stream) {
+    setvbuf(stream, NULL, _IOLBF, 0);
+}
+
 int fprintf(FILE *__restrict stream, const char *__restrict format, ...) {
 	va_list args;
 	va_start(args, format);

--- a/options/ansi/include/errno.h
+++ b/options/ansi/include/errno.h
@@ -12,5 +12,7 @@ extern __thread int __mlibc_errno;
 
 extern char *program_invocation_name;
 extern char *program_invocation_short_name;
+extern char *__progname;
+extern char *__progname_full;
 
 #endif // _ERRNO_H

--- a/options/ansi/include/stdio.h
+++ b/options/ansi/include/stdio.h
@@ -92,6 +92,7 @@ FILE *fopen(const char *__restrict filename, const char *__restrict mode);
 FILE *freopen(const char *__restrict filename, const char *__restrict mode, FILE *__restrict stream);
 void setbuf(FILE *__restrict stream, char *__restrict buffer);
 int setvbuf(FILE *__restrict stream, char *__restrict buffer, int mode, size_t size);
+void setlinebuf(FILE *stream);
 
 // [C11-7.21.6] Formatted input/output functions
 

--- a/options/ansi/include/time.h
+++ b/options/ansi/include/time.h
@@ -44,6 +44,7 @@ struct tm {
 	int tm_yday;
 	int tm_isdst;
 	long int tm_gmtoff;
+	const char *tm_zone;
 };
 
 // [7.27.2] Time manipulation functions

--- a/options/ansi/include/time.h
+++ b/options/ansi/include/time.h
@@ -43,6 +43,7 @@ struct tm {
 	int tm_wday;
 	int tm_yday;
 	int tm_isdst;
+	long int tm_gmtoff;
 };
 
 // [7.27.2] Time manipulation functions

--- a/options/glibc/include/ar.h
+++ b/options/glibc/include/ar.h
@@ -1,0 +1,25 @@
+
+#ifndef  _AR_H
+#define  _AR_H
+
+#define ARMAG  "!<arch>\n"
+#define SARMAG 8
+#define ARFMAG "`\n"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ar_hdr {
+	char ar_name[16];
+	char ar_date[12];
+	char ar_uid[6];
+	char ar_gid[6];
+	char ar_mode[8];
+	char ar_size[10];
+	char ar_fmag[2];
+};
+
+#endif
+
+#endif

--- a/options/glibc/meson.build
+++ b/options/glibc/meson.build
@@ -15,7 +15,8 @@ if not no_headers
 		'include/paths.h',
 		'include/sysexits.h',
 		'include/resolv.h',
-		'include/endian.h'
+		'include/endian.h',
+		'include/ar.h'
 	)
 	install_headers(
 		'include/sys/ioctl.h',

--- a/options/linux/generic/utmp-stubs.cpp
+++ b/options/linux/generic/utmp-stubs.cpp
@@ -1,0 +1,17 @@
+#include <bits/ensure.h>
+#include <utmp.h>
+
+void setutent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+struct utmp *getutent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+void endutent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/include/utmp.h
+++ b/options/linux/include/utmp.h
@@ -41,7 +41,7 @@ struct utmp {
 	struct exit_status ut_exit;
 	long   ut_session;
 	struct timeval ut_tv;
-	int32_t ut_addr_v6[4];
+	__mlibc_int32_t ut_addr_v6[4];
 	char __unused[20];
 };
 

--- a/options/linux/include/utmp.h
+++ b/options/linux/include/utmp.h
@@ -2,6 +2,9 @@
 #ifndef  _UTMP_H
 #define  _UTMP_H
 
+#include <stdint.h>
+#include <bits/posix/pid_t.h>
+#include <bits/posix/timeval.h>
 #include <bits/types.h>
 
 #ifdef __cplusplus
@@ -38,7 +41,7 @@ struct utmp {
 	struct exit_status ut_exit;
 	long   ut_session;
 	struct timeval ut_tv;
-	__mlibc_int32_t ut_addr_v6[4];
+	int32_t ut_addr_v6[4];
 	char __unused[20];
 };
 
@@ -49,6 +52,10 @@ struct utmp {
 #endif
 #define ut_xtime ut_tv.tv_sec
 #define ut_addr ut_addr_v6[0]
+
+void setutent(void);
+struct utmp *getutent(void);
+void endutent(void);
 
 #ifdef __cplusplus
 }

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -18,6 +18,7 @@ libc_sources += files(
 	'generic/sys-eventfd.cpp',
 	'generic/sys-reboot.cpp',
 	'generic/netinet-in6addr.cpp',
+	'generic/utmp-stubs.cpp',
 )
 
 if not no_headers

--- a/options/posix/include/bits/posix/fd_set.h
+++ b/options/posix/include/bits/posix/fd_set.h
@@ -1,0 +1,14 @@
+
+#ifndef MLIBC_FD_SET_H
+#define MLIBC_FD_SET_H
+
+// FIXME: use something like uint8_t with fixed bit-size
+typedef struct {
+	union {
+		char __mlibc_elems[128];
+		// Some programs require the fds_bits field to be present
+		char fds_bits[128];
+	};
+} fd_set;
+
+#endif // MLIBC_FD_SET_H

--- a/options/posix/include/netinet/in.h
+++ b/options/posix/include/netinet/in.h
@@ -71,6 +71,10 @@ extern "C" {
 #define IN_CLASSD(a) ((((in_addr_t)(a)) & 0xf0000000) == 0xe0000000)
 #define IN_MULTICAST(a) IN_CLASSD(a)
 
+#define IN_CLASSA_NET 0xff000000
+#define IN_CLASSB_NET 0xffff0000
+#define IN_CLASSC_NET 0xffffff00
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/posix/include/sys/param.h
+++ b/options/posix/include/sys/param.h
@@ -9,6 +9,8 @@
 
 // Report the same value as Linux here.
 #define MAXPATHLEN 4096
+#define HOST_NAME_MAX 64
+#define MAXHOSTNAMELEN HOST_NAME_MAX
 
 #ifdef __cplusplus
 extern "C" {

--- a/options/posix/include/sys/select.h
+++ b/options/posix/include/sys/select.h
@@ -5,19 +5,11 @@
 #include <bits/ansi/time_t.h>
 #include <bits/posix/suseconds_t.h>
 #include <bits/posix/timeval.h>
+#include <bits/posix/fd_set.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// FIXME: use something like uint8_t with fixed bit-size
-typedef struct {
-	union {
-		char __mlibc_elems[128];
-		// Some programs require the fds_bits field to be present
-		char fds_bits[128];
-	};
-} fd_set;
 
 #define FD_SETSIZE 1024
 

--- a/options/posix/include/sys/types.h
+++ b/options/posix/include/sys/types.h
@@ -23,8 +23,7 @@
 
 #include <bits/posix/fsblkcnt_t.h>
 #include <bits/posix/fsfilcnt_t.h>
-
-#include <sys/select.h>
+#include <bits/posix/fd_set.h>
 
 typedef unsigned int u_int;
 typedef unsigned char u_char;

--- a/options/posix/include/sys/types.h
+++ b/options/posix/include/sys/types.h
@@ -24,8 +24,11 @@
 #include <bits/posix/fsblkcnt_t.h>
 #include <bits/posix/fsfilcnt_t.h>
 
+#include <sys/select.h>
+
 typedef unsigned int u_int;
 typedef unsigned char u_char;
+typedef unsigned short u_short;
 typedef void *caddr_t;
 
 #endif // _SYS_TYPES_H

--- a/options/posix/include/sys/wait.h
+++ b/options/posix/include/sys/wait.h
@@ -21,6 +21,8 @@ struct rusage;
 #define WNOWAIT 16
 #define WSTOPPED 32
 
+#define WCOREFLAG 0x80
+
 // TODO: #error if int is smaller than 32 bits
 
 #define WEXITSTATUS(x) ((x) & 0x000000FF)
@@ -30,6 +32,7 @@ struct rusage;
 #define WIFSTOPPED(x) ((x) & 0x00000800)
 #define WSTOPSIG(x) (((x) & 0x00FF0000) >> 16)
 #define WTERMSIG(x) (((x) & 0xFF000000) >> 24)
+#define WCOREDUMP(x) ((x) & WCOREFLAG)
 
 // TODO: move to own file and include in sys/types.h
 typedef enum {

--- a/options/posix/meson.build
+++ b/options/posix/meson.build
@@ -143,6 +143,7 @@ if not no_headers
 		'include/bits/posix/suseconds_t.h',
 		'include/bits/posix/timeval.h',
 		'include/bits/posix/uid_t.h',
+		'include/bits/posix/fd_set.h',
 		subdir: 'bits/posix'
 	)
 endif


### PR DESCRIPTION
This PR aims to let `sysklogd` and `make` compile. It adds the following:

- `setlinebuf()`
- `setutent()`, stubbed
- `getutent()`, stubbed
- `endutent()`, stubbed

Furthermore, this PR defines a couple of constants and adds an header as required for `sysklogd` and `make`