### PR TITLE
Various stubs and defines for util-linux

### DIFF
--- a/options/glibc/generic/shadow-stubs.cpp
+++ b/options/glibc/generic/shadow-stubs.cpp
@@ -29,3 +29,8 @@ int ulckpwdf(void) {
 	mlibc::infoLogger() << "mlibc: ulckpwdf is unimplemented like musl" << frg::endlog;
 	return 0;
 }
+
+struct spwd *getspnam(const char *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/glibc/include/shadow.h
+++ b/options/glibc/include/shadow.h
@@ -26,6 +26,7 @@ struct spwd {
 int putspent(const struct spwd *, FILE *);
 int lckpwdf(void);
 int ulckpwdf(void);
+struct spwd *getspnam(const char *);
 
 #ifdef __cplusplus
 }

--- a/options/linux/generic/linux-unistd.cpp
+++ b/options/linux/generic/linux-unistd.cpp
@@ -5,3 +5,8 @@ int dup3(int fd, int newfd, int flags) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+int vhangup(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/generic/utmpx.cpp
+++ b/options/linux/generic/utmpx.cpp
@@ -1,0 +1,7 @@
+#include <bits/ensure.h>
+#include <utmpx.h>
+
+void updwtmpx(const char *, const struct utmpx *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/generic/utmpx.cpp
+++ b/options/linux/generic/utmpx.cpp
@@ -5,3 +5,28 @@ void updwtmpx(const char *, const struct utmpx *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+void endutxent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+void setutxent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+struct utmpx *getutxent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+struct utmpx *pututxline(const struct utmpx *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int utmpxname(const char *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/include/asm/ioctls.h
+++ b/options/linux/include/asm/ioctls.h
@@ -8,6 +8,7 @@
 #define TIOCSCTTY 0x540E
 #define TIOCSTI 0x5412
 #define TIOCGWINSZ 0x5413
+#define TIOCMGET 0x5415
 #define TIOCNOTTY 0x5422
 
 #define TIOCGPTN _IOR('T', 0x30, unsigned int)

--- a/options/linux/include/bits/linux/linux_unistd.h
+++ b/options/linux/include/bits/linux/linux_unistd.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 int dup3(int fd, int newfd, int flags);
+int vhangup(void);
 
 #ifdef __cplusplus
 }

--- a/options/linux/include/ifaddrs.h
+++ b/options/linux/include/ifaddrs.h
@@ -1,0 +1,28 @@
+
+#ifndef  _IFADDRS_H
+#define  _IFADDRS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+// Struct definitions taken from musl
+struct ifaddrs {
+	struct ifaddrs *ifa_next;
+	char *ifa_name;
+	unsigned ifa_flags;
+	struct sockaddr *ifa_addr;
+	struct sockaddr *ifa_netmask;
+	struct sockaddr *ifa_broadaddr;
+	struct sockaddr *ifa_dstaddr;
+	void *ifa_data;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _IFADDRS_H

--- a/options/linux/include/utmpx.h
+++ b/options/linux/include/utmpx.h
@@ -2,6 +2,10 @@
 #ifndef  _UTMPX_H
 #define  _UTMPX_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <abi-bits/pid_t.h>
 #include <bits/posix/timeval.h>
 
@@ -25,5 +29,19 @@ struct utmpx {
 };
 
 void updwtmpx(const char *, const struct utmpx *);
+
+#define EMPTY           0
+#define RUN_LVL         1
+#define BOOT_TIME       2
+#define NEW_TIME        3
+#define OLD_TIME        4
+#define INIT_PROCESS    5
+#define LOGIN_PROCESS   6
+#define USER_PROCESS    7
+#define DEAD_PROCESS    8
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _UTMPX_H

--- a/options/linux/include/utmpx.h
+++ b/options/linux/include/utmpx.h
@@ -29,6 +29,11 @@ struct utmpx {
 };
 
 void updwtmpx(const char *, const struct utmpx *);
+int utmpxname(const char *);
+struct utmpx *pututxline(const struct utmpx *);
+struct utmpx *getutxent(void);
+void setutxent(void);
+void endutxent(void);
 
 #define EMPTY           0
 #define RUN_LVL         1

--- a/options/linux/include/utmpx.h
+++ b/options/linux/include/utmpx.h
@@ -1,0 +1,29 @@
+
+#ifndef  _UTMPX_H
+#define  _UTMPX_H
+
+#include <abi-bits/pid_t.h>
+#include <bits/posix/timeval.h>
+
+// Struct definition taken from musl
+struct utmpx {
+	short ut_type;
+	short __ut_pad1;
+	pid_t ut_pid;
+	char ut_line[32];
+	char ut_id[4];
+	char ut_user[32];
+	char ut_host[256];
+	struct {
+		short __e_termination;
+		short __e_exit;
+	} ut_exit;
+	int ut_session, __ut_pad2;
+	struct timeval ut_tv;
+	unsigned ut_addr_v6[4];
+	char __unused[20];
+};
+
+void updwtmpx(const char *, const struct utmpx *);
+
+#endif // _UTMPX_H

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -19,6 +19,7 @@ libc_sources += files(
 	'generic/sys-reboot.cpp',
 	'generic/netinet-in6addr.cpp',
 	'generic/utmp-stubs.cpp',
+	'generic/utmpx.cpp',
 	'generic/linux-unistd.cpp',
 )
 
@@ -30,6 +31,7 @@ if not no_headers
 		'include/poll.h',
 		'include/pty.h',
 		'include/utmp.h',
+		'include/utmpx.h',
 		'include/values.h',
 		'include/lastlog.h',
 	)

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -25,6 +25,7 @@ libc_sources += files(
 
 if not no_headers
 	install_headers(
+		'include/ifaddrs.h',
 		'include/malloc.h',
 		'include/memory.h',
 		'include/mntent.h',

--- a/options/posix/generic/grp-stubs.cpp
+++ b/options/posix/generic/grp-stubs.cpp
@@ -168,3 +168,8 @@ struct group *fgetgrent(FILE *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+int getgrouplist(const char *, gid_t, gid_t *, int *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/generic/search.cpp
+++ b/options/posix/generic/search.cpp
@@ -2,14 +2,32 @@
 #include <bits/ensure.h>
 #include <search.h>
 
+struct node {
+	const void *key;
+	void *a[2];
+	int h;
+};
+
 void *tsearch(const void *, void **, int(*compar)(const void *, const void *)) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-void *tfind(const void *, void *const *, int (*compar)(const void *, const void *)) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+// This implementation is taken from musl
+void *tfind(const void *key, void *const *rootp, int (*compar)(const void *, const void *)) {
+	if(!rootp)
+		return 0;
+
+	struct node *n = (struct node *)*rootp;
+	for(;;) {
+		if(!n) 
+			break;
+		int c = compar(key, n->key);
+		if(!c)
+			break;
+		n = (struct node *)n->a[c > 0];
+	}
+	return n;
 }
 
 void *tdelete(const void *, void **, int(*compar)(const void *, const void *)) {

--- a/options/posix/generic/search.cpp
+++ b/options/posix/generic/search.cpp
@@ -16,3 +16,13 @@ void *tdelete(const void *, void **, int(*compar)(const void *, const void *)) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+void twalk(const void *, void (*action)(const void *, VISIT, int)) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+void tdestroy(void *, void (*free_node)(void *)) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/generic/search.cpp
+++ b/options/posix/generic/search.cpp
@@ -1,6 +1,11 @@
 
 #include <bits/ensure.h>
 #include <search.h>
+#include <stddef.h>
+#include <new>
+#include <mlibc/allocator.hpp>
+#include <frg/stack.hpp>
+#include <stdlib.h>
 
 struct node {
 	const void *key;
@@ -8,9 +13,84 @@ struct node {
 	int h;
 };
 
-void *tsearch(const void *, void **, int(*compar)(const void *, const void *)) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+namespace {
+	int height(struct node *node) {
+		return node ? node->h : 0;
+	}
+
+	int rotate(struct node **nodep, int side) {
+		struct node *node = *nodep;
+		struct node *x = static_cast<struct node *>(node->a[side]);
+		struct node *y = static_cast<struct node *>(x->a[!side]);
+		struct node *z = static_cast<struct node *>(x->a[side]);
+
+		int height_node = node->h;
+		int height_y = height(y);
+		if (height_y > height(z)) {
+			// Perform double rotation
+			node->a[side] = y->a[!side];
+			x->a[!side] = y->a[side];
+			y->a[!side] = node;
+			y->a[side] = x;
+			node->h = height_y;
+			x->h = height_y;
+			y->h = height_y + 1;
+		} else {
+			// Perform single rotation
+			node->a[side] = y;
+			x->a[!side] = node;
+			node->h = height_y + 1;
+			x->h = height_y + 2;
+			y = x;
+
+		}
+		*nodep = y;
+		return y->h - height_node;
+	}
+
+	int balance_tree(struct node **nodep) {
+		struct node *node = *nodep;
+		int height_a = height(static_cast<struct node *>(node->a[0]));
+		int height_b = height(static_cast<struct node *>(node->a[1]));
+		if (height_a - height_b < 2) {
+			int old = node->h;
+			node->h = height_a < height_b ? height_b + 1 : height_a + 1;
+			return node->h - old;
+		}
+
+		return rotate(nodep, height_a < height_b);
+	}
+}
+
+void *tsearch(const void *key, void **rootp, int(*compar)(const void *, const void *)) {
+	if (!rootp)
+		return NULL;
+
+	struct node *n = static_cast<struct node *>(*rootp);
+	frg::stack<struct node **, MemoryAllocator> nodes(getAllocator());
+	nodes.push(reinterpret_cast<struct node **>(rootp));
+	int c = 0;
+	for (;;) {
+		if (!n)
+			break;
+		c = compar(key, n->key);
+		if (!c)
+			return n;
+		nodes.push(reinterpret_cast<struct node **>(&n->a[c > 0]));
+		n = static_cast<struct node *>(n->a[c > 0]);
+	}
+
+	struct node *insert = static_cast<struct node*>(malloc(sizeof(struct node)));
+	if (!insert)
+		return NULL;
+	insert->key = key;
+	insert->a[0] = insert->a[1] = NULL;
+	insert->h = 1;
+
+	(*nodes.top()) = insert;
+	nodes.pop();
+	while(nodes.size() && balance_tree(nodes.top())) nodes.pop();
+	return insert;
 }
 
 // This implementation is taken from musl
@@ -20,7 +100,7 @@ void *tfind(const void *key, void *const *rootp, int (*compar)(const void *, con
 
 	struct node *n = (struct node *)*rootp;
 	for(;;) {
-		if(!n) 
+		if(!n)
 			break;
 		int c = compar(key, n->key);
 		if(!c)

--- a/options/posix/include/grp.h
+++ b/options/posix/include/grp.h
@@ -29,6 +29,9 @@ struct group *fgetgrent(FILE *);
 int setgroups(size_t size, const gid_t *list);
 int initgroups(const char *user, gid_t group);
 
+// Non standard extension
+int getgrouplist(const char *, gid_t, gid_t *, int *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/posix/include/net/if.h
+++ b/options/posix/include/net/if.h
@@ -47,10 +47,13 @@ struct ifreq {
 struct ifconf {
 	int ifc_len;
 	union {
-		char *ifc_buf;
-		struct ifreq *ifc_req;
-	};
+		char *ifcu_buf;
+		struct ifreq *ifcu_req;
+	} ifc_ifcu;
 };
+
+#define ifc_buf ifc_ifcu.ifcu_buf
+#define ifc_req ifc_ifcu.ifcu_req
 
 void if_freenameindex(struct if_nameindex *);
 char *if_indextoname(unsigned int, char *);

--- a/options/posix/include/net/if.h
+++ b/options/posix/include/net/if.h
@@ -57,6 +57,10 @@ char *if_indextoname(unsigned int, char *);
 struct if_nameindex *if_nameindex(void);
 unsigned int if_nametoindex(const char *);
 
+#define IFF_UP 0x1
+#define IFF_LOOPBACK 0x8
+#define IFF_RUNNING 0x40
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/posix/include/search.h
+++ b/options/posix/include/search.h
@@ -6,9 +6,18 @@
 extern "C" {
 #endif
 
+typedef enum {
+  preorder,
+  postorder,
+  endorder,
+  leaf
+} VISIT;
+
 void *tsearch(const void *, void **, int(*compar)(const void *, const void *));
 void *tfind(const void *, void *const *, int (*compar)(const void *, const void *));
 void *tdelete(const void *, void **, int(*compar)(const void *, const void *));
+void twalk(const void *, void (*action)(const void *, VISIT, int));
+void tdestroy(void *, void (*free_node)(void *));
 
 #ifdef __cplusplus
 }

--- a/options/posix/include/sys/param.h
+++ b/options/posix/include/sys/param.h
@@ -8,6 +8,7 @@
 #define NGROUPS NGROUPS_MAX
 
 // Report the same value as Linux here.
+#define MAXNAMLEN 255
 #define MAXPATHLEN 4096
 #define HOST_NAME_MAX 64
 #define MAXHOSTNAMELEN HOST_NAME_MAX

--- a/options/posix/include/sys/ttydefaults.h
+++ b/options/posix/include/sys/ttydefaults.h
@@ -3,6 +3,7 @@
 #define _SYS_TTYDEFAULTS_H
 
 // Values taken from musl
+#define TTYDEF_SPEED (B9600)
 #define CTRL(x) ((x) & 037)
 #define CEOF CTRL('d')
 

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -106,6 +106,8 @@ extern "C" {
 #define _SC_VERSION 11
 #define _SC_SAVED_IDS 12
 #define _SC_JOB_CONTROL 13
+#define _SC_HOST_NAME_MAX 14
+#define _SC_LINE_MAX 15
 
 #define STDERR_FILENO 2
 #define STDIN_FILENO 0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,7 +19,8 @@ posix_test_cases = [
 	'dprintf',
 	'posix_spawn',
 	'index',
-	'rindex'
+	'rindex',
+	'search'
 ]
 
 glibc_test_cases = [

--- a/tests/posix/search.c
+++ b/tests/posix/search.c
@@ -1,0 +1,44 @@
+#include <search.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+static int compare(const void *pa, const void *pb) {
+	if (*(int*)pa < *(int*) pb)
+		return -1;
+	if (*(int*)pa > *(int*) pb)
+		return 1;
+	return 0;
+}
+
+static void check_key(int key, void *root) {
+	int keyp = key;
+	void *ret = tfind((void*) &keyp, &root, compare);
+	assert(ret);
+	assert(**((int **) ret) == key);
+}
+
+int main() {
+	void *root = NULL;
+	for (int i = 0; i < 12; i++) {
+		int *ptr = malloc(sizeof(int));
+		assert(ptr);
+		*ptr = i;
+
+		void *ret = tsearch((void*) ptr, &root, compare);
+		assert(ret);
+		assert(**((int **) ret) == i);
+	}
+
+	// Test a couple of keys
+	check_key(1, root);
+	check_key(5, root);
+	check_key(10, root);
+
+	// Verify NULL on non-existent key
+	int key = -1;
+	void *ret = tfind((void*) &key, &root, compare);
+	assert(ret == NULL);
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds the following stubs:

- `udwtmpx()`,
- `endutxent()`,
- `setutxent()`,
- `getutxent()`,
- `pututxline()`,
- `utmpxname()`,
- `vhangup()`,
- `getgrouplist()`,
- `twalk()`,
- `tdestroy()`,
- `getspnam()`.

This PR implements the following function:
- `tfind()`,
- `tsearch()`.

Furthermore, the following defines and structs were added:

- `struct utmpx`,
- several `utmpx` related defines,
- `MAXNAMELEN`,
- 2 sysconf defines,
- `struct ifaddrs`,
- `TTYDEF_SPEED`,
- 3 `net/if.h` related defines,
- `TIOCMGET` ioctl define,
- the `VISIT` enum.