### PR TITLE
Update lemon sysdeps

### DIFF
--- a/sysdeps/lemon/generic/lemon.cpp
+++ b/sysdeps/lemon/generic/lemon.cpp
@@ -120,6 +120,16 @@ namespace mlibc{
 		return -syscall(SYS_SETEUID, euid, 0, 0, 0, 0);
 	}
 
+	int sys_getgid(){
+		mlibc::infoLogger() << "mlibc: sys_getgid is a stub" << frg::endlog;
+		return 0;
+	}
+
+	int sys_getegid(){
+		mlibc::infoLogger() << "mlibc: sys_getegid is a stub" << frg::endlog;
+		return 0;
+	}
+
 	void sys_yield(){
 		syscall(SYS_YIELD, 0, 0, 0, 0, 0);
 	}

--- a/sysdeps/lemon/generic/lemon.cpp
+++ b/sysdeps/lemon/generic/lemon.cpp
@@ -104,9 +104,24 @@ namespace mlibc{
 		return 0;
 	}
 	
-	uid_t sys_getuid() {
+	uid_t sys_getuid(){
 		return syscall(SYS_GETUID, 0, 0, 0, 0, 0);
 	}
 
+	uid_t sys_geteuid(){
+		return syscall(SYS_GETEUID, 0, 0, 0, 0, 0);
+	}
+
+	int sys_setuid(uid_t uid){
+		return -syscall(SYS_SETUID, uid, 0, 0, 0, 0);
+	}
+
+	int sys_seteuid(uid_t euid){
+		return -syscall(SYS_SETEUID, euid, 0, 0, 0, 0);
+	}
+
+	void sys_yield(){
+		syscall(SYS_YIELD, 0, 0, 0, 0, 0);
+	}
 	#endif
 } 

--- a/sysdeps/lemon/include/lemon/syscall.h
+++ b/sysdeps/lemon/include/lemon/syscall.h
@@ -18,17 +18,16 @@
 #define SYS_MAP_FB 14
 #define SYS_ALLOC 15
 #define SYS_CHMOD 16
-#define SYS_CREATE_DESKTOP 17
+#define SYS_FSTAT 17
 #define SYS_STAT 18
 #define SYS_LSEEK 19
 #define SYS_GETPID 20
 #define SYS_MOUNT 21
-#define SYS_CREATE_WINDOW 22
-#define SYS_DESTROY_WINDOW 23
-#define SYS_DESKTOP_GET_WINDOW 24
+#define SYS_MKDIR 22
+#define SYS_RMDIR 23
+#define SYS_RENAME 24
 #define SYS_YIELD 25
-#define SYS_UPDATE_WINDOW 26
-#define SYS_GET_DESKTOP_PID 27
+#define SYS_READDIR_NEXT 26
 #define SYS_SEND_MESSAGE 28
 #define SYS_RECEIVE_MESSAGE 29
 #define SYS_UPTIME 30
@@ -64,6 +63,8 @@
 #define SYS_POLL 60
 #define SYS_SENDMSG 61
 #define SYS_RECVMSG 62
+#define SYS_GETEUID 63
+#define SYS_SETEUID 64
 
 static inline long _syscall(uint64_t call, uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4) {
     volatile long ret;


### PR DESCRIPTION
sysdeps/lemon: Stat no longer calls open, implemented rm/mkdir, (un)link, read_entries, open_dir, rename, set(e)uid and get(e)uid