### PR TITLE
Various Linux fixes for OpenSSL

### DIFF
--- a/options/glibc/include/memory.h
+++ b/options/glibc/include/memory.h
@@ -1,0 +1,6 @@
+#ifndef _MEMORY_H
+#define _MEMORY_H
+
+#include <string.h>
+
+#endif

--- a/options/glibc/meson.build
+++ b/options/glibc/meson.build
@@ -18,7 +18,8 @@ if not no_headers
 		'include/resolv.h',
 		'include/endian.h',
 		'include/ar.h',
-		'include/shadow.h'
+		'include/shadow.h',
+		'include/memory.h'
 	)
 	install_headers(
 		'include/sys/ioctl.h',

--- a/options/linux/include/sys/syscall.h
+++ b/options/linux/include/sys/syscall.h
@@ -1,0 +1,6 @@
+#ifndef _SYS_SYSCALL_H
+#define _SYS_SYSCALL_H
+
+// OpenSSL wants this header to exist
+
+#endif // _SYS_SYSCALL_H

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -88,6 +88,7 @@ if not no_headers
 		'include/sys/random.h',
 		'include/sys/sendfile.h',
 		'include/sys/signalfd.h',
+		'include/sys/syscall.h',
 		'include/sys/sysmacros.h',
 		'include/sys/timerfd.h',
 		'include/sys/eventfd.h',

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -38,6 +38,10 @@
 #define NR_kill 62
 #define NR_fcntl 72
 #define NR_unlink 87
+#define NR_getuid 102
+#define NR_getgid 104
+#define NR_geteuid 107
+#define NR_getegid 108
 #define NR_arch_prctl 158
 #define NR_sys_futex 202
 #define NR_clock_gettime 228
@@ -369,6 +373,30 @@ int sys_tgkill(int tgid, int tid, int sig) {
 pid_t sys_getpid() {
 	auto ret = do_syscall(NR_getpid);
 	// getpid() always succeeds.
+	return sc_int_result<pid_t>(ret);
+}
+
+uid_t sys_getuid() {
+	auto ret = do_syscall(NR_getuid);
+	// getuid() always succeeds.
+	return sc_int_result<pid_t>(ret);
+}
+
+uid_t sys_geteuid() {
+	auto ret = do_syscall(NR_geteuid);
+	// geteuid() always succeeds.
+	return sc_int_result<pid_t>(ret);
+}
+
+gid_t sys_getgid() {
+	auto ret = do_syscall(NR_getgid);
+	// getgid() always succeeds.
+	return sc_int_result<pid_t>(ret);
+}
+
+gid_t sys_getegid() {
+	auto ret = do_syscall(NR_getegid);
+	// getegid() always succeeds.
 	return sc_int_result<pid_t>(ret);
 }
 


### PR DESCRIPTION
This PR adds various headers and syscalls for the Linux port, enabling it to compile and run `OpenSSL` commands.

The following headers have been added:
- `memory.h`, installed when the ansi option is enabled,
- `sys/syscall.h`, a dummy header is installed when the linux option is enabled.

Furthermore, this PR implements the following syscalls for the Linux port:
- `sys_getuid()`,
- `sys_geteuid()`,
- `sys_getgid()`,
- `sys_getegid()`.