### PR TITLE
rtdl: Implement the case in dladdr where the symbol cannot be found

### DIFF
--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -278,6 +278,9 @@ SharedObject *ObjectRepository::requestObjectAtPath(frg::string_view path, uint6
 void ObjectRepository::_fetchFromPhdrs(SharedObject *object, void *phdr_pointer,
 		size_t phdr_entry_size, size_t phdr_count, void *entry_pointer) {
 	__ensure(object->isMainObject);
+	object->phdrPointer = phdr_pointer;
+	object->phdrEntrySize = phdr_entry_size;
+	object->phdrCount = phdr_count;
 	if(verbose)
 		mlibc::infoLogger() << "rtdl: Loading " << object->name << frg::endlog;
 

--- a/options/rtdl/generic/linker.hpp
+++ b/options/rtdl/generic/linker.hpp
@@ -167,6 +167,11 @@ struct SharedObject {
 	bool wasInitialized;
 
 	Scope *objectScope;
+
+	// PHDR related stuff, we only set these for the main executable
+	void *phdrPointer = nullptr;
+	size_t phdrEntrySize = 0;
+	size_t phdrCount = 0;
 };
 
 void processCopyRelocations(SharedObject *object);


### PR DESCRIPTION
This PR implements the missing case for when `dladdr()` can't find the symbol, and should return the DSO that it should be in. Required for `clang` to function.

(Partially) fixes #211 