### PR TITLE
Small fix related to getrandom

### DIFF
--- a/options/linux/generic/sys-random-stubs.cpp
+++ b/options/linux/generic/sys-random-stubs.cpp
@@ -23,4 +23,3 @@ ssize_t getrandom(void *buffer, size_t max_size, unsigned int flags) {
 	}
 	return max_size;
 }
-

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -836,6 +836,10 @@ int getentropy(void *buffer, size_t length) {
 		errno = ENOSYS;
 		return -1;
 	}
+	if(length > 256) {
+		errno = EIO;
+		return -1;
+	}
 	if(int e = mlibc::sys_getentropy(buffer, length); e) {
 		errno = e;
 		return -1;

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -4270,9 +4270,6 @@ int sys_getentropy(void *buffer, size_t length) {
 	auto p = reinterpret_cast<char *>(buffer);
 	size_t n = 0;
 
-	if(length > 256)
-		return EIO;
-
 	while(n < length) {
 		size_t chunk;
 		HEL_CHECK(helGetRandomBytes(p + n, length - n, &chunk));


### PR DESCRIPTION
This PR moves the size check from the managarm sysdep (which is the only platform that implements `sys_getentropy`) to the actual `getrandom()` function.