### PR TITLE
options/ansi: Implement abs, labs and llabs, include <bits/feature.h> in ctype.h to fix POSIX locale ctype extensions

### DIFF
--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -281,17 +281,16 @@ void qsort(void *base, size_t count, size_t size,
 	}
 }
 
-int abs(int number) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int abs(int num) {
+	return num < 0 ? -num : num;
 }
-long labs(long number) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+long labs(long num) {
+	return num < 0 ? -num : num;
 }
-long long llabs(long long number) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+long long llabs(long long num) {
+	return num < 0 ? -num : num;
 }
 
 div_t div(int number, int denom) {

--- a/options/ansi/include/ctype.h
+++ b/options/ansi/include/ctype.h
@@ -1,6 +1,8 @@
 #ifndef _CTYPE_H
 #define _CTYPE_H
 
+#include <bits/feature.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tests/ansi/abs.c
+++ b/tests/ansi/abs.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+#include <assert.h>
+#include <limits.h>
+
+int main(){
+    assert(abs(-10) == 10);
+    assert(abs(2021) == 2021);
+
+    assert(labs(-256) == 256);
+    assert(labs(10034890) == 10034890);
+
+    assert(llabs(-0x2deadbeef) == 0x2deadbeef);
+    assert(llabs(49238706947) == 49238706947);
+
+    return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,7 +3,8 @@ ansi_test_cases = [
 	'sprintf',
 	'snprintf',
 	'utf8',
-	'strtol'
+	'strtol',
+	'abs'
 ]
 
 posix_test_cases = [


### PR DESCRIPTION
These are used by some software such as NASM.