### PR TITLE
Various fixes for hexchat

### DIFF
--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -61,13 +61,17 @@ int timespec_get(struct timespec *ts, int base) {
 	return ret < 0 ? 0 : base;
 }
 
-char *asctime(const struct tm *ptr){
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+char *asctime(const struct tm *ptr) {
+	static char buf[26];
+	return asctime_r(ptr, buf);
 }
-char *ctime(const time_t *timer){
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+char *ctime(const time_t *timer) {
+	struct tm *tm = localtime(timer);
+	if(!tm) {
+		return 0;
+	}
+	return asctime(tm);
 }
 
 struct tm *gmtime(const time_t *unix_gmt) {
@@ -549,9 +553,22 @@ struct tm *localtime_r(const time_t *unix_gmt, struct tm *res) {
 	return res;
 }
 
+// This implementation of asctime_r is taken from sortix
 char *asctime_r(const struct tm *tm, char *buf) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	static char weekday_names[7][4] =
+		{ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+	static char month_names[12][4] =
+		{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
+		  "Nov", "Dec" };
+	sprintf(buf, "%.3s %.3s%3d %.2d:%.2d%.2d %d\n",
+	             weekday_names[tm->tm_wday],
+	             month_names[tm->tm_mon],
+	             tm->tm_mday,
+	             tm->tm_hour,
+	             tm->tm_min,
+	             tm->tm_sec,
+	             tm->tm_year + 1900);
+	return buf;
 }
 
 char *ctime_r(const time_t *, char *) {

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -939,9 +939,13 @@ int sys_socket(int domain, int type_and_flags, int proto, int *fd) {
 
 	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recvResp.data(), recvResp.length());
-	__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
-	*fd = resp.fd();
-	return 0;
+	if(resp.error() == managarm::posix::Errors::ILLEGAL_ARGUMENTS) {
+		return EAFNOSUPPORT;
+	} else {
+		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
+		*fd = resp.fd();
+		return 0;
+	}
 }
 
 int sys_pipe(int *fds, int flags) {

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1112,6 +1112,16 @@ int sys_msg_send(int sockfd, const struct msghdr *hdr, int flags, ssize_t *lengt
 		return ENOTCONN;
 	}else if(resp.error() == managarm::fs::Errors::WOULD_BLOCK) {
 		return EAGAIN;
+	}else if(resp.error() == managarm::fs::Errors::HOST_UNREACHABLE) {
+		return EHOSTUNREACH;
+	}else if(resp.error() == managarm::fs::Errors::ACCESS_DENIED) {
+		return EACCES;
+	}else if(resp.error() == managarm::fs::Errors::NETWORK_UNREACHABLE) {
+		return ENETUNREACH;
+	}else if(resp.error() == managarm::fs::Errors::DESTINATION_ADDRESS_REQUIRED) {
+		return EDESTADDRREQ;
+	}else if(resp.error() == managarm::fs::Errors::ADDRESS_NOT_AVAILABLE) {
+		return EADDRNOTAVAIL;
 	}else{
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 		*length = resp.size();

--- a/sysdeps/managarm/generic/socket.cpp
+++ b/sysdeps/managarm/generic/socket.cpp
@@ -169,11 +169,14 @@ int sys_sockname(int fd, struct sockaddr *addr_ptr, socklen_t max_addr_length,
 	HEL_CHECK(offer->error);
 	HEL_CHECK(send_req->error);
 	HEL_CHECK(recv_resp->error);
-	HEL_CHECK(recv_addr->error);
 
 	managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
+	if(resp.error() == managarm::fs::Errors::ILLEGAL_OPERATION_TARGET) {
+		return ENOTSOCK;
+	}
 	__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
+	HEL_CHECK(recv_addr->error);
 	*actual_length = resp.file_size();
 	return 0;
 }


### PR DESCRIPTION
This PR adds various functions for `hexchat` to function on Managarm. It also adds additional error handling to several sysdeps of Managarm. As the work to get `hexchat` running is still ongoing, this PR remains a draft for now.

The following functions have been implemented:
- `ctime()`,
- `asctime()`,
- `asctime_r()`.

The managarm counterpart to this PR is managarm/managarm#336