### PR TITLE
options/posix: Include sys/select.h in sys/time.h, include timespec i…

### DIFF
--- a/options/posix/include/sys/select.h
+++ b/options/posix/include/sys/select.h
@@ -5,6 +5,7 @@
 #include <abi-bits/signal.h>
 
 #include <bits/ansi/time_t.h>
+#include <bits/ansi/timespec.h>
 #include <bits/posix/suseconds_t.h>
 #include <bits/posix/timeval.h>
 #include <bits/posix/fd_set.h>

--- a/options/posix/include/sys/time.h
+++ b/options/posix/include/sys/time.h
@@ -6,6 +6,8 @@
 #include <bits/posix/suseconds_t.h>
 #include <bits/posix/timeval.h>
 
+#include <sys/select.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The POSIX spec states that time.h should include select function and various macros from sys/select.h. It also states that sys/select.h should define timespec. This is needed for zsh to compile as it tests for timespec in sys/time.h.