### PR TITLE
abis/mlibc: Change uid_t, gid_t and id_t to unsigned

### DIFF
--- a/abis/mlibc/gid_t.h
+++ b/abis/mlibc/gid_t.h
@@ -2,7 +2,7 @@
 #ifndef _ABIBITS_GID_T_H
 #define _ABIBITS_GID_T_H
 
-typedef int gid_t;
+typedef unsigned int gid_t;
 
 #endif // _ABIBITS_GID_T_H
 

--- a/abis/mlibc/uid_t.h
+++ b/abis/mlibc/uid_t.h
@@ -2,7 +2,7 @@
 #ifndef _ABIBITS_UID_T_H
 #define _ABIBITS_UID_T_H
 
-typedef int uid_t;
+typedef unsigned int uid_t;
 
 #endif // _ABIBITS_UID_T_H
 

--- a/options/posix/include/bits/posix/id_t.h
+++ b/options/posix/include/bits/posix/id_t.h
@@ -1,6 +1,6 @@
 #ifndef _MLIBC_ID_T_H
 #define _MLIBC_ID_T_H
 
-typedef int id_t;
+typedef unsigned int id_t;
 
 #endif // _MLIBC_ID_T_H

--- a/sysdeps/lemon/generic/lemon.cpp
+++ b/sysdeps/lemon/generic/lemon.cpp
@@ -123,12 +123,12 @@ namespace mlibc{
 		return -syscall(SYS_SETEUID, euid);
 	}
 
-	int sys_getgid(){
+	gid_t sys_getgid(){
 		mlibc::infoLogger() << "mlibc: sys_getgid is a stub" << frg::endlog;
 		return 0;
 	}
 
-	int sys_getegid(){
+	gid_t sys_getegid(){
 		mlibc::infoLogger() << "mlibc: sys_getegid is a stub" << frg::endlog;
 		return 0;
 	}


### PR DESCRIPTION
On Linux (and apparently everywhere else), these are unsigned types.
