### PR TITLE
Python fixes

### DIFF
--- a/options/ansi/generic/wchar-stubs.cpp
+++ b/options/ansi/generic/wchar-stubs.cpp
@@ -174,10 +174,15 @@ size_t wcsrtombs(char *mbs, const wchar_t **wcsp, size_t mb_limit, mbstate_t *st
 	mlibc::code_seq<char> nseq{mbs, mbs + mb_limit};
 	mlibc::code_seq<const wchar_t> wseq{*wcsp, nullptr};
 
-	__ensure(mbs && "Handle !mbs case as in mbstowcs()");
-
 	if(!stp)
 		stp = &wcsrtombs_state;
+
+	if(!mbs) {
+		size_t size;
+		if(auto e = cc->encode_wtranscode_length(wseq, &size, *stp); e != mlibc::charcode_error::null)
+			__ensure(!"decode_wtranscode() errors are not handled");
+		return size;
+	}
 
 	if(auto e = cc->encode_wtranscode(nseq, wseq, *stp); e != mlibc::charcode_error::null) {
 		__ensure(!"encode_wtranscode() errors are not handled");
@@ -197,10 +202,15 @@ size_t wcsnrtombs(char *mbs, const wchar_t **wcsp, size_t wc_limit, size_t mb_li
 	mlibc::code_seq<char> nseq{mbs, mbs + mb_limit};
 	mlibc::code_seq<const wchar_t> wseq{*wcsp, (*wcsp) + wc_limit};
 
-	__ensure(mbs && "Handle !mbs case as in mbstowcs()");
-
 	if(!stp)
 		stp = &wcsrtombs_state;
+
+	if(!mbs) {
+		size_t size;
+		if(auto e = cc->encode_wtranscode_length(wseq, &size, *stp); e != mlibc::charcode_error::null)
+			__ensure(!"decode_wtranscode() errors are not handled");
+		return size;
+	}
 
 	if(auto e = cc->encode_wtranscode(nseq, wseq, *stp); e != mlibc::charcode_error::null) {
 		__ensure(!"encode_wtranscode() errors are not handled");

--- a/options/ansi/include/mlibc/file-io.hpp
+++ b/options/ansi/include/mlibc/file-io.hpp
@@ -76,7 +76,7 @@ public:
 };
 
 struct fd_file : abstract_file {
-	fd_file(int fd, void (*do_dispose)(abstract_file *) = nullptr);
+	fd_file(int fd, void (*do_dispose)(abstract_file *) = nullptr, bool force_unbuffered = false);
 
 	int fd();
 
@@ -93,6 +93,7 @@ protected:
 private:
 	// Underlying file descriptor.
 	int _fd;
+	bool _force_unbuffered;
 };
 
 } // namespace mlibc

--- a/options/internal/include/mlibc/charcode.hpp
+++ b/options/internal/include/mlibc/charcode.hpp
@@ -99,7 +99,10 @@ struct polymorphic_charcode {
 	virtual charcode_error encode_wtranscode(code_seq<char> &nseq, code_seq<const wchar_t> &wseq,
 			__mlibc_mbstate &st) = 0;
 
-	// True iff promotion only zero-extends units below 0x7F.
+	virtual charcode_error encode_wtranscode_length(code_seq<const wchar_t> &wseq, size_t *n,
+			__mlibc_mbstate &st) = 0;
+
+	// True if promotion only zero-extends units below 0x7F.
 	const bool preserves_7bit_units;
 
 	// Whether the encoding has shift states.

--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -353,7 +353,7 @@ int pthread_setcancelstate(int state, int *oldstate) {
 void pthread_testcancel(void) {
 	auto self = reinterpret_cast<Tcb *>(mlibc::get_current_tcb());
 	int value = self->cancelBits;
-	if (value & (tcbCancelEnableBit | tcbCancelTriggerBit)) {
+	if ((value & tcbCancelEnableBit) && (value & tcbCancelTriggerBit)) {
 		__mlibc_do_cancel();
 		__builtin_unreachable();
 	}

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -58,6 +58,9 @@ ssize_t confstr(int name, char *buf, size_t len) {
 	} else if(name == _CS_GNU_LIBPTHREAD_VERSION) {
 		// We are not glibc, so we can return 0 here.
 		return 0;
+	} else if(name == _CS_GNU_LIBC_VERSION) {
+		// We are not glibc, so we can return 0 here.
+		return 0;
 	} else {
 		mlibc::infoLogger() << "\e[31mmlibc: confstr() request " << name << " is unimplemented\e[39m"
 				<< frg::endlog;

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -45,9 +45,16 @@ int fchdir(int fd) {
 	return 0;
 }
 
-int chown(const char *, uid_t, gid_t) {
-	mlibc::infoLogger() << "\e[31mmlibc: chown() is not implemented correctly\e[39m"
-			<< frg::endlog;
+int chown(const char *path, uid_t uid, gid_t gid) {
+	if(!mlibc::sys_fchownat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_fchownat(AT_FDCWD, path, uid, gid, 0); e) {
+		errno = e;
+		return -1;
+	}
 	return 0;
 }
 
@@ -198,15 +205,30 @@ int faccessat(int dirfd, const char *pathname, int mode, int flags) {
 	return 0;
 }
 
-int fchown(int, uid_t, gid_t) {
-	mlibc::infoLogger() << "\e[31mmlibc: fchown() is not implemented correctly\e[39m"
-			<< frg::endlog;
+int fchown(int fd, uid_t uid, gid_t gid) {
+	if(!mlibc::sys_fchownat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_fchownat(fd, "", uid, gid, AT_EMPTY_PATH); e) {
+		errno = e;
+		return -1;
+	}
 	return 0;
 }
 
-int fchownat(int, const char *, uid_t, gid_t, int) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int fchownat(int fd, const char *path, uid_t uid, gid_t gid, int flags) {
+	if(!mlibc::sys_fchownat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_fchownat(fd, path, uid, gid, flags); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int fdatasync(int fd) {
@@ -387,9 +409,17 @@ pid_t getsid(pid_t pid) {
 	return sid;
 }
 
-int lchown(const char *, uid_t, gid_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int lchown(const char *path, uid_t uid, gid_t gid) {
+	if(!mlibc::sys_fchownat) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_fchownat(AT_FDCWD, path, uid, gid, AT_SYMLINK_NOFOLLOW); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int link(const char *old_path, const char *new_path) {

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -160,6 +160,8 @@ int sys_vm_unmap(void *pointer, size_t size);
 [[gnu::weak]] int sys_before_cancellable_syscall(ucontext_t *uctx);
 [[gnu::weak]] int sys_tgkill(int tgid, int tid, int sig);
 
+[[gnu::weak]] int sys_fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flags);
+
 } //namespace mlibc
 
 #endif // MLIBC_POSIX_SYSDEPS

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -3376,6 +3376,8 @@ int sys_openat(int dirfd, const char *path, int flags, int *fd) {
 		return EINVAL;
 	}else if(resp.error() == managarm::posix::Errors::NO_BACKING_DEVICE) {
 		return ENXIO;
+	}else if(resp.error() == managarm::posix::Errors::IS_DIRECTORY) {
+		return EISDIR;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		*fd = resp.fd();
@@ -3867,6 +3869,8 @@ int sys_stat(fsfd_target fsfdt, int fd, const char *path, int flags, struct stat
 		return ENOENT;
 	}else if(resp.error() == managarm::posix::Errors::BAD_FD) {
 		return EBADF;
+	}else if(resp.error() == managarm::posix::Errors::NOT_A_DIRECTORY) {
+		return ENOTDIR;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		memset(result, 0, sizeof(struct stat));
@@ -4105,6 +4109,8 @@ int sys_unlinkat(int fd, const char *path, int flags) {
 		return ENOENT;
 	}else if(resp.error() == managarm::posix::Errors::RESOURCE_IN_USE) {
 		return EBUSY;
+	}else if(resp.error() == managarm::posix::Errors::IS_DIRECTORY) {
+		return EISDIR;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		return 0;

--- a/tests/ansi/wcsrtombs.c
+++ b/tests/ansi/wcsrtombs.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <wchar.h>
+#include <assert.h>
+#include <string.h>
+
+int main() {
+	const wchar_t str[] = L"wcsrtombs";
+	const wchar_t *p = str;
+	int ret = wcsrtombs(NULL, &p, 343245234, NULL);
+	assert(ret == 9);
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,8 @@ ansi_test_cases = [
 	'strverscmp',
 	'strftime',
 	'strchr',
-	'strrchr'
+	'strrchr',
+	'wcsrtombs'
 ]
 
 posix_test_cases = [

--- a/tests/posix/pthread_cancel.c
+++ b/tests/posix/pthread_cancel.c
@@ -60,6 +60,22 @@ static void *worker4(void *arg) {
 	__builtin_unreachable();
 }
 
+static void *worker5(void *arg) {
+	assert(!pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL));
+
+	worker_ready = 1;
+
+	while(!main_ready);
+
+	// Cancellation point - we should NOT cancel right now
+	pthread_testcancel();
+
+	int *arg_int = (int*)arg;
+	*arg_int = 1;
+
+	return NULL;
+}
+
 static void check_result(pthread_t thread) {
 
 	void *ret_val = NULL;
@@ -80,6 +96,7 @@ int main() {
 
 	main_ready = 0;
 	worker_ready = 0;
+	main_ready = 0;
 	ret = pthread_create(&thread, NULL, &worker2, NULL);
 	assert(!ret);
 
@@ -91,6 +108,7 @@ int main() {
 
 	main_ready = 0;
 	worker_ready = 0;
+	main_ready = 0;
 	ret = pthread_create(&thread, NULL, &worker3, NULL);
 	assert(!ret);
 
@@ -110,6 +128,23 @@ int main() {
 	assert(!ret);
 	main_ready = 1;
 	check_result(thread);
+
+	// Test for bug where pthread_testcancel() was not checking if
+	// cancellation was triggered properly.
+	worker_ready = 0;
+	int pthread_arg = 0;
+	main_ready = 0;
+	ret = pthread_create(&thread, NULL, &worker5, &pthread_arg);
+	assert(!ret);
+
+	while(!worker_ready);
+	main_ready = 1;
+
+	void *ret_val = NULL;
+	ret = pthread_join(thread, &ret_val);
+	assert(!ret);
+	assert(!ret_val);
+	assert(pthread_arg == 1);
 
 	return 0;
 }


### PR DESCRIPTION
This PR adds more error handling code to several of Managarms sysdeps and adds proper handling to `wcsrtombs()` and `wcsrntombs()` when the first argument is NULL. This also allows the python dynamic interpreter to work on Managarm. Furthermore, a bug in the pthread cancel implementation was found and fixed,  `_CS_GNU_LIBC_VERSION` is now handled in `confstr()` and the buffer mode of `stderr` is now correctly set.

Blocked on managarm/managarm#351, but should be merged at the same time to avoid build failures.