### PR TITLE
build: Bump c++ standard to c++20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             # Note: the default jsonschema is too old.
             #       xbstrap should fix this by demanding a recent version.
             run: |
-                sudo apt-get install ninja-build
+                sudo apt-get install ninja-build g++-10
                 sudo pip3 install setuptools
                 sudo pip3 install -U jsonschema
                 sudo pip3 install meson xbstrap
@@ -39,7 +39,7 @@ jobs:
             run: 'xbstrap install ${{matrix.builds}}'
             working-directory: build/
           - name: Test mlibc
-            run: 'meson test -C pkg-builds/${{matrix.builds}}'
+            run: 'C=gcc-10 CXX=g++-10 meson test -C pkg-builds/${{matrix.builds}}'
             working-directory: build/
           - name: Build GCC
             run: 'xbstrap install-tool gcc'
@@ -56,7 +56,7 @@ jobs:
             # Note: the default jsonschema is too old.
             #       xbstrap should fix this by demanding a recent version.
             run: |
-                sudo apt-get install ninja-build
+                sudo apt-get install ninja-build g++-10
                 sudo pip3 install setuptools
                 sudo pip3 install -U jsonschema
                 sudo pip3 install meson xbstrap

--- a/ci/bootstrap.yml
+++ b/ci/bootstrap.yml
@@ -9,7 +9,7 @@ sources:
 
   - name: gcc
     git: 'git://gcc.gnu.org/git/gcc.git'
-    tag: 'releases/gcc-9.2.0'
+    tag: 'releases/gcc-10.3.0'
     regenerate:
       - args: ['./contrib/download_prerequisites']
         workdir: '@THIS_SOURCE_DIR@'
@@ -41,6 +41,9 @@ tools:
         # -g blows up GCC's binary size.
         - 'CFLAGS=-O2'
         - 'CXXFLAGS=-O2'
+        environ:
+          C: 'gcc-10'
+          CXX: 'g++-10'
     stages:
       - name: compiler
         pkgs_required:
@@ -51,14 +54,15 @@ tools:
           - args: ['make', '-j@PARALLELISM@', 'all-gcc']
         install:
           - args: ['make', 'install-gcc']
-      - name: libgcc
-        tools_required:
-          - tool: gcc
-            stage_dependencies: [compiler]
-        compile:
-          - args: ['make', '-j@PARALLELISM@', 'all-target-libgcc']
-        install:
-          - args: ['make', 'install-target-libgcc']
+       # TODO: Fix libgcc, seems to require <sys/syscall.h> now, and we don't implement that yet.
+#      - name: libgcc
+#        tools_required:
+#          - tool: gcc
+#            stage_dependencies: [compiler]
+#        compile:
+#          - args: ['make', '-j@PARALLELISM@', 'all-target-libgcc']
+#        install:
+#          - args: ['make', 'install-target-libgcc']
        # TODO: to build libstdc++, we need to pass -rpath and --dynamic-linker.
 #      - name: libstdc++
 #        tools_required:
@@ -80,6 +84,9 @@ packages:
         - '--buildtype=debugoptimized'
         - "-Dbuild_tests=true"
         - '@THIS_SOURCE_DIR@'
+        environ:
+          C: 'gcc-10'
+          CXX: 'g++-10'
     build:
       - args: ['ninja']
       - args: ['ninja', 'install']
@@ -98,6 +105,9 @@ packages:
         - "-Dbuild_tests=true"
         - "-Dstatic=true"
         - '@THIS_SOURCE_DIR@'
+        environ:
+          C: 'gcc-10'
+          CXX: 'g++-10'
     build:
       - args: ['ninja']
       - args: ['ninja', 'install']
@@ -115,6 +125,9 @@ packages:
         - "-Dbuild_tests=true"
         - "-Ddisable_posix_option=true"
         - '@THIS_SOURCE_DIR@'
+        environ:
+          C: 'gcc-10'
+          CXX: 'g++-10'
     build:
       - args: ['ninja']
       - args: ['ninja', 'install']

--- a/ci/dripos.cross-file
+++ b/ci/dripos.cross-file
@@ -1,6 +1,6 @@
 [binaries]
-c = 'cc'
-cpp = 'c++'
+c = 'gcc-10'
+cpp = 'g++-10'
 
 [properties]
 needs_exe_wrapper = true

--- a/ci/lemon.cross-file
+++ b/ci/lemon.cross-file
@@ -1,6 +1,6 @@
 [binaries]
-c = 'cc'
-cpp = 'c++'
+c = 'gcc-10'
+cpp = 'g++-10'
 
 [properties]
 needs_exe_wrapper = true

--- a/ci/qword.cross-file
+++ b/ci/qword.cross-file
@@ -1,6 +1,6 @@
 [binaries]
-c = 'cc'
-cpp = 'c++'
+c = 'gcc-10'
+cpp = 'g++-10'
 
 [properties]
 needs_exe_wrapper = true

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,7 @@ if not headers_only
 	c_compiler = meson.get_compiler('c')
 
 	add_project_arguments('-nostdinc', '-fno-builtin', language: ['c', 'cpp'])
-	add_project_arguments('-std=c++17', language: 'cpp')
+	add_project_arguments('-std=c++20', language: 'cpp')
 	add_project_arguments('-fno-rtti', '-fno-exceptions', language: 'cpp')
 	add_project_link_arguments('-nostdlib', language: ['c', 'cpp'])
 


### PR DESCRIPTION
This PR adapts mlibc to the changes in cxxshim that are required to build managarm with gcc 10. It is thus blocked on everything listed in manangarm/bootstrap-managarm#100 and can only be merged if all the blockers in that PR (with exception of the managarm one) is already merged. After this PR is merged, managarm/bootstrap-managarm#100 _needs_ to be merged to avoid build failures.