### PR TITLE
Implement lockf and fixed a bug in environment handling

### DIFF
--- a/options/ansi/generic/environment.cpp
+++ b/options/ansi/generic/environment.cpp
@@ -80,7 +80,8 @@ void unassign_variable(frg::string_view name) {
 	__ensure(environ == vector.data());
 
 	auto k = find_environ_index(name);
-	FRG_ASSERT(k != size_t(-1));
+	if(k == size_t(-1))
+		return;
 
 	// Last pointer of environ must always be a null delimiter.
 	__ensure(vector.size() >= 2 && !vector.back());

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -362,10 +362,35 @@ int linkat(int olddirfd, const char *old_path, int newdirfd, const char *new_pat
 	return 0;
 }
 
-int lockf(int, int, off_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+// Code take from musl
+int lockf(int fd, int op, off_t size) {
+	struct flock l = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_CUR,
+		.l_len = size,
+	};
+
+	switch(op) {
+		case F_TEST:
+			l.l_type = F_RDLCK;
+			if(fcntl(fd, F_GETLK, &l) < 0)
+				return -1;
+			if(l.l_type == F_UNLCK || l.l_pid == getpid())
+				return 0;
+			errno = EACCES;
+			return -1;
+		case F_ULOCK:
+			l.l_type = F_UNLCK;
+		case F_TLOCK:
+			return fcntl(fd, F_SETLK, &l);
+		case F_LOCK:
+			return fcntl(fd, F_SETLKW, &l);
+	}
+
+	errno = EINVAL;
+	return -1;
 }
+
 int nice(int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();


### PR DESCRIPTION
This PR fixes a bug in the handling of environment variables found while working with `gtk3` on managarm. Furthermore, it implements `lockf()` like musl.

This PR fixes #169 