### PR TITLE
options/ansi: Add _POSIX_HOST_NAME_MAX define

### DIFF
--- a/options/ansi/include/limits.h
+++ b/options/ansi/include/limits.h
@@ -43,5 +43,6 @@
 
 #define _POSIX_ARG_MAX 4096
 #define _POSIX_OPEN_MAX 16
+#define _POSIX_HOST_NAME_MAX 255
 
 #endif // _LIMITS_H


### PR DESCRIPTION
Glib 2.68.0 and higher seems to require this define. It's value matches Linux.