### PR TITLE
options/linux: Add TIOCSTI

### DIFF
--- a/options/linux/include/asm/ioctls.h
+++ b/options/linux/include/asm/ioctls.h
@@ -6,8 +6,9 @@
 #define TCGETS 0x5401
 #define TCSETS 0x5402
 #define TIOCSCTTY 0x540E
-#define TIOCNOTTY 0x5422
+#define TIOCSTI 0x5412
 #define TIOCGWINSZ 0x5413
+#define TIOCNOTTY 0x5422
 
 #define TIOCGPTN _IOR('T', 0x30, unsigned int)
 #define TIOCSPTLCK _IOW('T', 0x31, int)


### PR DESCRIPTION
This PR adds a ioctl define needed for `cmatrix`