### PR TITLE
Fix ANSI-only build after strcasestr() implementation

### DIFF
--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -1,5 +1,4 @@
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 #include <wchar.h>
 #include <ctype.h>
@@ -222,18 +221,6 @@ char *strchrnul(const char *s, int c) {
 		i++;
 	}
 	return const_cast<char *>(s + i);
-}
-
-char *strcasestr(const char *s, const char *pattern) {
-	size_t plen = strlen(pattern);
-	const char *p = s;
-	while(*p) {
-		// Need strncasecmp() to avoid checking past the end of a successful match.
-		if(!strncasecmp(p, pattern, plen))
-			return const_cast<char *>(p);
-		++p;
-	}
-	return nullptr;
 }
 
 double wcstod(const wchar_t *__restrict, wchar_t **__restrict) MLIBC_STUB_BODY

--- a/options/ansi/include/string.h
+++ b/options/ansi/include/string.h
@@ -42,7 +42,6 @@ char *strtok(char *__restrict s, const char *__restrict delimiter);
 
 // This is a GNU extension.
 char *strchrnul(const char *, int);
-char *strcasestr(const char *, const char *);
 
 // [7.24.6] Miscellaneous functions
 

--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -1,7 +1,7 @@
-
 #include <bits/ensure.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <signal.h>
 
 #include <mlibc/debug.hpp>
@@ -101,3 +101,14 @@ char *strsignal(int sig) {
 	return const_cast<char *>(s);
 }
 
+char *strcasestr(const char *s, const char *pattern) {
+	size_t plen = strlen(pattern);
+	const char *p = s;
+	while(*p) {
+		// Need strncasecmp() to avoid checking past the end of a successful match.
+		if(!strncasecmp(p, pattern, plen))
+			return const_cast<char *>(p);
+		++p;
+	}
+	return nullptr;
+}

--- a/options/posix/include/bits/posix/posix_string.h
+++ b/options/posix/include/bits/posix/posix_string.h
@@ -17,6 +17,9 @@ char *strsignal(int sig);
 
 int strcoll_l(const char *s1, const char *s2, locale_t locale);
 
+// GNU extensions.
+char *strcasestr(const char *, const char *);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fix the build by moving this function to the POSIX option.