### PR TITLE
Various changes needed to update weston

### DIFF
--- a/abis/mlibc/fcntl.h
+++ b/abis/mlibc/fcntl.h
@@ -22,4 +22,10 @@
 // constants for fcntl()'s additional argument of F_GETFD and F_SETFD
 #define FD_CLOEXEC 1
 
+// Used by mmap
+#define F_SEAL_SHRINK 0x0002
+#define F_SEAL_GROW   0x0004
+#define F_SEAL_WRITE  0x0008
+#define F_GET_SEALS   1034
+
 #endif // _ABITBITS_FCNTL_H

--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -172,6 +172,15 @@ int pthread_cleanup_pop(int) {
 	__builtin_unreachable();
 }
 
+int pthread_setname_np(pthread_t, const char *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+int pthread_getname_np(pthread_t, char *, size_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
 int pthread_setcanceltype(int, int *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/include/pthread.h
+++ b/options/posix/include/pthread.h
@@ -145,6 +145,9 @@ int pthread_detach(pthread_t);
 int pthread_cleanup_push(void (*) (void *), void *);
 int pthread_cleanup_pop(int);
 
+int pthread_setname_np(pthread_t, const char *);
+int pthread_getname_np(pthread_t, char *, size_t);
+
 int pthread_setcanceltype(int, int *);
 int pthread_setcancelstate(int, int *);
 void pthread_testcancel(void);

--- a/sysdeps/managarm/generic/time.cpp
+++ b/sysdeps/managarm/generic/time.cpp
@@ -58,6 +58,13 @@ int sys_clock_get(int clock, time_t *secs, long *nanos) {
 				"\e[39m" << frg::endlog;
 		*secs = 0;
 		*nanos = 0;
+	}else if(clock == CLOCK_MONOTONIC_RAW) {
+		mlibc::infoLogger() << "\e[31mmlibc: clock_gettime implements CLOCK_MONOTONIC_RAW as CLOCK_MONOTONIC"
+				"\e[39m" << frg::endlog;
+		uint64_t tick;
+		HEL_CHECK(helGetClock(&tick));
+		*secs = tick / 1000000000;
+		*nanos = tick % 1000000000;
 	}else{
 		mlibc::panicLogger() << "mlibc: Unexpected clock " << clock << frg::endlog;
 	}


### PR DESCRIPTION
While updating `weston` for Managarm, the following changes were required:

New functions:
- `pthread_setname_np()`, stubbed.
- `pthread_getname_np()`, stubbed.

New defines:
- 4 fcntl defines related to `mmap()` and friends have been defined.

Updates:
- In Managarm sysdeps, `clock_getres()` now handles `CLOCK_MONOTONIC_RAW` like `CLOCK_MONOTONIC` instead of panicking (`CLOCK_MONOTONIC_RAW` is a Linux extension).