### PR TITLE
options/ansi: Stub strptime

### DIFF
--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -561,8 +561,8 @@ char *ctime_r(const time_t *, char *) {
 
 char *strptime(const char *__restrict, const char *__restrict,
 		struct tm *__restrict) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "mlibc: strptime is a stub!" << frg::endlog;
+	return nullptr;
 }
 
 time_t timelocal(struct tm *) {


### PR DESCRIPTION
This PR stubs `strptime()` as a temporary solution, allowing `xbps-install` to work on Managarm.