### PR TITLE
sysdeps/managarm: Handle EINVAL in ioctl(TIOCGWINSZ)

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2768,6 +2768,8 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result) {
 
 		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp->data, recv_resp->length);
+		if(resp.error() == managarm::fs::Errors::ILLEGAL_OPERATION_TARGET)
+			return EINVAL;
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
 		*result = resp.result();


### PR DESCRIPTION
This fixes certain applications failing on unhandled ioctl's on writer side fifo's

Blocked on (and directly after) managarm/managarm#245