### PR TITLE
Implement various process group functions

### DIFF
--- a/options/posix/generic/termios-stubs.cpp
+++ b/options/posix/generic/termios-stubs.cpp
@@ -1,6 +1,7 @@
 
 #include <errno.h>
 #include <termios.h>
+#include <sys/ioctl.h>
 
 #include <bits/ensure.h>
 #include <mlibc/posix-sysdeps.hpp>
@@ -68,10 +69,14 @@ int tcgetattr(int fd, struct termios *attr) {
 	return 0;
 }
 
-pid_t tcgetsid(int) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+pid_t tcgetsid(int fd) {
+	int sid;
+	if(ioctl(fd, TIOCGSID, &sid) < 0) {
+		return -1;
+	}
+	return sid;
 }
+
 int tcsendbreak(int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
+#include <termios.h>
+#include <sys/ioctl.h>
 
 #include <bits/ensure.h>
 #include <mlibc/allocator.hpp>
@@ -702,17 +704,19 @@ unsigned long sysconf(int number) {
 			__builtin_unreachable();
 	}
 }
+
 pid_t tcgetpgrp(int fd) {
-	(void)fd;
-	mlibc::infoLogger() << "mlibc: tcgetpgrp() fails with ENOSYS" << frg::endlog;
-	errno = ENOSYS;
-	return -1;
+	int pgrp;
+	if(ioctl(fd, TIOCGPGRP, &pgrp) < 0) {
+		return -1;
+	}
+	return pgrp;
 }
-int tcsetpgrp(int, pid_t) {
-	mlibc::infoLogger() << "mlibc: tcsetpgrp() fails with ENOSYS" << frg::endlog;
-	errno = ENOSYS;
-	return -1;
+
+int tcsetpgrp(int fd, pid_t pgrp) {
+	return ioctl(fd, TIOCSPGRP, pgrp);
 }
+
 int truncate(const char *, off_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -1078,3 +1078,7 @@ int daemon(int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+char *ctermid(char *s) {
+	return s ? strcpy(s, "/dev/tty") : const_cast<char *>("/dev/tty");
+}

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -567,11 +567,19 @@ int setgid(gid_t gid) {
 	return 0;
 }
 
-int setpgid(pid_t, pid_t) {
-	mlibc::infoLogger() << "mlibc: setpgid() fails with ENOSYS" << frg::endlog;
-	errno = ENOSYS;
-	return -1;
+int setpgid(pid_t pid, pid_t pgid) {
+	if(!mlibc::sys_setpgid) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_setpgid(pid, pgid); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
+
 pid_t setpgrp(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -592,10 +592,10 @@ int setpgid(pid_t pid, pid_t pgid) {
 	return 0;
 }
 
-pid_t setpgrp(void) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+pid_t setpgrp(pid_t pid, pid_t pgid) {
+	return setpgid(pid, pgid);
 }
+
 int setregid(gid_t, gid_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -366,10 +366,20 @@ pid_t getpgrp(void) {
 	}
 	return mlibc::sys_getpgrp();
 }
-pid_t getsid(pid_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+pid_t getsid(pid_t pid) {
+	if(!mlibc::sys_getsid) {
+		MLIBC_MISSING_SYSDEP();
+		return -1;
+	}
+	pid_t sid;
+	if(int e = mlibc::sys_getsid(pid, &sid); e) {
+		errno = e;
+		return -1;
+	}
+	return sid;
 }
+
 int lchown(const char *path, uid_t uid, gid_t gid) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -359,12 +359,7 @@ pid_t getpgid(pid_t pid) {
 }
 
 pid_t getpgrp(void) {
-	if(!mlibc::sys_getpgrp) {
-		MLIBC_MISSING_SYSDEP();
-		mlibc::infoLogger() << "mlibc: missing sysdep sys_getpgrp(). Returning invalid PGID" << frg::endlog;
-		return 0;
-	}
-	return mlibc::sys_getpgrp();
+	return getpgid(0);
 }
 
 pid_t getsid(pid_t pid) {

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -341,10 +341,21 @@ int getopt(int argc, char *const argv[], const char *optstring) {
 	return c;
 }
 
-pid_t getpgid(pid_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+pid_t getpgid(pid_t pid) {
+	pid_t pgid;
+
+	if(!mlibc::sys_getpgid) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_getpgid(pid, &pgid); e) {
+		errno = e;
+		return -1;
+	}
+	return pgid;
 }
+
 pid_t getpgrp(void) {
 	if(!mlibc::sys_getpgrp) {
 		MLIBC_MISSING_SYSDEP();

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -77,6 +77,7 @@ int sys_close(int fd);
 [[gnu::weak]] pid_t sys_getppid();
 [[gnu::weak]] pid_t sys_getpgrp();
 [[gnu::weak]] pid_t sys_getpgid(pid_t pid, pid_t *pgid);
+[[gnu::weak]] pid_t sys_getsid(pid_t pid, pid_t *sid);
 [[gnu::weak]] int sys_setpgid(pid_t pid, pid_t pgid);
 [[gnu::weak]] int sys_setuid(uid_t uid);
 [[gnu::weak]] int sys_seteuid(uid_t euid);

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -75,7 +75,6 @@ int sys_close(int fd);
 [[gnu::weak]] uid_t sys_geteuid();
 [[gnu::weak]] pid_t sys_getpid();
 [[gnu::weak]] pid_t sys_getppid();
-[[gnu::weak]] pid_t sys_getpgrp();
 [[gnu::weak]] pid_t sys_getpgid(pid_t pid, pid_t *pgid);
 [[gnu::weak]] pid_t sys_getsid(pid_t pid, pid_t *sid);
 [[gnu::weak]] int sys_setpgid(pid_t pid, pid_t pgid);

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -76,6 +76,7 @@ int sys_close(int fd);
 [[gnu::weak]] pid_t sys_getpid();
 [[gnu::weak]] pid_t sys_getppid();
 [[gnu::weak]] pid_t sys_getpgrp();
+[[gnu::weak]] pid_t sys_getpgid(pid_t pid, pid_t *pgid);
 [[gnu::weak]] int sys_setuid(uid_t uid);
 [[gnu::weak]] int sys_seteuid(uid_t euid);
 [[gnu::weak]] int sys_setgid(gid_t gid);

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -77,6 +77,7 @@ int sys_close(int fd);
 [[gnu::weak]] pid_t sys_getppid();
 [[gnu::weak]] pid_t sys_getpgrp();
 [[gnu::weak]] pid_t sys_getpgid(pid_t pid, pid_t *pgid);
+[[gnu::weak]] int sys_setpgid(pid_t pid, pid_t pgid);
 [[gnu::weak]] int sys_setuid(uid_t uid);
 [[gnu::weak]] int sys_seteuid(uid_t euid);
 [[gnu::weak]] int sys_setgid(gid_t gid);

--- a/options/posix/include/termios.h
+++ b/options/posix/include/termios.h
@@ -135,6 +135,8 @@ int tcsetattr(int, int, const struct termios *);
 
 // This is a linux extension
 
+#define TIOCGPGRP 0x540F
+#define TIOCSPGRP 0x5410
 #define TIOCGWINSZ 0x5413
 #define TIOCSWINSZ 0x5414
 

--- a/options/posix/include/termios.h
+++ b/options/posix/include/termios.h
@@ -139,6 +139,7 @@ int tcsetattr(int, int, const struct termios *);
 #define TIOCSPGRP 0x5410
 #define TIOCGWINSZ 0x5413
 #define TIOCSWINSZ 0x5414
+#define TIOCGSID 0x5429
 
 struct winsize {
 	unsigned short ws_row;

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -115,6 +115,8 @@ extern "C" {
 
 #define _POSIX_VDISABLE (-1)
 
+#define L_ctermid 20
+
 // MISSING: intptr_t
 
 int access(const char *path, int mode);
@@ -124,6 +126,7 @@ int chown(const char *path, uid_t uid, gid_t gid);
 int close(int fd);
 ssize_t confstr(int, char *, size_t);
 char *crypt(const char *, const char *);
+char *ctermid(char *s);
 int dup(int fd);
 int dup2(int src_fd, int dest_fd);
 __attribute__ ((noreturn)) void _exit(int status);

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -185,7 +185,7 @@ int setegid(gid_t);
 int seteuid(uid_t);
 int setgid(gid_t);
 int setpgid(pid_t, pid_t);
-pid_t setpgrp(void);
+pid_t setpgrp(pid_t, pid_t);
 int setregid(gid_t, gid_t);
 int setreuid(uid_t, uid_t);
 pid_t setsid(void);

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -886,6 +886,10 @@ int sys_setsid(pid_t *sid) {
 
 	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
+	if(resp.error() == managarm::posix::Errors::ACCESS_DENIED) {
+		*sid = -1;
+		return EPERM;
+	}
 	__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 	*sid = resp.sid();
 	return 0;

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2882,49 +2882,38 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result) {
 		return 0;
 	}
 	case TIOCGPGRP: {
-		HelAction actions[4];
-		globalQueue.trim();
-
 		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
 		req.set_command(request);
 
 		frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 		req.SerializeToString(&ser);
-		actions[0].type = kHelActionOffer;
-		actions[0].flags = kHelItemAncillary;
-		actions[1].type = kHelActionSendFromBuffer;
-		actions[1].flags = kHelItemChain;
-		actions[1].buffer = ser.data();
-		actions[1].length = ser.size();
-		actions[2].type = kHelActionImbueCredentials;
-		actions[2].flags = kHelItemChain;
-		actions[3].type = kHelActionRecvInline;
-		actions[3].flags = 0;
-		HEL_CHECK(helSubmitAsync(handle, actions, 4,
-				globalQueue.getQueue(), 0, 0));
+		
+		auto [offer, imbue_creds, send_req, recv_resp] =
+			exchangeMsgsSync(
+					handle,
+					helix_ng::offer(
+							helix_ng::imbueCredentials(),
+							helix_ng::sendBuffer(ser.data(), ser.size()),
+							helix_ng::recvInline()
+					)
+			);
 
-		auto element = globalQueue.dequeueSingle();
-		auto offer = parseSimple(element);
-		auto imbue_creds = parseSimple(element);
-		auto send_req = parseSimple(element);
-		auto recv_resp = parseInline(element);
-
-		HEL_CHECK(offer->error);
-		HEL_CHECK(imbue_creds->error);
-		HEL_CHECK(send_req->error);
-		HEL_CHECK(recv_resp->error);
+		HEL_CHECK(offer.error());
+		HEL_CHECK(imbue_creds.error());
+		if(send_req.error())
+			return EINVAL;
+		HEL_CHECK(send_req.error());
+		HEL_CHECK(recv_resp.error());
 
 		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
-		resp.ParseFromArray(recv_resp->data, recv_resp->length);
+		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 		*result = resp.result();
 		return 0;
 	}
 	case TIOCSPGRP: {
 		auto param = reinterpret_cast<int *>(arg);
-		HelAction actions[4];
-		globalQueue.trim();
 
 		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
@@ -2933,32 +2922,24 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result) {
 
 		frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 		req.SerializeToString(&ser);
-		actions[0].type = kHelActionOffer;
-		actions[0].flags = kHelItemAncillary;
-		actions[1].type = kHelActionSendFromBuffer;
-		actions[1].flags = kHelItemChain;
-		actions[1].buffer = ser.data();
-		actions[1].length = ser.size();
-		actions[2].type = kHelActionImbueCredentials;
-		actions[2].flags = kHelItemChain;
-		actions[3].type = kHelActionRecvInline;
-		actions[3].flags = 0;
-		HEL_CHECK(helSubmitAsync(handle, actions, 4,
-				globalQueue.getQueue(), 0, 0));
+		
+		auto [offer, imbue_creds, send_req, recv_resp] =
+			exchangeMsgsSync(
+					handle,
+					helix_ng::offer(
+							helix_ng::imbueCredentials(),
+							helix_ng::sendBuffer(ser.data(), ser.size()),
+							helix_ng::recvInline()
+					)
+			);
 
-		auto element = globalQueue.dequeueSingle();
-		auto offer = parseSimple(element);
-		auto imbue_creds = parseSimple(element);
-		auto send_req = parseSimple(element);
-		auto recv_resp = parseInline(element);
-
-		HEL_CHECK(offer->error);
-		HEL_CHECK(imbue_creds->error);
-		HEL_CHECK(send_req->error);
-		HEL_CHECK(recv_resp->error);
+		HEL_CHECK(offer.error());
+		HEL_CHECK(imbue_creds.error());
+		HEL_CHECK(send_req.error());
+		HEL_CHECK(recv_resp.error());
 
 		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
-		resp.ParseFromArray(recv_resp->data, recv_resp->length);
+		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 		*result = resp.result();
 		return 0;

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -501,6 +501,12 @@ pid_t sys_getpgid(pid_t pid, pid_t *pgid) {
 	}
 }
 
+pid_t sys_getpgrp() {
+	pid_t pgid;
+	sys_getpgid(0, &pgid);
+	return pgid;
+}
+
 int sys_setpgid(pid_t pid, pid_t pgid) {
 	SignalGuard sguard;
 

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -195,13 +195,13 @@ gid_t sys_getgid() {
 	managarm::posix::GetGidRequest<MemoryAllocator> req(getSysdepsAllocator());
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -221,13 +221,13 @@ int sys_setgid(gid_t gid) {
 	req.set_uid(gid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -251,13 +251,13 @@ gid_t sys_getegid() {
 	managarm::posix::GetEgidRequest<MemoryAllocator> req(getSysdepsAllocator());
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -277,13 +277,13 @@ int sys_setegid(gid_t egid) {
 	req.set_uid(egid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -307,13 +307,13 @@ uid_t sys_getuid() {
 	managarm::posix::GetUidRequest<MemoryAllocator> req(getSysdepsAllocator());
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -333,13 +333,13 @@ int sys_setuid(uid_t uid) {
 	req.set_uid(uid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -363,13 +363,13 @@ uid_t sys_geteuid() {
 	managarm::posix::GetEuidRequest<MemoryAllocator> req(getSysdepsAllocator());
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -389,13 +389,13 @@ int sys_seteuid(uid_t euid) {
 	req.set_uid(euid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -455,13 +455,13 @@ pid_t sys_getppid() {
 	managarm::posix::GetPpidRequest<MemoryAllocator> req(getSysdepsAllocator());
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -480,13 +480,13 @@ pid_t sys_getsid(pid_t pid, pid_t *sid) {
 	req.set_pid(pid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -511,13 +511,13 @@ pid_t sys_getpgid(pid_t pid, pid_t *pgid) {
 	req.set_pid(pid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());
@@ -544,13 +544,13 @@ int sys_setpgid(pid_t pid, pid_t pgid) {
 	req.set_pgid(pgid);
 
 	auto [offer, send_head, recv_resp] =
-			exchangeMsgsSync(
-					getPosixLane(),
-					helix_ng::offer(
-							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
-							helix_ng::recvInline()
-					)
-			);
+		exchangeMsgsSync(
+			getPosixLane(),
+			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+				helix_ng::recvInline()
+			)
+		);
 
 	HEL_CHECK(offer.error());
 	HEL_CHECK(send_head.error());

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -470,6 +470,37 @@ pid_t sys_getppid() {
 	return resp.pid();
 }
 
+pid_t sys_getpgid(pid_t pid, pid_t *pgid) {
+	SignalGuard sguard;
+
+	managarm::posix::GetPgidRequest<MemoryAllocator> req(getSysdepsAllocator());
+	req.set_pid(pid);
+
+	auto [offer, send_head, recv_resp] =
+			exchangeMsgsSync(
+					getPosixLane(),
+					helix_ng::offer(
+							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+							helix_ng::recvInline()
+					)
+			);
+
+	HEL_CHECK(offer.error());
+	HEL_CHECK(send_head.error());
+	HEL_CHECK(recv_resp.error());
+
+	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	if(resp.error() == managarm::posix::Errors::NO_SUCH_RESOURCE) {
+		*pgid = 0;
+		return ESRCH;
+	} else {
+		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
+		*pgid = resp.pid();
+		return 0;
+	}
+}
+
 int sys_getrusage(int scope, struct rusage *usage) {
 	memset(usage, 0, sizeof(struct rusage));
 

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -501,6 +501,37 @@ pid_t sys_getpgid(pid_t pid, pid_t *pgid) {
 	}
 }
 
+int sys_setpgid(pid_t pid, pid_t pgid) {
+	SignalGuard sguard;
+
+	managarm::posix::SetPgidRequest<MemoryAllocator> req(getSysdepsAllocator());
+
+	req.set_pid(pid);
+	req.set_pgid(pgid);
+
+	auto [offer, send_head, recv_resp] =
+			exchangeMsgsSync(
+					getPosixLane(),
+					helix_ng::offer(
+							helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
+							helix_ng::recvInline()
+					)
+			);
+
+	HEL_CHECK(offer.error());
+	HEL_CHECK(send_head.error());
+	HEL_CHECK(recv_resp.error());
+
+	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
+	if(resp.error() == managarm::posix::Errors::NO_SUCH_RESOURCE) {
+		return ESRCH;
+	}else{
+		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
+		return 0;
+	}
+}
+
 int sys_getrusage(int scope, struct rusage *usage) {
 	memset(usage, 0, sizeof(struct rusage));
 

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -561,8 +561,12 @@ int sys_setpgid(pid_t pid, pid_t pgid) {
 
 	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
-	if(resp.error() == managarm::posix::Errors::NO_SUCH_RESOURCE) {
+	if(resp.error() == managarm::posix::Errors::INSUFFICIENT_PERMISSION) {
+		return EPERM;
+	}else if(resp.error() == managarm::posix::Errors::NO_SUCH_RESOURCE) {
 		return ESRCH;
+	}else if(resp.error() == managarm::posix::Errors::ACCESS_DENIED) {
+		return EACCES;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		return 0;

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -96,6 +96,9 @@ int sys_waitpid(pid_t pid, int *status, int flags, pid_t *ret_pid) {
 
 	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
+	if(resp.error() == managarm::posix::Errors::ILLEGAL_ARGUMENTS) {
+		return EINVAL;
+	}
 	__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 	if(status)
 		*status = resp.mode();

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -532,12 +532,6 @@ pid_t sys_getpgid(pid_t pid, pid_t *pgid) {
 	}
 }
 
-pid_t sys_getpgrp() {
-	pid_t pgid;
-	sys_getpgid(0, &pgid);
-	return pgid;
-}
-
 int sys_setpgid(pid_t pid, pid_t pgid) {
 	SignalGuard sguard;
 

--- a/sysdeps/qword/generic/generic.cpp
+++ b/sysdeps/qword/generic/generic.cpp
@@ -777,7 +777,9 @@ pid_t sys_getppid() {
     return ppid;
 }
 
-pid_t sys_getpgrp(void) {
+pid_t sys_getpgid(pid_t pid) {
+    if(pid != 0)
+        return ENOSYS;
     pid_t pgid;
     asm volatile ("syscall" : "=a"(pgid)
             : "a"(38), "D"(0)


### PR DESCRIPTION
This PR implements various process group functions for managarm.

At the moment the following functions are implemented (most of these are actualy sysdeps for managarm):
- `getpgid()`,
- `setpgid()`,
- `tcgetpgrp()`.
- `tcsetpgrp()`,
- `getpgrp()`,
- `getsid()`,
- `setpgrp()`,
- `ctermid()`.

This PR is blocked on managarm/managarm#250