### PR TITLE
Various additions and fixes

### DIFF
--- a/options/ansi/generic/inttypes-stubs.cpp
+++ b/options/ansi/generic/inttypes-stubs.cpp
@@ -20,18 +20,28 @@ imaxdiv_t imaxdiv(intmax_t, intmax_t) {
 template <class T> T strtoxmax(const char *it, char **out, int base) {
 	T v = 0;
 	bool negate = false;
-
-	// TODO: In this case we have to detect the base based on the prefix.
-	__ensure(base);
+	const unsigned char *s = (const unsigned char *)it;
+	int c;
 
 	if(std::is_signed<T>::value) {
-		if(*it == '+') {
-			it++;
-		}else if(*it == '-') {
+		if(*s == '+') {
+			s++;
+		}else if(*s == '-') {
 			negate = true;
-			it++;
+			s++;
 		}
 	}
+
+	do {
+		c = *s++;
+	} while (isspace(c));
+	if ((base == 0 || base == 16) && c == '0' && (*s == 'x' || *s == 'X')) {
+		c = s[1];
+		s += 2;
+		base = 16;
+	}
+	if (base == 0)
+		base = c == '0' ? 8 : 10;
 
 	if(base == 8) {
 		if(*it != 0)

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -257,6 +257,11 @@ int printf(const char *__restrict format, ...) {
 	return result;
 }
 
+int dprintf(int fd, const char *format, ...) {
+    __ensure(!"Not implemented");
+    __builtin_unreachable();
+}
+
 namespace {
     enum {
         SCANF_TYPE_CHAR,

--- a/options/ansi/include/inttypes.h
+++ b/options/ansi/include/inttypes.h
@@ -90,6 +90,7 @@
 #define PRIXPTR "lX"
 
 #define SCNu64 "lu"
+#define SCNuMAX "lu"
 
 #ifdef __cplusplus
 extern "C" {

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -47,6 +47,7 @@ int sys_anon_free(void *pointer, size_t size);
 
 #ifndef MLIBC_BUILDING_RTDL
 	[[noreturn]] void sys_exit(int status);
+	[[noreturn]] void sys_thread_exit();
 	int sys_clock_get(int clock, time_t *secs, long *nanos);
 #endif // !defined(MLIBC_BUILDING_RTDL)
 
@@ -104,8 +105,6 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_fork(pid_t *child);
 	[[gnu::weak]] int sys_clone(void *entry, void *user_arg, void *tcb, pid_t *pid_out);
 	[[gnu::weak]] int sys_execve(const char *path, char *const argv[], char *const envp[]);
-	[[gnu::weak]] int sys_select(int num_fds, fd_set *read_set, fd_set *write_set,
-			fd_set *except_set, struct timeval *timeout, int *num_events);
 	[[gnu::weak]] int sys_pselect(int num_fds, fd_set *read_set, fd_set *write_set,
 			fd_set *except_set, const struct timespec *timeout, const sigset_t *sigmask, int *num_events);
 	[[gnu::weak]] int sys_getrusage(int scope, struct rusage *usage);
@@ -157,8 +156,6 @@ int sys_vm_unmap(void *pointer, size_t size);
 	[[gnu::weak]] int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events);
 	[[gnu::weak]] int sys_epoll_create(int flags, int *fd);
 	[[gnu::weak]] int sys_epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev);
-	[[gnu::weak]] int sys_epoll_wait(int epfd, struct epoll_event *evnts, int n,
-			int timeout, int *raised);
 	[[gnu::weak]] int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,
 			int timeout, const sigset_t *sigmask, int *raised);
 	[[gnu::weak]] int sys_inotify_create(int flags, int *fd);

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -81,6 +81,7 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_stat(fsfd_target fsfdt, int fd, const char *path, int flags,
 			struct stat *statbuf);
 	[[gnu::weak]] int sys_readlink(const char *path, void *buffer, size_t max_size, ssize_t *length);
+	[[gnu::weak]] int sys_rmdir(const char *path);
 	[[gnu::weak]] int sys_ftruncate(int fd, size_t size);
 	[[gnu::weak]] int sys_fallocate(int fd, off_t offset, size_t size);
 	[[gnu::weak]] int sys_unlink(const char *path);

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -106,6 +106,8 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_execve(const char *path, char *const argv[], char *const envp[]);
 	[[gnu::weak]] int sys_select(int num_fds, fd_set *read_set, fd_set *write_set,
 			fd_set *except_set, struct timeval *timeout, int *num_events);
+	[[gnu::weak]] int sys_pselect(int num_fds, fd_set *read_set, fd_set *write_set,
+			fd_set *except_set, const struct timespec *timeout, const sigset_t *sigmask, int *num_events);
 	[[gnu::weak]] int sys_getrusage(int scope, struct rusage *usage);
 	[[gnu::weak]] int sys_getrlimit(int resource, struct rlimit *limit);
 	[[gnu::weak]] int sys_timerfd_create(int flags, int *fd);
@@ -157,6 +159,8 @@ int sys_vm_unmap(void *pointer, size_t size);
 	[[gnu::weak]] int sys_epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev);
 	[[gnu::weak]] int sys_epoll_wait(int epfd, struct epoll_event *evnts, int n,
 			int timeout, int *raised);
+	[[gnu::weak]] int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,
+			int timeout, const sigset_t *sigmask, int *raised);
 	[[gnu::weak]] int sys_inotify_create(int flags, int *fd);
 	[[gnu::weak]] int sys_inotify_add_watch(int ifd, const char *path, uint32_t mask, int *wd);
 	[[gnu::weak]] int sys_inotify_rm_watch(int ifd, int wd);

--- a/options/linux/generic/sys-epoll.cpp
+++ b/options/linux/generic/sys-epoll.cpp
@@ -19,9 +19,19 @@ int epoll_create(int) {
 	return fd;
 }
 
-int epoll_pwait(int, struct epoll_event *, int, int, const sigset_t *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int epoll_pwait(int epfd, struct epoll_event *evnts, int n, int timeout,
+		const sigset_t *sigmask) {
+	int raised;
+	if(!mlibc::sys_epoll_pwait) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_epoll_pwait(epfd, evnts, n, timeout, sigmask, &raised)) {
+		errno = e;
+		return -1;
+	}
+	return raised;
 }
 
 int epoll_create1(int flags) {

--- a/options/linux/generic/sys-epoll.cpp
+++ b/options/linux/generic/sys-epoll.cpp
@@ -63,12 +63,12 @@ int epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev) {
 
 int epoll_wait(int epfd, struct epoll_event *evnts, int n, int timeout) {
 	int raised;
-	if(!mlibc::sys_epoll_wait) {
+	if(!mlibc::sys_epoll_pwait) {
 		MLIBC_MISSING_SYSDEP();
 		errno = ENOSYS;
 		return -1;
 	}
-	if(int e = mlibc::sys_epoll_wait(epfd, evnts, n, timeout, &raised)) {
+	if(int e = mlibc::sys_epoll_pwait(epfd, evnts, n, timeout, NULL, &raised)) {
 		errno = e;
 		return -1;
 	}

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
@@ -197,7 +198,17 @@ char *realpath(const char *path, char *out) {
 				-1, resolv.data(), AT_SYMLINK_NOFOLLOW, &st); e)
 			return e;
 
-		__ensure(!S_ISLNK(st.st_mode) && "TODO: Use readlink in realpath()");
+		if(S_ISLNK(st.st_mode)) {
+			if(debugPathResolution) {
+				mlibc::infoLogger() << "mlibc realpath(): Encountered symlink '" << resolv.data() << "'" << frg::endlog;
+			}
+			char path[512];
+			readlink(resolv.data(), path, 512);
+			if(debugPathResolution) {
+				mlibc::infoLogger() << "mlibc realpath(): symlink resolves to '" << path << "'" << frg::endlog;
+			}
+			realpath(path, NULL);
+		}
 		// TODO: If it is a link, prepend it to lnk, adjust ls and revert the change to resolv.
 		return 0;
 	};

--- a/options/posix/generic/sys-select-stubs.cpp
+++ b/options/posix/generic/sys-select-stubs.cpp
@@ -31,15 +31,18 @@ void FD_ZERO(fd_set *set) {
 // TODO: Provide a sys_select() function instead.
 int select(int num_fds, fd_set *__restrict read_set, fd_set *__restrict write_set,
 		fd_set *__restrict except_set, struct timeval *__restrict timeout) {
-    if(!mlibc::sys_select) {
+    if(!mlibc::sys_pselect) {
 		MLIBC_MISSING_SYSDEP();
 		errno = ENOSYS;
 		return -1;
 	}
 
 	int num_events = 0;
-	if(int e = mlibc::sys_select(num_fds, read_set, write_set, except_set,
-				timeout, &num_events); e) {
+	struct timespec timeouts = {0};
+	timeouts.tv_sec = timeout->tv_sec;
+	timeouts.tv_nsec = timeout->tv_usec * 1000;
+	if(int e = mlibc::sys_pselect(num_fds, read_set, write_set, except_set,
+				&timeouts, NULL, &num_events); e) {
 		errno = e;
 		return -1;
 	}

--- a/options/posix/generic/sys-select-stubs.cpp
+++ b/options/posix/generic/sys-select-stubs.cpp
@@ -45,3 +45,9 @@ int select(int num_fds, fd_set *__restrict read_set, fd_set *__restrict write_se
 	}
 	return num_events;
 }
+
+int pselect(int, fd_set *, fd_set *, fd_set *, const struct timespec *,
+		const sigset_t *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/generic/sys-select-stubs.cpp
+++ b/options/posix/generic/sys-select-stubs.cpp
@@ -46,8 +46,19 @@ int select(int num_fds, fd_set *__restrict read_set, fd_set *__restrict write_se
 	return num_events;
 }
 
-int pselect(int, fd_set *, fd_set *, fd_set *, const struct timespec *,
-		const sigset_t *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int pselect(int num_fds, fd_set *read_set, fd_set *write_set, fd_set *except_set,
+		const struct timespec *timeout,	const sigset_t *sigmask) {
+	if(!mlibc::sys_pselect) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+
+	int num_events = 0;
+	if(int e = mlibc::sys_pselect(num_fds, read_set, write_set, except_set,
+				timeout, sigmask, &num_events); e) {
+		errno = e;
+		return -1;
+	}
+	return num_events;
 }

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -425,10 +425,12 @@ ssize_t pread(int fd, void *buf, size_t n, off_t off) {
 	}
 	return num_read;
 }
+
 ssize_t pwrite(int, const void *, size_t, off_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 ssize_t readlink(const char *__restrict path, char *__restrict buffer, size_t max_size) {
 	ssize_t length;
 	if(!mlibc::sys_readlink) {
@@ -442,13 +444,23 @@ ssize_t readlink(const char *__restrict path, char *__restrict buffer, size_t ma
 	}
 	return length;
 }
+
 ssize_t readlinkat(int, const char *__restrict, char *__restrict, size_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-int rmdir(const char *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+int rmdir(const char *path) {
+	if(!mlibc::sys_rmdir) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_rmdir(path); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int setegid(gid_t egid) {

--- a/options/posix/include/bits/posix/fd_set.h
+++ b/options/posix/include/bits/posix/fd_set.h
@@ -11,6 +11,4 @@ typedef struct {
 	};
 } fd_set;
 
-#define FD_SETSIZE 1024
-
 #endif // MLIBC_FD_SET_H

--- a/options/posix/include/bits/posix/fd_set.h
+++ b/options/posix/include/bits/posix/fd_set.h
@@ -11,4 +11,6 @@ typedef struct {
 	};
 } fd_set;
 
+#define FD_SETSIZE 1024
+
 #endif // MLIBC_FD_SET_H

--- a/options/posix/include/bits/posix/posix_stdio.h
+++ b/options/posix/include/bits/posix/posix_stdio.h
@@ -24,6 +24,8 @@ FILE *open_memstream(char **, size_t *);
 int fseeko(FILE *stream, off_t offset, int whence);
 off_t ftello(FILE *stream);
 
+int dprintf(int fd, const char *format, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/posix/include/sys/select.h
+++ b/options/posix/include/sys/select.h
@@ -2,10 +2,14 @@
 #ifndef _SYS_SELECT_H
 #define _SYS_SELECT_H
 
+#include <abi-bits/signal.h>
+
 #include <bits/ansi/time_t.h>
 #include <bits/posix/suseconds_t.h>
 #include <bits/posix/timeval.h>
 #include <bits/posix/fd_set.h>
+
+#define FD_SETSIZE 1024
 
 #ifdef __cplusplus
 extern "C" {

--- a/options/posix/include/sys/select.h
+++ b/options/posix/include/sys/select.h
@@ -11,17 +11,15 @@
 extern "C" {
 #endif
 
-#define FD_SETSIZE 1024
-
 void FD_CLR(int fd, fd_set *);
 int FD_ISSET(int fd, fd_set *);
 void FD_SET(int fd, fd_set *);
 void FD_ZERO(fd_set *);
 
-// MISSING: pselect
-
 int select(int, fd_set *__restrict, fd_set *__restrict, fd_set *__restrict,
 		struct timeval *__restrict);
+int pselect(int, fd_set *, fd_set *, fd_set *, const struct timespec *,
+		const sigset_t *);
 
 #ifdef __cplusplus
 }

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1267,14 +1267,8 @@ int sys_pselect(int num_fds, fd_set *read_set, fd_set *write_set,
 	}
 
 	struct epoll_event evnts[16];
-	int n;
-	if(sigmask != NULL) {
-		n = epoll_pwait(fd, evnts, 16,
-			timeout ? (timeout->tv_sec * 1000 + timeout->tv_nsec / 100) : -1, sigmask);
-	} else {
-		n = epoll_wait(fd, evnts, 16,
-			timeout ? (timeout->tv_sec * 1000 + timeout->tv_nsec / 100) : -1);
-	}
+	int n = epoll_pwait(fd, evnts, 16,
+		timeout ? (timeout->tv_sec * 1000 + timeout->tv_nsec / 100) : -1, sigmask);
 	if(n == -1)
 		return -1;
 
@@ -1519,7 +1513,7 @@ int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,
 	req.set_size(n);
 	req.set_timeout(timeout > 0 ? int64_t{timeout} * 1000000 : timeout);
 	if(sigmask != NULL) {
-		req.set_sigmask((long int)sigmask);
+		req.set_sigmask((long int)*sigmask);
 		req.set_sigmask_needed(true);
 	} else {
 		req.set_sigmask_needed(false);

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -3893,6 +3893,48 @@ int sys_readlink(const char *path, void *data, size_t max_size, ssize_t *length)
 	}
 }
 
+int sys_rmdir(const char *path) {
+	SignalGuard sguard;
+	HelAction actions[3];
+
+	globalQueue.trim();
+
+	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
+	req.set_request_type(managarm::posix::CntReqType::RMDIR);
+	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), path));
+
+	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
+	req.SerializeToString(&ser);
+	actions[0].type = kHelActionOffer;
+	actions[0].flags = kHelItemAncillary;
+	actions[1].type = kHelActionSendFromBuffer;
+	actions[1].flags = kHelItemChain;
+	actions[1].buffer = ser.data();
+	actions[1].length = ser.size();
+	actions[2].type = kHelActionRecvInline;
+	actions[2].flags = 0;
+	HEL_CHECK(helSubmitAsync(getPosixLane(), actions, 3,
+			globalQueue.getQueue(), 0, 0));
+
+	auto element = globalQueue.dequeueSingle();
+	auto offer = parseSimple(element);
+	auto send_req = parseSimple(element);
+	auto recv_resp = parseInline(element);
+
+	HEL_CHECK(offer->error);
+	HEL_CHECK(send_req->error);
+	HEL_CHECK(recv_resp->error);
+
+	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+	resp.ParseFromArray(recv_resp->data, recv_resp->length);
+	if(resp.error() == managarm::posix::Errors::FILE_NOT_FOUND) {
+		return ENOENT;
+	}else{
+		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
+		return 0;
+	}
+}
+
 int sys_ftruncate(int fd, size_t size) {
 	SignalGuard sguard;
 	HelAction actions[3];

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1235,82 +1235,6 @@ int sys_msg_recv(int sockfd, struct msghdr *hdr, int flags, ssize_t *length) {
 	}
 }
 
-int sys_select(int num_fds, fd_set *read_set, fd_set *write_set,
-		fd_set *except_set, struct timeval *timeout, int *num_events) {
-	// TODO: Do not keep errors from epoll (?).
-	int fd = epoll_create1(0);
-	if(fd == -1)
-		return -1;
-
-	for(int k = 0; k < FD_SETSIZE; k++) {
-		struct epoll_event ev;
-		memset(&ev, 0, sizeof(struct epoll_event));
-
-		if(read_set && FD_ISSET(k, read_set))
-			ev.events |= EPOLLIN; // TODO: Additional events.
-		if(write_set && FD_ISSET(k, write_set))
-			ev.events |= EPOLLOUT; // TODO: Additional events.
-		if(except_set && FD_ISSET(k, except_set))
-			ev.events |= EPOLLPRI;
-
-		if(!ev.events)
-			continue;
-		ev.data.u32 = k;
-
-		if(epoll_ctl(fd, EPOLL_CTL_ADD, k, &ev))
-			return -1;
-	}
-
-	struct epoll_event evnts[16];
-	int n = epoll_wait(fd, evnts, 16,
-			timeout ? (timeout->tv_sec * 1000 + timeout->tv_usec / 10) : -1);
-	if(n == -1)
-		return -1;
-
-	fd_set res_read_set;
-	fd_set res_write_set;
-	fd_set res_except_set;
-	FD_ZERO(&res_read_set);
-	FD_ZERO(&res_write_set);
-	FD_ZERO(&res_except_set);
-	int m = 0;
-
-	for(int i = 0; i < n; i++) {
-		int k = evnts[i].data.u32;
-
-		if(read_set && FD_ISSET(k, read_set)
-				&& evnts[i].events & (EPOLLIN | EPOLLERR | EPOLLHUP)) {
-			FD_SET(k, &res_read_set);
-			m++;
-		}
-
-		if(write_set && FD_ISSET(k, write_set)
-				&& evnts[i].events & (EPOLLOUT | EPOLLERR | EPOLLHUP)) {
-			FD_SET(k, &res_write_set);
-			m++;
-		}
-
-		if(except_set && FD_ISSET(k, except_set)
-				&& evnts[i].events & EPOLLPRI) {
-			FD_SET(k, &res_except_set);
-			m++;
-		}
-	}
-
-	if(close(fd))
-		__ensure("close() failed on epoll file");
-
-	if(read_set)
-		memcpy(read_set, &res_read_set, sizeof(fd_set));
-	if(write_set)
-		memcpy(write_set, &res_write_set, sizeof(fd_set));
-	if(except_set)
-		memcpy(except_set, &res_except_set, sizeof(fd_set));
-
-	*num_events = m;
-	return 0;
-}
-
 int sys_pselect(int num_fds, fd_set *read_set, fd_set *write_set,
 		fd_set *except_set, const struct timespec *timeout,
 		const sigset_t *sigmask, int *num_events) {
@@ -1339,8 +1263,14 @@ int sys_pselect(int num_fds, fd_set *read_set, fd_set *write_set,
 	}
 
 	struct epoll_event evnts[16];
-	int n = epoll_pwait(fd, evnts, 16,
+	int n;
+	if(sigmask != NULL) {
+		n = epoll_pwait(fd, evnts, 16,
 			timeout ? (timeout->tv_sec * 1000 + timeout->tv_nsec / 100) : -1, sigmask);
+	} else {
+		n = epoll_wait(fd, evnts, 16,
+			timeout ? (timeout->tv_sec * 1000 + timeout->tv_nsec / 100) : -1);
+	}
 	if(n == -1)
 		return -1;
 

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -295,6 +295,10 @@ int sys_linkat(int olddirfd, const char *old_path, int newdirfd, const char *new
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
 	if(resp.error() == managarm::posix::Errors::FILE_NOT_FOUND) {
 		return ENOENT;
+	}else if(resp.error() == managarm::posix::Errors::ILLEGAL_ARGUMENTS) {
+		return EINVAL;
+	}else if(resp.error() == managarm::posix::Errors::BAD_FD) {
+		return EBADF;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		return 0;

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1501,58 +1501,6 @@ int sys_epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev) {
 	return 0;
 }
 
-int sys_epoll_wait(int epfd, struct epoll_event *evnts, int n, int timeout, int *raised) {
-	__ensure(timeout >= 0 || timeout == -1); // TODO: Report errors correctly.
-
-	SignalGuard sguard;
-	HelAction actions[4];
-	globalQueue.trim();
-
-	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-	req.set_request_type(managarm::posix::CntReqType::EPOLL_WAIT);
-	req.set_fd(epfd);
-	req.set_size(n);
-	req.set_timeout(timeout > 0 ? int64_t{timeout} * 1000000 : timeout);
-
-	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
-	req.SerializeToString(&ser);
-	actions[0].type = kHelActionOffer;
-	actions[0].flags = kHelItemAncillary;
-	actions[1].type = kHelActionSendFromBuffer;
-	actions[1].flags = kHelItemChain;
-	actions[1].buffer = ser.data();
-	actions[1].length = ser.size();
-	actions[2].type = kHelActionRecvInline;
-	actions[2].flags = kHelItemChain;
-	actions[3].type = kHelActionRecvToBuffer;
-	actions[3].flags = 0;
-	actions[3].buffer = evnts;
-	actions[3].length = n * sizeof(struct epoll_event);
-	HEL_CHECK(helSubmitAsync(getPosixLane(), actions, 4,
-			globalQueue.getQueue(), 0, 0));
-
-	auto element = globalQueue.dequeueSingle();
-	auto offer = parseSimple(element);
-	auto send_req = parseSimple(element);
-	auto recv_resp = parseInline(element);
-	auto recv_data = parseLength(element);
-
-	HEL_CHECK(offer->error);
-	HEL_CHECK(send_req->error);
-	HEL_CHECK(recv_resp->error);
-	HEL_CHECK(recv_data->error);
-
-	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
-	resp.ParseFromArray(recv_resp->data, recv_resp->length);
-	if(resp.error() == managarm::posix::Errors::BAD_FD) {
-		return EBADF;
-	}
-	__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
-	__ensure(!(recv_data->length % sizeof(struct epoll_event)));
-	*raised = recv_data->length / sizeof(struct epoll_event);
-	return 0;
-}
-
 int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,
 		int timeout, const sigset_t *sigmask, int *raised) {
 	__ensure(timeout >= 0 || timeout == -1); // TODO: Report errors correctly.
@@ -1566,8 +1514,12 @@ int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,
 	req.set_fd(epfd);
 	req.set_size(n);
 	req.set_timeout(timeout > 0 ? int64_t{timeout} * 1000000 : timeout);
-	req.set_sigmask((long int)sigmask);
-	req.set_sigmask_needed(true);
+	if(sigmask != NULL) {
+		req.set_sigmask((long int)sigmask);
+		req.set_sigmask_needed(true);
+	} else {
+		req.set_sigmask_needed(false);
+	}
 
 	frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 	req.SerializeToString(&ser);


### PR DESCRIPTION
This PR adds the following functions:

- `pselect()`, stubbed in to make `bc` happy
- `dprintf()`, stubbed in to satisfy a test program in `weston`

Furthermore, the following changes have been made:

- The macro `FD_SETSIZE` has been moved to `bits/posix/fd_set.h`. This change allows `git` to compile, but may not be ideal.
- The macro `SCNuMAX` has been defined, again, this makes `git` happy

~~This PR is blocked pending inclusion of pr managarm/managarm#178~~(Has been merged)
This PR is blocked pending inclusion of pr managarm/managarm#180