### PR TITLE
options/posix: Add rindex

### DIFF
--- a/options/posix/generic/strings-stubs.cpp
+++ b/options/posix/generic/strings-stubs.cpp
@@ -9,6 +9,10 @@ char *index (const char *s, int c) {
 	return strchr(s, c);
 }
 
+char *rindex(const char *s, int c) {
+	return strrchr(s, c);
+}
+
 int ffs(int word) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/include/strings.h
+++ b/options/posix/include/strings.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 char *index (const char *s, int c);
+char *rindex(const char *s, int c);
 
 int ffs(int word);
 int strcasecmp(const char *a, const char *b);

--- a/tests/ansi/strchr.c
+++ b/tests/ansi/strchr.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <string.h>
+#include <stddef.h>
+
+int main(int argc, char *argv[]) {
+  char str[] = "This is a sample string";
+  char *pch;
+  // The character 's' is at position 4, 7, 11 and 18
+  pch = strchr(str, 's');
+  assert(pch - str + 1 == 4);
+  pch = strchr(pch + 1, 's');
+  assert(pch - str + 1 == 7);
+  pch = strchr(pch + 1, 's');
+  assert(pch - str + 1 == 11);
+  pch = strchr(pch + 1, 's');
+  assert(pch - str + 1 == 18);
+  pch = strchr(pch + 1, 's');
+  assert(pch == NULL);
+  return 0;
+}

--- a/tests/ansi/strrchr.c
+++ b/tests/ansi/strrchr.c
@@ -1,0 +1,11 @@
+#include <string.h>
+#include <assert.h>
+
+int main(int argc, char *argv[]) {
+  char str[] = "This is a sample string";
+  char *pch;
+  pch = strrchr(str, 's');
+  // The last occurence of 's' is at position 18
+  assert(pch - str + 1 == 18);
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,7 +6,9 @@ ansi_test_cases = [
 	'strtol',
 	'abs',
 	'strverscmp',
-	'strftime'
+	'strftime',
+	'strchr',
+	'strrchr'
 ]
 
 posix_test_cases = [
@@ -15,7 +17,9 @@ posix_test_cases = [
 	'pthread_rwlock',
 	'getaddrinfo',
 	'dprintf',
-	'posix_spawn'
+	'posix_spawn',
+	'index',
+	'rindex'
 ]
 
 glibc_test_cases = [

--- a/tests/posix/index.c
+++ b/tests/posix/index.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <strings.h>
+#include <stddef.h>
+
+int main(int argc, char *argv[]) {
+  char str[] = "This is a sample string";
+  char *pch;
+  // The character 's' is at position 4, 7, 11 and 18
+  pch = index(str, 's');
+  assert(pch - str + 1 == 4);
+  pch = index(pch + 1, 's');
+  assert(pch - str + 1 == 7);
+  pch = index(pch + 1, 's');
+  assert(pch - str + 1 == 11);
+  pch = index(pch + 1, 's');
+  assert(pch - str + 1 == 18);
+  pch = index(pch + 1, 's');
+  assert(pch == NULL);
+  return 0;
+}

--- a/tests/posix/rindex.c
+++ b/tests/posix/rindex.c
@@ -1,0 +1,11 @@
+#include <strings.h>
+#include <assert.h>
+
+int main(int argc, char *argv[]) {
+  char str[] = "This is a sample string";
+  char *pch;
+  pch = rindex(str, 's');
+  // The last occurence of 's' is at position 18
+  assert(pch - str + 1 == 18);
+  return 0;
+}


### PR DESCRIPTION
The recent addition of `index` and the subsequent patch update for `xorg-proto` broke `xorg-server` on managarm, this PR fixes that issue.

The following functions have been added:
- `rindex()`, the reverse variant of `index()`.