### PR TITLE
sysdeps/managarm: Implement sys_mknodat

### DIFF
--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -334,6 +334,7 @@ char *strerror(int e) {
 	case ESPIPE: s = "Seek not possible (ESPIPE)"; break;
 	case ENXIO: s = "No such device or address (ENXIO)"; break;
 	case ENOEXEC: s = "Exec format error (ENOEXEC)"; break;
+	case ENOSPC: s = "No space left on device (ENOSPC)"; break;
 	default:
 		s = "Unknown error code (?)";
 	}

--- a/options/posix/generic/sys-stat-stubs.cpp
+++ b/options/posix/generic/sys-stat-stubs.cpp
@@ -120,14 +120,25 @@ int mkfifoat(int dirfd, const char *path, mode_t mode) {
 	return 0;
 }
 
-int mknod(const char *, mode_t, dev_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int mknod(const char *path, mode_t mode, dev_t dev) {
+	return mknodat(AT_FDCWD, path, mode, dev);
 }
-int mknodat(int, const char *, mode_t, dev_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+int mknodat(int dirfd, const char *path, mode_t mode, dev_t dev) {
+	if (!mlibc::sys_mknodat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+
+	if (int e = mlibc::sys_mknodat(dirfd, path, mode, dev); e) {
+		errno = e;
+		return -1;
+	}
+
+	return 0;
 }
+
 mode_t umask(mode_t) {
 	mlibc::infoLogger() << "\e[31mmlibc: umask() is a no-op and always returns 0\e[39m"
 			<< frg::endlog;

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -149,6 +149,7 @@ int sys_vm_unmap(void *pointer, size_t size);
 [[gnu::weak]] int sys_gethostname(char *buffer, size_t bufsize);
 [[gnu::weak]] int sys_mkfifoat(int dirfd, const char *path, int mode);
 [[gnu::weak]] int sys_getentropy(void *buffer, size_t length);
+[[gnu::weak]] int sys_mknodat(int dirfd, const char *path, int mode, int dev);
 
 } //namespace mlibc
 


### PR DESCRIPTION
This PR is the mlibc counterpart of managarm/managarm#248 and provides an implementation of `sys_mknodat()` for managarm, wires `mknod()` to `mknodat()`, improves error handling in some managarm sysdeps and adds a string for ENOSPC to `strerror()`.

Blocked on and to be merged shortly after managarm/managarm#248
Fixes #94 