### PR TITLE
options/linux: Implement getrandom

### DIFF
--- a/options/linux/generic/sys-random-stubs.cpp
+++ b/options/linux/generic/sys-random-stubs.cpp
@@ -3,9 +3,24 @@
 #include <bits/ensure.h>
 
 #include <mlibc/debug.hpp>
+#include <mlibc/posix-sysdeps.hpp>
+
+#include <errno.h>
 
 ssize_t getrandom(void *buffer, size_t max_size, unsigned int flags) {
-	mlibc::infoLogger() << "\e[31mmlibc: getrandom() is a no-op\e[39m" << frg::endlog;
+	if(flags & ~(GRND_RANDOM | GRND_NONBLOCK)) {
+		errno = EINVAL;
+		return -1;
+	}
+	if(!mlibc::sys_getentropy) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_getentropy(buffer, max_size); e) {
+		errno = e;
+		return -1;
+	}
 	return max_size;
 }
 


### PR DESCRIPTION
This PR implements `getrandom` via `sys_getentropy()`, this should remove the `mlibc: getrandom() is a no-op` message shown on managarm boot.