### PR TITLE
Small fixes for xorg-server

### DIFF
--- a/abis/mlibc/signal.h
+++ b/abis/mlibc/signal.h
@@ -91,6 +91,8 @@ extern "C" {
 #define SIG_UNBLOCK 2
 #define SIG_SETMASK 3
 
+#define SI_USER 0
+
 #define NSIG 65
 
 // TODO: replace this by uint64_t

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -269,8 +269,11 @@ int printf(const char *__restrict format, ...) {
 }
 
 int dprintf(int fd, const char *format, ...) {
-    __ensure(!"Not implemented");
-    __builtin_unreachable();
+    va_list args;
+    va_start(args, format);
+    int result = vdprintf(fd, format, args);
+    va_end(args);
+    return result;
 }
 
 namespace {
@@ -758,6 +761,13 @@ int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_l
 int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc_va_list args) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
+}
+
+int vdprintf(int fd, const char *format, __gnuc_va_list args) {
+    FILE *file = fdopen(fd, "a");
+    int ret = vfprintf(file, format, args);
+    fclose(file);
+    return ret;
 }
 
 int fwprintf(FILE *__restrict, const wchar_t *__restrict, ...) MLIBC_STUB_BODY

--- a/options/ansi/include/stdio.h
+++ b/options/ansi/include/stdio.h
@@ -111,6 +111,7 @@ int vsnprintf(char *__restrict buffer, size_t max_size,
 		const char *__restrict format, __gnuc_va_list args);
 int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_list args);
 int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc_va_list args);
+int vdprintf(int fd, const char *format, __gnuc_va_list args);
 
 // this is a gnu extension
 int vasprintf(char **, const char *, __gnuc_va_list);

--- a/options/internal/include/mlibc/sysdeps.hpp
+++ b/options/internal/include/mlibc/sysdeps.hpp
@@ -186,6 +186,7 @@ int sys_vm_unmap(void *pointer, size_t size);
 	[[gnu::weak]] int sys_gethostname(char *buffer, size_t bufsize);
 	[[gnu::weak]] int sys_mkfifoat(int dirfd, const char *path, int mode);
 	[[gnu::weak]] int sys_eventfd_create(unsigned int initval, int flags, int *fd);
+	[[gnu::weak]] int sys_getentropy(void *buffer, size_t length);
 #endif // !defined(MLIBC_BUILDING_RTDL)
 
 } //namespace mlibc

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -694,9 +694,17 @@ pid_t gettid(void) {
 	return mlibc::sys_getpid();
 }
 
-int getentropy(void *, size_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int getentropy(void *buffer, size_t length) {
+	if(!mlibc::sys_getentropy) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_getentropy(buffer, length); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 ssize_t write(int fd, const void *buf, size_t count) {

--- a/options/posix/include/sys/select.h
+++ b/options/posix/include/sys/select.h
@@ -20,6 +20,11 @@ int FD_ISSET(int fd, fd_set *);
 void FD_SET(int fd, fd_set *);
 void FD_ZERO(fd_set *);
 
+#define FD_CLR FD_CLR
+#define FD_ISSET FD_ISSET
+#define FD_SET FD_SET
+#define FD_ZERO FD_ZERO
+
 int select(int, fd_set *__restrict, fd_set *__restrict, fd_set *__restrict,
 		struct timeval *__restrict);
 int pselect(int, fd_set *, fd_set *, fd_set *, const struct timespec *,

--- a/options/posix/include/sys/types.h
+++ b/options/posix/include/sys/types.h
@@ -28,7 +28,7 @@
 typedef unsigned int u_int;
 typedef unsigned char u_char;
 typedef unsigned short u_short;
-typedef void *caddr_t;
+typedef char *caddr_t;
 
 #endif // _SYS_TYPES_H
 

--- a/sysdeps/managarm/generic/socket.cpp
+++ b/sysdeps/managarm/generic/socket.cpp
@@ -231,8 +231,11 @@ int sys_getsockopt(int fd, int layer, int number,
 		creds.gid = resp.gid();
 		memcpy(buffer, &creds, sizeof(struct ucred));
 		return 0;
+	}else if(layer == SOL_SOCKET && number == SO_SNDBUF) {
+		mlibc::infoLogger() << "\e[31mmlibc: getsockopt() call with SOL_SOCKET and SO_SNDBUF is unimplemented\e[39m" << frg::endlog;
+		return 4096;
 	}else{
-		mlibc::panicLogger() << "\e[31mmlibc: Unexpected getsockopt() call\e[39m" << frg::endlog;
+		mlibc::panicLogger() << "\e[31mmlibc: Unexpected getsockopt() call, layer: " << layer << " number: " << number << "\e[39m" << frg::endlog;
 		__builtin_unreachable();
 	}
 }
@@ -292,8 +295,11 @@ int sys_setsockopt(int fd, int layer, int number,
 		mlibc::infoLogger() << "\e[31mmlibc: setsockopt(SO_RCVBUFFORCE) is not implemented"
 				" correctly\e[39m" << frg::endlog;
 		return 0;
+	}else if(layer == SOL_SOCKET && number == SO_SNDBUF) {
+		mlibc::infoLogger() << "\e[31mmlibc: setsockopt() call with SOL_SOCKET and SO_SNDBUF is unimplemented\e[39m" << frg::endlog;
+		return 0;
 	}else{
-		mlibc::panicLogger() << "\e[31mmlibc: Unexpected setsockopt() call\e[39m" << frg::endlog;
+		mlibc::panicLogger() << "\e[31mmlibc: Unexpected setsockopt() call, layer: " << layer << " number: " << number << "\e[39m" << frg::endlog;
 		__builtin_unreachable();
 	}
 }


### PR DESCRIPTION
This PR fixes some small bugs that the compilation of xorg-server on managarm found.
Furthermore, it implements some functions that are required at runtime for `Xwayland`. It also adds `getentropy()`, and the corresponding syscall for managarm.

Blocked on managarm/managarm#195
Closes #117 