### PR TITLE
Various fixes for `exa`

### DIFF
--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -69,12 +69,10 @@ static constexpr unsigned int rc_waiters_bit = static_cast<uint32_t>(1) << 31;
 
 // pthread_attr functions.
 int pthread_attr_init(pthread_attr_t *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	return 0;
 }
 int pthread_attr_destroy(pthread_attr_t *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	return 0;
 }
 
 int pthread_attr_getdetachstate(const pthread_attr_t *, int *) {
@@ -91,8 +89,8 @@ int pthread_attr_getstacksize(const pthread_attr_t *__restrict, size_t *__restri
 	__builtin_unreachable();
 }
 int pthread_attr_setstacksize(pthread_attr_t *, size_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "mlibc: pthread_attr_setstacksize() is not implemented correctly" << frg::endlog;
+	return 0;
 }
 
 int pthread_attr_getguardsize(const pthread_attr_t *__restrict, size_t *__restrict) {
@@ -751,16 +749,15 @@ int pthread_cond_destroy(pthread_cond_t *) {
 }
 
 int pthread_cond_wait(pthread_cond_t *__restrict cond, pthread_mutex_t *__restrict mutex) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
-/*
-	auto seq = __atomic_load_n(&cond->__mlibc_seq, __ATOMIC_RELAXED);
+	auto seq = __atomic_load_n(&cond->__mlibc_seq, __ATOMIC_ACQUIRE);
 	// TODO: do proper error handling here.
 	if(pthread_mutex_unlock(mutex))
 		__ensure(!"Failed to unlock the mutex");
 	if(mlibc::sys_futex_wait(&cond->__mlibc_seq, seq))
 		__ensure(!"sys_futex_wait() failed");
-	return 0;*/
+	if(pthread_mutex_lock(mutex))
+		__ensure(!"Failed to lock the mutex");
+	return 0;
 }
 int pthread_cond_timedwait(pthread_cond_t *__restrict, pthread_mutex_t *__restrict,
 		const struct timespec *__restrict) {
@@ -777,7 +774,7 @@ int pthread_cond_signal(pthread_cond_t *cond) {
 int pthread_cond_broadcast(pthread_cond_t *cond) {
 	SCOPE_TRACE();
 
-	__atomic_fetch_add(&cond->__mlibc_seq, 1, __ATOMIC_RELAXED);
+	__atomic_fetch_add(&cond->__mlibc_seq, 1, __ATOMIC_RELEASE);
 	if(int e = mlibc::sys_futex_wake((int *)&cond->__mlibc_seq); e)
 		__ensure(!"sys_futex_wake() failed");
 	return 0;

--- a/options/posix/include/pthread.h
+++ b/options/posix/include/pthread.h
@@ -88,7 +88,7 @@ typedef struct __mlibc_condattr_struct pthread_condattr_t;
 
 struct  __mlibc_cond {
 	// TODO: the clock attribute needs to be supported here.
-	unsigned int __mlibc_seq;
+	int __mlibc_seq;
 };
 typedef struct __mlibc_cond pthread_cond_t;
 

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -6,6 +6,7 @@
 #include <mlibc/debug.hpp>
 #include <mlibc/all-sysdeps.hpp>
 #include <mlibc/thread-entry.hpp>
+#include <limits.h>
 #include "cxx-syscall.hpp"
 
 #define STUB_ONLY { __ensure(!"STUB_ONLY function was called"); __builtin_unreachable(); }
@@ -445,12 +446,10 @@ int sys_futex_wait(int *pointer, int expected) {
 }
 
 int sys_futex_wake(int *pointer) {
-	auto ret = do_syscall(NR_sys_futex, pointer, FUTEX_WAKE, 1);
+	auto ret = do_syscall(NR_sys_futex, pointer, FUTEX_WAKE, INT_MAX);
 	if (int e = sc_error(ret); e)
 		return e;
-	auto num_woken = sc_int_result<int>(ret);
-	__ensure(num_woken >= 0 && num_woken <= 1);
-	return num_woken;
+	return 0;
 }
 
 } // namespace mlibc

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -15,6 +15,7 @@ posix_test_cases = [
 	'inet_ntop',
 	'inet_pton',
 	'pthread_rwlock',
+	'pthread_cond',
 	'pthread_create',
 	'pthread_cancel',
 	'pwd',

--- a/tests/posix/pthread_cond.c
+++ b/tests/posix/pthread_cond.c
@@ -1,0 +1,48 @@
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+
+#include <stdio.h>
+
+struct thread_arg {
+	int *counter;
+	pthread_cond_t *cond;
+	pthread_mutex_t *mtx;
+};
+
+static void *waiting_thread(void *arg) {
+	struct thread_arg *t = arg;
+	pthread_mutex_lock(t->mtx);
+	pthread_cond_wait(t->cond, t->mtx);
+	++*t->counter;
+	pthread_mutex_unlock(t->mtx);
+	return NULL;
+}
+
+static void test_broadcast_wakes_all() {
+	int cnt = 0;
+	pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+	pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
+
+	pthread_t t1, t2;
+	struct thread_arg arg = { .counter = &cnt, .cond = &cond, .mtx = &mtx };
+	pthread_create(&t1, NULL, &waiting_thread, &arg);
+	pthread_create(&t2, NULL, &waiting_thread, &arg);
+
+	struct timespec wait_time = { .tv_sec = 0, .tv_nsec = 150000000 }; // 150ms
+	nanosleep(&wait_time, NULL);
+
+	pthread_mutex_lock(&mtx);
+	assert(!pthread_cond_broadcast(&cond));
+	pthread_mutex_unlock(&mtx);
+
+	nanosleep(&wait_time, NULL);
+	assert(cnt == 2);
+
+	pthread_join(t1, NULL);
+	pthread_join(t2, NULL);
+}
+
+int main() {
+	test_broadcast_wakes_all();
+}

--- a/tests/posix/pwd.c
+++ b/tests/posix/pwd.c
@@ -22,19 +22,23 @@ int main()
 	assert(result);
 	assert(pwd.pw_uid == 0);
 	assert(!strcmp(pwd.pw_name, "root"));
+	assert(strlen(pwd.pw_passwd) <= 1000);
 
 	s = getpwuid_r(0, &pwd, buf, bufsize, &result);
 	assert(result);
 	assert(pwd.pw_uid == 0);
 	assert(!strcmp(pwd.pw_name, "root"));
+	assert(strlen(pwd.pw_passwd) <= 1000);
 	
 	result = getpwnam("root");
 	assert(result);
 	assert(result->pw_uid == 0);
 	assert(!strcmp(result->pw_name, "root"));
+	assert(strlen(result->pw_passwd) <= 1000);
 
 	result = getpwuid(0);
 	assert(result);
 	assert(result->pw_uid == 0);
 	assert(!strcmp(result->pw_name, "root"));
+	assert(strlen(result->pw_passwd) <= 1000);
 }


### PR DESCRIPTION
- options/posix: fill pw_passwd in getpw{nam,uid}
- options/posix: stub pthread_attr_init, enable pthread_cond_{wait, broadcast}

![image](https://user-images.githubusercontent.com/6154626/127757435-67bb0c3b-9bfc-4ae9-a185-ae2b77e58506.png)

After this PR, it just crashes on `pthread_detach`.