### PR TITLE
Various libuv and cmake related changes

### DIFF
--- a/abis/mlibc/socket.h
+++ b/abis/mlibc/socket.h
@@ -25,6 +25,11 @@ struct sockaddr_storage {
 	char __padding[128 - sizeof(sa_family_t)];
 };
 
+struct mmsghdr {
+	struct msghdr msg_hdr;
+	unsigned int  msg_len;
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/linux/generic/linux-unistd.cpp
+++ b/options/linux/generic/linux-unistd.cpp
@@ -1,0 +1,7 @@
+#include <bits/linux/linux_unistd.h>
+#include <bits/ensure.h>
+
+int dup3(int fd, int newfd, int flags) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/include/bits/linux/linux_unistd.h
+++ b/options/linux/include/bits/linux/linux_unistd.h
@@ -1,0 +1,14 @@
+#ifndef _LINUX_UNISTD_H
+#define _LINUX_UNISTD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int dup3(int fd, int newfd, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _LINUX_UNISTD_H

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -19,6 +19,7 @@ libc_sources += files(
 	'generic/sys-reboot.cpp',
 	'generic/netinet-in6addr.cpp',
 	'generic/utmp-stubs.cpp',
+	'generic/linux-unistd.cpp',
 )
 
 if not no_headers
@@ -35,6 +36,10 @@ if not no_headers
 		'include/asm/ioctl.h',
 		'include/asm/ioctls.h',
 		subdir: 'asm'
+	)
+	install_headers(
+		'include/bits/linux/linux_unistd.h',
+		subdir: 'bits/linux'
 	)
 	install_headers(
 		'include/linux/bpf_common.h',

--- a/options/posix/generic/net-if-stubs.cpp
+++ b/options/posix/generic/net-if-stubs.cpp
@@ -1,5 +1,6 @@
 
 #include <dirent.h>
+#include <net/if.h>
 #include <bits/ensure.h>
 
 void if_freenameindex(struct if_nameindex *) {
@@ -21,4 +22,3 @@ unsigned int if_nametoindex(const char *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-

--- a/options/posix/generic/sys-socket-stubs.cpp
+++ b/options/posix/generic/sys-socket-stubs.cpp
@@ -143,6 +143,11 @@ ssize_t recvmsg(int fd, struct msghdr *hdr, int flags) {
 	return length;
 }
 
+int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
 ssize_t send(int fd, const void *buffer, size_t size, int flags) {
 	return sendto(fd, buffer, size, flags, nullptr, 0);
 }
@@ -174,6 +179,11 @@ ssize_t sendmsg(int fd, const struct msghdr *hdr, int flags) {
 		return -1;
 	}
 	return length;
+}
+
+int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
 }
 
 int setsockopt(int fd, int layer, int number,

--- a/options/posix/generic/sys-uio.cpp
+++ b/options/posix/generic/sys-uio.cpp
@@ -47,3 +47,12 @@ ssize_t writev(int fd, const struct iovec *iovs, int iovc) {
 	return written;
 }
 
+ssize_t preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/generic/termios-stubs.cpp
+++ b/options/posix/generic/termios-stubs.cpp
@@ -19,6 +19,10 @@ int cfsetospeed(struct termios *, speed_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+void cfmakeraw(struct termios *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
 int tcdrain(int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/include/sys/socket.h
+++ b/options/posix/include/sys/socket.h
@@ -86,6 +86,8 @@ ssize_t recvmsg(int, struct msghdr *, int);
 ssize_t send(int, const void *, size_t, int);
 ssize_t sendmsg(int, const struct msghdr *, int);
 ssize_t sendto(int, const void *, size_t, int, const struct sockaddr *, socklen_t);
+int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout);
+int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags);
 int setsockopt(int, int, int, const void *, socklen_t);
 int shutdown(int, int);
 int sockatmark(int);

--- a/options/posix/include/sys/uio.h
+++ b/options/posix/include/sys/uio.h
@@ -3,14 +3,19 @@
 
 #include <bits/posix/iovec.h>
 #include <bits/ssize_t.h>
+#include <bits/off_t.h>
 #include <bits/size_t.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-ssize_t readv(int, const struct iovec *, int);
-ssize_t writev(int, const struct iovec *, int);
+ssize_t readv(int fd, const struct iovec *iov, int iovcnt);
+ssize_t writev(int fd, const struct iovec *iov, int iovcnt);
+
+// Non standard extensions, also found on modern BSD's
+ssize_t preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset);
+ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset);
 
 #ifdef __cplusplus
 }

--- a/options/posix/include/termios.h
+++ b/options/posix/include/termios.h
@@ -123,6 +123,7 @@ speed_t cfgetispeed(const struct termios *);
 speed_t cfgetospeed(const struct termios *);
 int cfsetispeed(struct termios *, speed_t);
 int cfsetospeed(struct termios *, speed_t);
+void cfmakeraw(struct termios *);
 int tcdrain(int);
 int tcflow(int, int);
 int tcflush(int, int);

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -2,6 +2,7 @@
 #ifndef _UNISTD_H
 #define _UNISTD_H
 
+#include <bits/feature.h>
 #include <bits/types.h>
 #include <bits/size_t.h>
 #include <bits/ssize_t.h>
@@ -220,6 +221,10 @@ int pipe2(int *pipefd, int flags);
 
 #ifdef __cplusplus
 }
+#endif
+
+#if __MLIBC_LINUX_OPTION
+#	include <bits/linux/linux_unistd.h>
 #endif
 
 #endif // _UNISTD_H


### PR DESCRIPTION
This PR aims to stub and provide functions and structs as requested by `libuv` and `cmake`. To accomplish this, the following struct has been added:

- `struct mmsghdr`.

Furthermore, the following functions have been added and stubbed:

- `cfmakeraw()`.
- `dup3()`,
- `recvmmsg()`,
- `sendmmsg()`,
- `preadv()`,
- `pwritev()`.
- All the functions in the net-if-stubs.cpp file located in options/posix are now declared with `extern "C"` linkage to satisfy `libuv`.