### PR TITLE
abis/mlibc: Add missing signal numbers

### DIFF
--- a/abis/mlibc/signal.h
+++ b/abis/mlibc/signal.h
@@ -62,9 +62,13 @@ extern "C" {
 #define SIGVTALRM 26
 #define SIGPROF 27
 #define SIGWINCH 28
-#define SIGPOLL 29
+#define SIGIO 29
+#define SIGPOLL SIGIO
 #define SIGPWR 30
 #define SIGSYS 31
+
+#define SIGRTMIN 32
+#define SIGRTMAX 33
 
 #define SIGUNUSED SIGSYS
 


### PR DESCRIPTION
During the refactor, some signals got left out while they are definitely needed. This caused issues with the eudev build on managarm. This PR fixes that