### PR TITLE
Update BUFSIZ macro to 4096 with stdio.h

### DIFF
--- a/options/ansi/include/stdio.h
+++ b/options/ansi/include/stdio.h
@@ -62,7 +62,7 @@ typedef size_t fpos_t;
 #define _IOLBF 2
 #define _IONBF 3
 
-#define BUFSIZ 512
+#define BUFSIZ 4096
 
 #define EOF (-1)
 


### PR DESCRIPTION
512 is extremely small and it will lead to very poor io performance.
By the way, libstdc++ will use this macro to set the buffer size of std::fstream, leading to extremely poor performance.

Thank you!