### PR TITLE
Various additions for tcl, gdb and perl

### DIFF
--- a/abis/mlibc/signal.h
+++ b/abis/mlibc/signal.h
@@ -49,26 +49,26 @@ extern "C" {
 #ifdef __MLIBC_POSIX_OPTION
 
 #define SIGALRM 8
-#define SIGBUS 9
-#define SIGCHLD 10
-#define SIGCONT 11
-#define SIGHUP 12
-#define SIGKILL 13
-#define SIGPIPE 14
-#define SIGQUIT 15
-#define SIGSTOP 16
-#define SIGTSTP 17
-#define SIGTTIN 18
-#define SIGTTOU 19
-#define SIGUSR1 20
-#define SIGUSR2 21
-#define SIGSYS 22
-#define SIGTRAP 23
-#define SIGURG 24
-#define SIGVTALRM 25
-#define SIGXCPU 26
-#define SIGXFSZ 27
-#define SIGWINCH 28
+#define SIGBUS 13
+#define SIGCHLD 14
+#define SIGCONT 15
+#define SIGHUP 16
+#define SIGKILL 17
+#define SIGPIPE 18
+#define SIGQUIT 19
+#define SIGSTOP 20
+#define SIGTSTP 21
+#define SIGTTIN 22
+#define SIGTTOU 23
+#define SIGUSR1 24
+#define SIGUSR2 25
+#define SIGSYS 26
+#define SIGTRAP 27
+#define SIGURG 28
+#define SIGVTALRM 29
+#define SIGXCPU 30
+#define SIGXFSZ 31
+#define SIGWINCH 32
 #define SIGUNUSED SIGSYS
 
 #define SA_NOCLDSTOP (1 << 0)

--- a/abis/mlibc/signal.h
+++ b/abis/mlibc/signal.h
@@ -49,26 +49,26 @@ extern "C" {
 #ifdef __MLIBC_POSIX_OPTION
 
 #define SIGALRM 8
-#define SIGBUS 13
-#define SIGCHLD 14
-#define SIGCONT 15
-#define SIGHUP 16
-#define SIGKILL 17
-#define SIGPIPE 18
-#define SIGQUIT 19
-#define SIGSTOP 20
-#define SIGTSTP 21
-#define SIGTTIN 22
-#define SIGTTOU 23
-#define SIGUSR1 24
-#define SIGUSR2 25
-#define SIGSYS 26
-#define SIGTRAP 27
-#define SIGURG 28
-#define SIGVTALRM 29
-#define SIGXCPU 30
-#define SIGXFSZ 31
-#define SIGWINCH 32
+#define SIGBUS 9
+#define SIGCHLD 10
+#define SIGCONT 11
+#define SIGHUP 12
+#define SIGKILL 13
+#define SIGPIPE 14
+#define SIGQUIT 15
+#define SIGSTOP 16
+#define SIGTSTP 17
+#define SIGTTIN 18
+#define SIGTTOU 19
+#define SIGUSR1 20
+#define SIGUSR2 21
+#define SIGSYS 22
+#define SIGTRAP 23
+#define SIGURG 24
+#define SIGVTALRM 25
+#define SIGXCPU 26
+#define SIGXFSZ 27
+#define SIGWINCH 28
 #define SIGUNUSED SIGSYS
 
 #define SA_NOCLDSTOP (1 << 0)

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -7,6 +7,8 @@
 #include <stdlib.h>
 #include <wchar.h>
 #include <ctype.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <bits/ensure.h>
 
@@ -185,9 +187,15 @@ struct ResizePrinter {
 };
 
 int remove(const char *filename) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+    struct stat statbuf;
+    if(stat(filename, &statbuf) != 0)
+        return -1;
+    if(S_ISDIR(statbuf.st_mode))
+        return rmdir(filename);
+    else
+        return unlink(filename);
 }
+
 int rename(const char *path, const char *new_path) {
 	if(!mlibc::sys_rename) {
 		MLIBC_MISSING_SYSDEP();
@@ -200,6 +208,7 @@ int rename(const char *path, const char *new_path) {
 	}
 	return 0;
 }
+
 int renameat(int olddirfd, const char *old_path, int newdirfd, const char *new_path) {
 	if(!mlibc::sys_renameat) {
         MLIBC_MISSING_SYSDEP();

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -334,9 +334,31 @@ int clock_settime(clockid_t, const struct timespec *) {
 	__builtin_unreachable();
 }
 
-int utimes(const char *, const struct timeval[2]) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int utimes(const char *filename, const struct timeval times[2]) {
+	if (!mlibc::sys_utimensat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	struct timespec time[2];
+	if(times == nullptr) {
+		time[0].tv_sec = UTIME_NOW;
+		time[0].tv_nsec = UTIME_NOW;
+		time[1].tv_sec = UTIME_NOW;
+		time[1].tv_nsec = UTIME_NOW;
+	} else {
+		time[0].tv_sec = times[0].tv_sec;
+		time[0].tv_nsec = times[0].tv_usec * 1000;
+		time[1].tv_sec = times[1].tv_sec;
+		time[1].tv_nsec = times[1].tv_usec * 1000;
+	}
+
+	if (int e = mlibc::sys_utimensat(AT_FDCWD, filename, time, 0); e) {
+		errno = e;
+		return -1;
+	}
+
+	return 0;
 }
 
 time_t time(time_t *out) {

--- a/options/glibc/include/sys/ioctl.h
+++ b/options/glibc/include/sys/ioctl.h
@@ -15,6 +15,7 @@ extern "C" {
 int ioctl(int fd, unsigned long request, ...);
 
 #define FIONREAD 0x541B
+#define FIONBIO	 0x5421
 
 #ifdef __cplusplus
 }

--- a/options/glibc/include/sys/ioctl.h
+++ b/options/glibc/include/sys/ioctl.h
@@ -15,7 +15,7 @@ extern "C" {
 int ioctl(int fd, unsigned long request, ...);
 
 #define FIONREAD 0x541B
-#define FIONBIO	 0x5421
+#define FIONBIO 0x5421
 
 #ifdef __cplusplus
 }

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -133,6 +133,7 @@ int sys_close(int fd);
 	[[gnu::weak]] int sys_chmod(const char *pathname, mode_t mode);
 	[[gnu::weak]] int sys_fchmod(int fd, mode_t mode);
 	[[gnu::weak]] int sys_fchmodat(int fd, const char *pathname, mode_t mode, int flags);
+	[[gnu::weak]] int sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);
 #endif // !defined(MLIBC_BUILDING_RTDL)
 
 // mlibc assumes that anonymous memory returned by sys_vm_map() is zeroed by the kernel / whatever is behind the sysdeps

--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -96,6 +96,14 @@ int pthread_attr_setguardsize(pthread_attr_t *, size_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+int pthread_attr_getscope(const pthread_attr_t *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+int pthread_attr_setscope(pthread_attr_t *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
 
 extern "C" Tcb *__rtdl_allocateTcb();
 

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -594,6 +594,14 @@ unsigned long sysconf(int number) {
 			// TODO: actually return a proper value for _SC_NPROCESSORS_ONLN
 			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_NPROCESSORS_ONLN) unconditionally returns 1\e[39m" << frg::endlog;
 			return 1;
+		case _SC_GETPW_R_SIZE_MAX:
+			// TODO: actually return a proper value for _SC_GETPW_R_SIZE_MAX
+			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_GETPW_R_SIZE_MAX) returns arbitrary value 8\e[39m" << frg::endlog;
+			return 8;
+		case _SC_GETGR_R_SIZE_MAX:
+			// TODO: actually return a proper value for _SC_GETGR_R_SIZE_MAX
+			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_GETGR_R_SIZE_MAX) returns arbitrary value 8\e[39m" << frg::endlog;
+			return 8;
 		default:
 			mlibc::panicLogger() << "\e[31mmlibc: sysconf() call is not implemented, number: " << number << "\e[39m" << frg::endlog;
 			__builtin_unreachable();

--- a/options/posix/generic/utime-stubs.cpp
+++ b/options/posix/generic/utime-stubs.cpp
@@ -1,10 +1,35 @@
 
 #include <utime.h>
+#include <fcntl.h>
+#include <errno.h>
 
 #include <bits/ensure.h>
+#include <mlibc/sysdeps.hpp>
 
-int utime(const char *, const struct utimbuf *times) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int utime(const char *filename, const struct utimbuf *times) {
+	if (!mlibc::sys_utimensat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	struct timespec time[2];
+	if(times) {
+		time[0].tv_sec = times->actime;
+		time[0].tv_nsec = 0;
+		time[1].tv_sec = times->modtime;
+		time[1].tv_nsec = 0;
+	} else {
+		time[0].tv_sec = UTIME_NOW;
+		time[0].tv_nsec = UTIME_NOW;
+		time[1].tv_sec = UTIME_NOW;
+		time[1].tv_nsec = UTIME_NOW;
+	}
+
+	if (int e = mlibc::sys_utimensat(AT_FDCWD, filename, time, 0); e) {
+		errno = e;
+		return -1;
+	}
+
+	return 0;
 }
 

--- a/options/posix/include/bits/posix/stat.h
+++ b/options/posix/include/bits/posix/stat.h
@@ -3,6 +3,10 @@
 
 #include <abi-bits/stat.h>
 
+// Used by utimensat and friends
+#define UTIME_NOW ((1l << 30) - 1l)
+#define UTIME_OMIT ((1l << 30) - 2l)
+
 #define S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)
 #define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
 #define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)

--- a/options/posix/include/netinet/in.h
+++ b/options/posix/include/netinet/in.h
@@ -11,6 +11,11 @@
 extern "C" {
 #endif
 
+uint32_t htonl(uint32_t);
+uint16_t htons(uint16_t);
+uint32_t ntohl(uint32_t);
+uint16_t ntohs(uint16_t);
+
 #define IN6_IS_ADDR_UNSPECIFIED(a) ({ \
     uint32_t *_a = (uint32_t *)((a)->s6_addr); \
     !_a[0] && \

--- a/options/posix/include/pthread.h
+++ b/options/posix/include/pthread.h
@@ -18,6 +18,10 @@ extern "C" {
 #define PTHREAD_CREATE_JOINABLE 0
 #define PTHREAD_CREATE_DETACHED 1
 
+// Values for pthread_attr_{get,set}scope
+#define PTHREAD_SCOPE_SYSTEM 0
+#define PTHREAD_SCOPE_PROCESS 1
+
 // values for pthread_{get,set}canceltype().
 #define PTHREAD_CANCEL_DEFERRED 0
 #define PTHREAD_CANCEL_ASYNCRONOUS 1
@@ -122,6 +126,9 @@ int pthread_attr_setstacksize(pthread_attr_t *, size_t);
 
 int pthread_attr_getguardsize(const pthread_attr_t *__restrict, size_t *__restrict);
 int pthread_attr_setguardsize(pthread_attr_t *, size_t);
+
+int pthread_attr_getscope(const pthread_attr_t *, int);
+int pthread_attr_setscope(pthread_attr_t *, int);
 
 // pthread functions.
 int pthread_create(pthread_t *__restrict, const pthread_attr_t *__restrict,

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -92,6 +92,7 @@ extern "C" {
 #define _SC_PAGESIZE _SC_PAGE_SIZE
 #define _SC_OPEN_MAX 5
 #define _SC_NPROCESSORS_ONLN 6
+#define _SC_GETGR_R_SIZE_MAX 7
 
 #define STDERR_FILENO 2
 #define STDIN_FILENO 0


### PR DESCRIPTION
This PR will hold the necessary changes to mlibc for `gdb` and `tcl` to build.
For now, these are:

- `pthread_attr_getscope()`, stubbed in, required by `tcl`
- `pthread_attr_setscope()`, stubbed in, required by `tcl`
- Defined `FIONBIO` for `gdb`
- Fixed overlapping signal constants (issue #27)
- Updated `sysconf()` with hardcoded values for `_SC_GETPW_R_SIZE_MAX` and `_SC_GETGR_R_SIZE_MAX`
- Moved the declarations of `htonl()` and friends to `netinet/in.h`, where they reside on Linux

Furthermore, some general improvements have been made:
- Implemented `utime()`, `utimes()`, `futimens()` and `utimensat()`
- Implemented `remove()`
- Defined `UTIME_NOW` and `UTIME_OMIT`

This PR is blocked on inclusion of managarm/managarm#181