### PR TITLE
abis/mlibc: add missing struct rusage members

### DIFF
--- a/abis/mlibc/resource.h
+++ b/abis/mlibc/resource.h
@@ -6,6 +6,20 @@
 struct rusage {
 	struct timeval ru_utime;
 	struct timeval ru_stime;
+	long int ru_maxrss;
+	long int ru_ixrss;
+	long int ru_idrss;
+	long int ru_isrss;
+	long int ru_minflt;
+	long int ru_majflt;
+	long int ru_nswap;
+	long int ru_inblock;
+	long int ru_oublock;
+	long int ru_msgsnd;
+	long int ru_msgrcv;
+	long int ru_nsignals;
+	long int ru_nvcsw;
+	long int ru_nivcsw;
 };
 
 #endif // _ABIBITS_RESOURCE_H


### PR DESCRIPTION
i used this site as a source: https://www.gnu.org/software/libc/manual/html_node/Resource-Usage.html