### PR TITLE
setjmp: Fix non spec-compliant longjmp for x86_64

### DIFF
--- a/options/internal/x86_64/setjmp.S
+++ b/options/internal/x86_64/setjmp.S
@@ -43,7 +43,9 @@ longjmp:
 	mov 0x20(%rdi), %r14
 	mov 0x28(%rdi), %r15
 
-	mov %rsi, %rax
-	mov 0x30(%rdi), %rsp
-	jmp *0x38(%rdi)
+	mov  %rsi, %rax
+	test %rax, %rax
+	setz %al
+	mov  0x30(%rdi), %rsp
+	jmp  *0x38(%rdi)
 


### PR DESCRIPTION
The definition of `longjmp` specifies that it must make `setjmp` return 1 if the passed value is 0, else it must make it return said value. The current `x86_64` implementation does not take that into account, now it does.

Source: https://pubs.opengroup.org/onlinepubs/009695399/functions/longjmp.html, more specifically
```
After longjmp() is completed, program execution continues as if the corresponding invocation of setjmp() had just returned the value specified by val. The longjmp() function shall not cause setjmp() to return 0; if val is 0, setjmp() shall return 1.
```