### PR TITLE
Some small fixes

### DIFF
--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -503,6 +503,7 @@ struct tm *gmtime_r(const time_t *unix_gmt, struct tm *res) {
 	res->tm_yday = yday - 1;
 	res->tm_isdst = -1;
 	res->tm_zone = __utc;
+	res->tm_gmtoff = 0;
 
 	return res;
 }
@@ -538,6 +539,7 @@ struct tm *localtime_r(const time_t *unix_gmt, struct tm *res) {
 	res->tm_yday = yday - 1;
 	res->tm_isdst = dst;
 	res->tm_zone = tm_zone;
+	res->tm_gmtoff = offset;
 
 	return res;
 }

--- a/options/ansi/include/ctype.h
+++ b/options/ansi/include/ctype.h
@@ -26,6 +26,9 @@ int isascii(int c);
 int tolower(int c);
 int toupper(int c);
 
+// Borrowed from glibc
+#define	toascii(c)	((c) & 0x7f)
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -608,6 +608,10 @@ unsigned long sysconf(int number) {
 		case _SC_JOB_CONTROL:
 			// If 1, job control is supported
 			return 1;
+		case _SC_CLK_TCK:
+			// TODO: This should be obsolete?
+			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_CLK_TCK) is obsolete and returns arbitrary value 1000000\e[39m" << frg::endlog;
+			return 1000000;
 		default:
 			mlibc::panicLogger() << "\e[31mmlibc: sysconf() call is not implemented, number: " << number << "\e[39m" << frg::endlog;
 			__builtin_unreachable();


### PR DESCRIPTION
This PR adds the following macro:

- `toascii`, This function, deemed deprecated by posix, is required for `libXaw` on managarm. It's implemented as a macro like glibc.

Furthermore, the following updates have taken place:

- `sysconf()` gained a response for the obsolete `_SC_CLK_TCK` call.
- `localtime_r()` and `gmtime_r()` neglected to set `tm_gmtoff` before returning, this lead to the use of uninitialized variables in python, crashing it.