### PR TITLE
Stubbed some pthread functions

### DIFF
--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -341,6 +341,15 @@ int pthread_mutexattr_setrobust(pthread_mutexattr_t *, int) {
 	__builtin_unreachable();
 }
 
+int pthread_mutexattr_getpshared(const pthread_mutexattr_t *, int *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+int pthread_mutexattr_setpshared(pthread_mutexattr_t *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
 // pthread_mutex functions
 int pthread_mutex_init(pthread_mutex_t *__restrict mutex,
 		const pthread_mutexattr_t *__restrict attr) {
@@ -508,6 +517,15 @@ int pthread_condattr_setclock(pthread_condattr_t *, clockid_t) {
 
 	mlibc::infoLogger() << "mlibc: pthread_condattr_setclock() is not implemented correctly" << frg::endlog;
 	return 0;
+}
+
+int pthread_condattr_getpshared(const pthread_condattr_t *__restrict, int *__restrict) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+int pthread_condattr_setpshared(pthread_condattr_t *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
 }
 
 int pthread_cond_init(pthread_cond_t *__restrict cond, const pthread_condattr_t *__restrict) {

--- a/options/posix/include/pthread.h
+++ b/options/posix/include/pthread.h
@@ -40,6 +40,10 @@ extern "C" {
 #define PTHREAD_MUTEX_STALLED 0
 #define PTHREAD_MUTEX_ROBUST 1
 
+// values for pthread_mutexattr_{get,set}pshared().
+#define PTHREAD_PROCESS_PRIVATE 0
+#define PTHREAD_PROCESS_SHARED 1
+
 #define PTHREAD_ONCE_INIT {0}
 #define PTHREAD_COND_INITIALIZER {0}
 #define PTHREAD_MUTEX_INITIALIZER {0, 0, 0}
@@ -180,6 +184,9 @@ int pthread_mutexattr_settype(pthread_mutexattr_t *, int);
 int pthread_mutexattr_getrobust(const pthread_mutexattr_t *__restrict, int *__restrict);
 int pthread_mutexattr_setrobust(pthread_mutexattr_t *, int);
 
+int pthread_mutexattr_getpshared(const pthread_mutexattr_t *, int *);
+int pthread_mutexattr_setpshared(pthread_mutexattr_t *, int);
+
 // pthread_mutex functions
 int pthread_mutex_init(pthread_mutex_t *__restrict, const pthread_mutexattr_t *__restrict);
 int pthread_mutex_destroy(pthread_mutex_t *);
@@ -201,6 +208,9 @@ int pthread_condattr_destroy(pthread_condattr_t *);
 
 int pthread_condattr_getclock(const pthread_condattr_t *__restrict, clockid_t *__restrict);
 int pthread_condattr_setclock(pthread_condattr_t *, clockid_t);
+
+int pthread_condattr_getpshared(const pthread_condattr_t *__restrict, int *__restrict);
+int pthread_condattr_setpshared(pthread_condattr_t *, int);
 
 int pthread_cond_init(pthread_cond_t *__restrict, const pthread_condattr_t *__restrict);
 int pthread_cond_destroy(pthread_cond_t *);


### PR DESCRIPTION
This PR adds 4 stubbed in pthread functions required for `libxshmfence` to compile.