### PR TITLE
options/posix: syslog improvements

### DIFF
--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -196,6 +196,13 @@ size_t strftime(char *__restrict dest, size_t max_size,
 				return 0;
 			p += chunk;
 			c += 2;
+		}else if (*(c + 1) == 'e') {
+			int chunk;
+			chunk = snprintf(p, space, "%2d", tm->tm_mday);
+			if(chunk >= space)
+				return 0;
+			p += chunk;
+			c += 2;
 		}else if (*(c + 1) == 'I') {
 			int hour = tm->tm_hour;
 			if(hour > 12)

--- a/options/posix/generic/syslog-stubs.cpp
+++ b/options/posix/generic/syslog-stubs.cpp
@@ -2,14 +2,29 @@
 #include <syslog.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <time.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <bits/ensure.h>
+
+#include <frg/mutex.hpp>
+#include <mlibc/lock.hpp>
+#include <mlibc/debug.hpp>
+
+// This syslog implementation is largely taken from musl
 
 static char log_ident[32];
 static int log_options;
 static int log_facility = LOG_USER;
 static int log_fd = -1;
+static int log_opt;
+static int log_mask = 0xff;
+
+static int use_mlibc_logger = 0;
+static FutexLock __syslog_lock;
 
 static const struct sockaddr_un log_addr {AF_UNIX, "/dev/log"};
 
@@ -20,8 +35,13 @@ void closelog(void) {
 
 static void __openlog() {
 	log_fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
-	if(log_fd >= 0)
-		connect(log_fd, (const sockaddr *)&log_addr, sizeof log_addr);
+	if(log_fd >= 0) {
+		int ret = connect(log_fd, (const sockaddr *)&log_addr, sizeof log_addr);
+		if(ret) {
+			mlibc::infoLogger() << "\e[31mmlibc: syslog: connect returned an error, falling back to infoLogger\e[39m" << frg::endlog;
+			use_mlibc_logger = 1;
+		}
+	}
 }
 
 void openlog(const char *ident, int options, int facility) {
@@ -44,13 +64,79 @@ int setlogmask(int) {
 	__builtin_unreachable();
 }
 
-void syslog(int, const char *, ...) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+static void _vsyslog(int priority, const char *message, va_list ap) {
+	auto is_lost_conn = [] (int e) {
+		return e == ECONNREFUSED || e == ECONNRESET || e == ENOTCONN || e == EPIPE;
+	};
+
+	char timebuf[16];
+	time_t now;
+	struct tm tm;
+	char buf[1024];
+	int errno_save = errno;
+	int pid;
+	int l, l2;
+	int hlen;
+	int fd;
+
+	if(log_fd < 0)
+		__openlog();
+
+	if(use_mlibc_logger) {
+		vsnprintf(buf, sizeof buf, message, ap);
+		mlibc::infoLogger() << "mlibc: syslog: " << buf << frg::endlog;
+		return;
+	}
+
+	if(!(priority & LOG_FACMASK))
+		priority |= log_facility;
+
+	now = time(NULL);
+	gmtime_r(&now, &tm);
+	strftime(timebuf, sizeof timebuf, "%b %e %T", &tm);
+
+	pid = (log_opt & LOG_PID) ? getpid() : 0;
+	l = snprintf(buf, sizeof buf, "<%d>%s %n%s%s%.0d%s: ",
+		priority, timebuf, &hlen, log_ident, "[" + !pid, pid, "]" + !pid);
+	errno = errno_save;
+	l2 = vsnprintf(buf + l, sizeof buf - l, message, ap);
+	if(l2 >= 0) {
+		if(l2 >= sizeof buf - l)
+			l = sizeof buf - 1;
+		else
+			l += l2;
+		if(buf[l - 1] != '\n')
+			buf[l++] = '\n';
+		if(send(log_fd, buf, l, 0) < 0 && (!is_lost_conn(errno)
+		    || connect(log_fd, (const sockaddr *)&log_addr, sizeof log_addr) < 0
+		    || send(log_fd, buf, l, 0) < 0)
+		    && (log_opt & LOG_CONS)) {
+			fd = open("/dev/console", O_WRONLY|O_NOCTTY|O_CLOEXEC);
+			if(fd >= 0) {
+				dprintf(fd, "%.*s", l - hlen, buf + hlen);
+				close(fd);
+			}
+		}
+		if(log_opt & LOG_PERROR)
+			dprintf(STDERR_FILENO, "%.*s", l - hlen, buf + hlen);
+	}
 }
 
-void vsyslog(int, const char *, va_list) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+void syslog(int priority, const char *format, ...) {
+	va_list ap;
+	va_start(ap, format);
+	vsyslog(priority, format, ap);
+	va_end(ap);
 }
 
+void vsyslog(int priority, const char *message, va_list ap) {
+	int cs;
+	if(!(log_mask & LOG_MASK(priority & 7)) || (priority & ~0x3ff)) {
+		mlibc::infoLogger() << "\e[31mmlibc: syslog: log_mask or priority out of range, not printing anything\e[39m" << frg::endlog;
+		return;
+	}
+	//pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	frg::unique_lock<FutexLock> lock(__syslog_lock);
+	_vsyslog(priority, message, ap);
+	//pthread_setcancelstate(cs, 0);
+}

--- a/options/posix/include/syslog.h
+++ b/options/posix/include/syslog.h
@@ -13,6 +13,7 @@ extern "C" {
 #define LOG_NDELAY 0x08
 #define LOG_ODELAY 0x04
 #define LOG_NOWAIT 0x10
+#define LOG_PERROR 0x20
 
 #define LOG_KERN (0<<3)
 #define LOG_USER (1<<3)

--- a/tests/ansi/strftime.c
+++ b/tests/ansi/strftime.c
@@ -1,0 +1,21 @@
+#include <string.h>
+#include <time.h>
+#include <assert.h>
+
+int main() {
+	char timebuf[16];
+	char result[16] = " 8";
+	struct tm tm;
+	tm.tm_sec = 0;
+	tm.tm_min = 17;
+	tm.tm_hour = 17;
+	tm.tm_mday = 8;
+	tm.tm_mon = 2;
+	tm.tm_year = 121;
+	tm.tm_wday = 2;
+	tm.tm_yday = 39;
+	strftime(timebuf, sizeof timebuf, "%e", &tm);
+	assert(!strcmp(timebuf, result));
+
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,7 +5,8 @@ ansi_test_cases = [
 	'utf8',
 	'strtol',
 	'abs',
-	'strverscmp'
+	'strverscmp',
+	'strftime'
 ]
 
 posix_test_cases = [


### PR DESCRIPTION
This PR implements `syslog()` and `vsyslog()` like musl, with the added extension that should the `connect()` call to the syslog socket fail, we fall back to using `mlibc::infoLogger()`.