### PR TITLE
sysdeps/managarm: Various netstack-related fixes

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -3372,8 +3372,7 @@ int sys_write(int fd, const void *data, size_t size, ssize_t *bytes_written) {
 		return ENOSPC;
 	}else{
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
-		//FIXME: handle partial writes
-		*bytes_written = size;
+		*bytes_written = resp.size();
 		return 0;
 	}
 }

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1446,6 +1446,10 @@ int sys_epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev) {
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
 	if(resp.error() == managarm::posix::Errors::BAD_FD) {
 		return EBADF;
+	} else if(resp.error() == managarm::posix::Errors::ALREADY_EXISTS) {
+		return EEXIST;
+	} else if(resp.error() == managarm::posix::Errors::FILE_NOT_FOUND) {
+		return ENOENT;
 	} else {
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		return 0;

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -203,6 +203,12 @@ int sys_mkdirat(int dirfd, const char *path, mode_t mode) {
 		return EEXIST;
 	} else if(resp.error() == managarm::posix::Errors::ILLEGAL_ARGUMENTS) {
 		return EINVAL;
+	}else if(resp.error() == managarm::posix::Errors::BAD_FD) {
+		return EBADF;
+	}else if(resp.error() == managarm::posix::Errors::FILE_NOT_FOUND) {
+		return ENOENT;
+	}else if(resp.error() == managarm::posix::Errors::NOT_A_DIRECTORY) {
+		return ENOTDIR;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		return 0;

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1747,6 +1747,16 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result) {
 		return EBADF;
 
 	switch(request) {
+	case FIONBIO: {
+		auto mode = reinterpret_cast<int *>(arg);
+		int flags = fcntl(fd, F_GETFL, 0);
+		if(*mode) {
+		    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+		}else{
+		    fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+		}
+		return 0;
+	}
 	case DRM_IOCTL_VERSION: {
 		auto param = reinterpret_cast<drm_version*>(arg);
 		HelAction actions[3];

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1096,6 +1096,8 @@ int sys_msg_send(int sockfd, const struct msghdr *hdr, int flags, ssize_t *lengt
 		return EPIPE;
 	}else if(resp.error() == managarm::fs::Errors::NOT_CONNECTED) {
 		return ENOTCONN;
+	}else if(resp.error() == managarm::fs::Errors::WOULD_BLOCK) {
+		return EAGAIN;
 	}else{
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 		*length = resp.size();
@@ -3370,6 +3372,8 @@ int sys_write(int fd, const void *data, size_t size, ssize_t *bytes_written) {
 		return EINVAL; // FD does not support writes.
 	}else if(resp.error() == managarm::fs::Errors::NO_SPACE_LEFT) {
 		return ENOSPC;
+	}else if(resp.error() == managarm::fs::Errors::WOULD_BLOCK) {
+		return EAGAIN;
 	}else{
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 		*bytes_written = resp.size();


### PR DESCRIPTION
This PR fixes the handling of partial writes in `sys_write()`, adds handling of EAGAIN in `sys_msg_send()` and `sys_write()` and adds code to handle `FIONBIO` to `sys_ioctl()`.

This PR is blocked on managarm/managarm#253