### PR TITLE
Add some defines needed for p11-kit

### DIFF
--- a/abis/managarm/auxv.h
+++ b/abis/managarm/auxv.h
@@ -5,6 +5,7 @@
 #define AT_PHENT 4
 #define AT_PHNUM 5
 #define AT_ENTRY 9
+#define AT_SECURE 23
 #define AT_RANDOM 25
 #define AT_EXECFN 31
 

--- a/options/posix/include/sys/un.h
+++ b/options/posix/include/sys/un.h
@@ -13,6 +13,9 @@ struct sockaddr_un {
 	char sun_path[108];
 };
 
+// Evaluate to actual length of the `sockaddr_un' structure.
+#define SUN_LEN(ptr) ((size_t) offsetof(struct sockaddr_un, sun_path))
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR adds the following two defines to satisfy `p11-kit`.

- `AT_SECURE` is defined for Managarm,
- `SUN_LEN` macro has been added.