### PR TITLE
 options/ansi: Return SIG_ERR instead of panic when sys_sigaction fails in signal()

### DIFF
--- a/options/ansi/generic/signal-stubs.cpp
+++ b/options/ansi/generic/signal-stubs.cpp
@@ -17,8 +17,10 @@ __sighandler signal(int sn, __sighandler handler) {
 	sa.sa_flags = 0;
 	sa.sa_mask = 0;
 	struct sigaction old;
-	if(mlibc::sys_sigaction(sn, &sa, &old))
-		mlibc::panicLogger() << "\e[31mmlibc: sys_sigaction() failed\e[39m" << frg::endlog;
+	if(int e = mlibc::sys_sigaction(sn, &sa, &old)){
+		errno = e;
+		return SIG_ERR;
+	}
 	return old.sa_handler;
 }
 

--- a/sysdeps/lemon/generic/filesystem.cpp
+++ b/sysdeps/lemon/generic/filesystem.cpp
@@ -11,346 +11,348 @@
 #include <mlibc/debug.hpp>
 
 namespace mlibc{
-	typedef struct {
-		dev_t st_dev;
-		ino_t st_ino;
-		mode_t st_mode;
-		nlink_t st_nlink;
-		uid_t st_uid;
-		uid_t st_gid;
-		dev_t st_rdev;
-		off_t st_size;
-		int64_t st_blksize;
-		int64_t st_blocks;
-	} lemon_stat_t;
 
-	int sys_write(int fd, const void* buffer, size_t count, ssize_t* written){
-		long ret = syscall(SYS_WRITE, fd, (uintptr_t)buffer, count);
+typedef struct {
+	dev_t st_dev;
+	ino_t st_ino;
+	mode_t st_mode;
+	nlink_t st_nlink;
+	uid_t st_uid;
+	uid_t st_gid;
+	dev_t st_rdev;
+	off_t st_size;
+	int64_t st_blksize;
+	int64_t st_blocks;
+} lemon_stat_t;
 
-		if(ret < 0)
-			return -ret;
+int sys_write(int fd, const void* buffer, size_t count, ssize_t* written){
+	long ret = syscall(SYS_WRITE, fd, (uintptr_t)buffer, count);
 
-		*written = ret;
-		return 0;
-	}
+	if(ret < 0)
+		return -ret;
 
-	int sys_read(int fd, void *buf, size_t count, ssize_t *bytes_read) {
-    	long ret = syscall(SYS_READ, fd, (uintptr_t)buf, count);
+	*written = ret;
+	return 0;
+}
 
-		if(ret < 0){
-			*bytes_read = 0;
-			return -ret;
-		}
+int sys_read(int fd, void *buf, size_t count, ssize_t *bytes_read) {
+	long ret = syscall(SYS_READ, fd, (uintptr_t)buf, count);
 
-		*bytes_read = ret;
-		return 0;
-	}
-	
-	int sys_pwrite(int fd, const void* buffer, size_t count, off_t off, ssize_t* written){
-		int ret = syscall(SYS_PWRITE, fd, (uintptr_t)buffer, count, 0, off);
-
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		*written = ret;
-		return 0;
-	}
-	
-	int sys_pread(int fd, void *buf, size_t count, off_t off, ssize_t *bytes_read) {
-		int ret = syscall(SYS_PREAD, fd, (uintptr_t)buf, count, 0, off);
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		*bytes_read = ret;
-		return 0;
-	}
-
-	int sys_seek(int fd, off_t offset, int whence, off_t *new_offset) {
-		long ret = syscall(SYS_LSEEK, fd, offset, whence);
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		*new_offset = ret;
-		return 0;
-	}
-
-
-	int sys_open(const char* filename, int flags, int* fd){
-		long ret = syscall(SYS_OPEN, (uintptr_t)filename, flags);
-
-		if(ret < 0)
-			return -ret;
-
-		*fd = ret;
-
-		return 0; 
-	}
-
-	int sys_close(int fd){
-		syscall(SYS_CLOSE, fd);
-		return 0;
-	}
-
-	int sys_access(const char* filename, int mode){
-		int fd;
-		if(int e = sys_open(filename, O_RDONLY, &fd)){
-			return e;
-		}
-
-		sys_close(fd);
-		return 0;
-	}
-	
-	int sys_stat(fsfd_target fsfdt, int fd, const char *path, int flags, struct stat *statbuf){
-		long ret = 0;
-
-		lemon_stat_t lemonStat;
-		switch(fsfdt){
-			case fsfd_target::fd:
-				ret = syscall(SYS_FSTAT, &lemonStat, fd);
-				break;
-			case fsfd_target::path:
-				ret = syscall(SYS_STAT, &lemonStat, path);
-				break;
-			default:
-				mlibc::infoLogger() << "mlibc warning: sys_stat: unsupported fsfd target" << frg::endlog;
-				return EINVAL;
-		}
-
-		statbuf->st_dev = lemonStat.st_dev;
-		statbuf->st_ino = lemonStat.st_ino;
-		statbuf->st_mode = lemonStat.st_mode;
-		statbuf->st_nlink = lemonStat.st_nlink;
-		statbuf->st_uid = lemonStat.st_uid;
-		statbuf->st_gid = lemonStat.st_gid;
-		statbuf->st_rdev = lemonStat.st_rdev;
-		statbuf->st_size = lemonStat.st_size;
-		statbuf->st_blksize = lemonStat.st_blksize;
-		statbuf->st_blocks = lemonStat.st_blocks;
-
+	if(ret < 0){
+		*bytes_read = 0;
 		return -ret;
 	}
 
-	int sys_ioctl(int fd, unsigned long request, void *arg, int *result){
-		return syscall(SYS_IOCTL, fd, request, arg, result);
+	*bytes_read = ret;
+	return 0;
+}
+
+int sys_pwrite(int fd, const void* buffer, size_t count, off_t off, ssize_t* written){
+	int ret = syscall(SYS_PWRITE, fd, (uintptr_t)buffer, count, 0, off);
+
+
+	if(ret < 0){
+		return -ret;
 	}
 
-	#ifndef MLIBC_BUILDING_RTDL
+	*written = ret;
+	return 0;
+}
 
-	#define LEMON_TIOCGATTR 0xB301
-	#define LEMON_TIOCSATTR 0xB302
+int sys_pread(int fd, void *buf, size_t count, off_t off, ssize_t *bytes_read) {
+	int ret = syscall(SYS_PREAD, fd, (uintptr_t)buf, count, 0, off);
 
-	int sys_isatty(int fd) {
-		struct winsize ws;
-		long ret = sys_ioctl(fd, TIOCGWINSZ, &ws, 0);
-
-		if(!ret) return 0;
-		
-		return ENOTTY;
+	if(ret < 0){
+		return -ret;
 	}
 
-	int sys_tcgetattr(int fd, struct termios *attr) {
-		if(int e = sys_isatty(fd))
-			return e;
+	*bytes_read = ret;
+	return 0;
+}
 
-		int ret;
-		sys_ioctl(fd, LEMON_TIOCGATTR, attr, &ret);
+int sys_seek(int fd, off_t offset, int whence, off_t *new_offset) {
+	long ret = syscall(SYS_LSEEK, fd, offset, whence);
 
-		if(ret)
-			return -ret;
-
-		return 0;
+	if(ret < 0){
+		return -ret;
 	}
 
-	int sys_tcsetattr(int fd, int optional_action, const struct termios *attr) {
-		if(int e = sys_isatty(fd))
-			return e;
+	*new_offset = ret;
+	return 0;
+}
 
-		if(optional_action){
-			mlibc::infoLogger() << "mlibc warning: sys_tcsetattr ignores optional_action" << frg::endlog;
-		}
 
-		int ret;
-		sys_ioctl(fd, LEMON_TIOCSATTR, const_cast<struct termios*>(attr), &ret);
+int sys_open(const char* filename, int flags, int* fd){
+	long ret = syscall(SYS_OPEN, (uintptr_t)filename, flags);
 
-		if(ret)
-			return -ret;
+	if(ret < 0)
+		return -ret;
 
-		return 0;
+	*fd = ret;
+
+	return 0; 
+}
+
+int sys_close(int fd){
+	syscall(SYS_CLOSE, fd);
+	return 0;
+}
+
+int sys_access(const char* filename, int mode){
+	int fd;
+	if(int e = sys_open(filename, O_RDONLY, &fd)){
+		return e;
 	}
 
-	int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events){
-		long ret = syscall(SYS_POLL, fds, count, timeout);
+	sys_close(fd);
+	return 0;
+}
 
-		if(ret < 0){
-			return -ret;
-		}
+int sys_stat(fsfd_target fsfdt, int fd, const char *path, int flags, struct stat *statbuf){
+	long ret = 0;
 
-		*num_events = ret;
-
-		return 0;
-	}
-
-	int sys_mkdir(const char* path){
-		long ret = syscall(SYS_MKDIR, path);
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		return 0;
-	}
-
-	int sys_rmdir(const char* path){
-		long ret = syscall(SYS_RMDIR, path);
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		return 0;
-	}
-
-	int sys_link(const char* srcpath, const char* destpath){
-		long ret = syscall(SYS_LINK, srcpath, destpath);
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		return 0;
-	}
-
-	int sys_unlink(const char* path){
-		long ret = syscall(SYS_UNLINK, path);
-
-		if(ret < 0){
-			return -ret;
-		}
-
-		return 0;
-	}
-
-	typedef struct lemon_dirent {
-		uint32_t inode; // Inode number
-		uint32_t type;
-		char name[NAME_MAX]; // Filename
-	} lemon_dirent_t;
-
-	int sys_read_entries(int handle, void *buffer, size_t max_size, size_t *bytes_read){
-		lemon_dirent_t lemonDirent;
-		long ret = syscall(SYS_READDIR_NEXT, handle, &lemonDirent);
-
-		if(!ret){
-			*bytes_read = 0;
-			return 0;
-		} else if(ret > 0){
-			dirent* dir = (dirent*)buffer;
-			strcpy(dir->d_name, lemonDirent.name);
-			dir->d_ino = lemonDirent.inode;
-			dir->d_off = 0;
-			dir->d_reclen = sizeof(dirent);
-			dir->d_type = lemonDirent.type;
-
-			*bytes_read = sizeof(dirent);
-			return 0;
-		} else {
-			return -ret;
-		}
-	}
-
-	int sys_open_dir(const char* path, int* handle){
-		return sys_open(path, O_DIRECTORY, handle);
-	}
-
-	int sys_rename(const char* path, const char* new_path){
-		return -syscall(SYS_RENAME, path, new_path);
-	}
-	
-	int sys_readlink(const char *path, void *buffer, size_t max_size, ssize_t *length){
-		long ret = syscall(SYS_READLINK, path, buffer, max_size);
-		if(ret < 0){
-			return -ret;
-		}
-
-		*length = ret;
-		return 0;
-	}
-
-	int sys_dup(int fd, int flags, int* newfd){
-		int ret = syscall(SYS_DUP, fd, flags, -1);
-		if(ret < 0){
-			return -ret;
-		}
-
-		*newfd = ret;
-		return 0;
-	}
-
-	int sys_dup2(int fd, int flags, int newfd){
-		int ret = syscall(SYS_DUP, fd, flags, newfd);
-		if(ret < 0){
-			return -ret;
-		}
-
-		return 0;
-	}
-
-	int sys_fcntl(int fd, int request, va_list args, int* result){
-		if(request == F_DUPFD){
-			return sys_dup(fd, 0, result);
-		} else if(request == F_GETFD){
-			*result = 0; // Lemon does not support O_CLOEXEC
-			return 0;
-		} else if(request == F_SETFD){
-			*result = 0; // Lemon does not support O_CLOEXEC
-			return 0;
-		} else if(request == F_GETFL){
-			int ret = syscall(SYS_GET_FILE_STATUS_FLAGS, fd);
-			if(ret < 0){
-				return -ret;
-			}
-			
-			*result = ret;
-			return 0;
-		} else if(request == F_SETFL){
-			int ret = syscall(SYS_SET_FILE_STATUS_FLAGS, fd, va_arg(args, int));
-			return -ret;
-		} else {
-			infoLogger() << "mlibc: sys_fcntl unsupported request (" << request << ")" << frg::endlog;
+	lemon_stat_t lemonStat;
+	switch(fsfdt){
+		case fsfd_target::fd:
+			ret = syscall(SYS_FSTAT, &lemonStat, fd);
+			break;
+		case fsfd_target::path:
+			ret = syscall(SYS_STAT, &lemonStat, path);
+			break;
+		default:
+			mlibc::infoLogger() << "mlibc warning: sys_stat: unsupported fsfd target" << frg::endlog;
 			return EINVAL;
-		}
 	}
 
-	int sys_pselect(int nfds, fd_set* readfds, fd_set* writefds,
-		fd_set *exceptfds, const struct timespec* timeout, const sigset_t* sigmask, int *num_events){
-		int ret = syscall(SYS_SELECT, nfds, readfds, writefds, exceptfds, timeout);
+	statbuf->st_dev = lemonStat.st_dev;
+	statbuf->st_ino = lemonStat.st_ino;
+	statbuf->st_mode = lemonStat.st_mode;
+	statbuf->st_nlink = lemonStat.st_nlink;
+	statbuf->st_uid = lemonStat.st_uid;
+	statbuf->st_gid = lemonStat.st_gid;
+	statbuf->st_rdev = lemonStat.st_rdev;
+	statbuf->st_size = lemonStat.st_size;
+	statbuf->st_blksize = lemonStat.st_blksize;
+	statbuf->st_blocks = lemonStat.st_blocks;
+
+	return -ret;
+}
+
+int sys_ioctl(int fd, unsigned long request, void *arg, int *result){
+	return syscall(SYS_IOCTL, fd, request, arg, result);
+}
+
+#ifndef MLIBC_BUILDING_RTDL
+
+#define LEMON_TIOCGATTR 0xB301
+#define LEMON_TIOCSATTR 0xB302
+
+int sys_isatty(int fd) {
+	struct winsize ws;
+	long ret = sys_ioctl(fd, TIOCGWINSZ, &ws, 0);
+
+	if(!ret) return 0;
+	
+	return ENOTTY;
+}
+
+int sys_tcgetattr(int fd, struct termios *attr) {
+	if(int e = sys_isatty(fd))
+		return e;
+
+	int ret;
+	sys_ioctl(fd, LEMON_TIOCGATTR, attr, &ret);
+
+	if(ret)
+		return -ret;
+
+	return 0;
+}
+
+int sys_tcsetattr(int fd, int optional_action, const struct termios *attr) {
+	if(int e = sys_isatty(fd))
+		return e;
+
+	if(optional_action){
+		mlibc::infoLogger() << "mlibc warning: sys_tcsetattr ignores optional_action" << frg::endlog;
+	}
+
+	int ret;
+	sys_ioctl(fd, LEMON_TIOCSATTR, const_cast<struct termios*>(attr), &ret);
+
+	if(ret)
+		return -ret;
+
+	return 0;
+}
+
+int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events){
+	long ret = syscall(SYS_POLL, fds, count, timeout);
+
+	if(ret < 0){
+		return -ret;
+	}
+
+	*num_events = ret;
+
+	return 0;
+}
+
+int sys_mkdir(const char* path){
+	long ret = syscall(SYS_MKDIR, path);
+
+	if(ret < 0){
+		return -ret;
+	}
+
+	return 0;
+}
+
+int sys_rmdir(const char* path){
+	long ret = syscall(SYS_RMDIR, path);
+
+	if(ret < 0){
+		return -ret;
+	}
+
+	return 0;
+}
+
+int sys_link(const char* srcpath, const char* destpath){
+	long ret = syscall(SYS_LINK, srcpath, destpath);
+
+	if(ret < 0){
+		return -ret;
+	}
+
+	return 0;
+}
+
+int sys_unlink(const char* path){
+	long ret = syscall(SYS_UNLINK, path);
+
+	if(ret < 0){
+		return -ret;
+	}
+
+	return 0;
+}
+
+typedef struct lemon_dirent {
+	uint32_t inode; // Inode number
+	uint32_t type;
+	char name[NAME_MAX]; // Filename
+} lemon_dirent_t;
+
+int sys_read_entries(int handle, void *buffer, size_t max_size, size_t *bytes_read){
+	lemon_dirent_t lemonDirent;
+	long ret = syscall(SYS_READDIR_NEXT, handle, &lemonDirent);
+
+	if(!ret){
+		*bytes_read = 0;
+		return 0;
+	} else if(ret > 0){
+		dirent* dir = (dirent*)buffer;
+		strcpy(dir->d_name, lemonDirent.name);
+		dir->d_ino = lemonDirent.inode;
+		dir->d_off = 0;
+		dir->d_reclen = sizeof(dirent);
+		dir->d_type = lemonDirent.type;
+
+		*bytes_read = sizeof(dirent);
+		return 0;
+	} else {
+		return -ret;
+	}
+}
+
+int sys_open_dir(const char* path, int* handle){
+	return sys_open(path, O_DIRECTORY, handle);
+}
+
+int sys_rename(const char* path, const char* new_path){
+	return -syscall(SYS_RENAME, path, new_path);
+}
+
+int sys_readlink(const char *path, void *buffer, size_t max_size, ssize_t *length){
+	long ret = syscall(SYS_READLINK, path, buffer, max_size);
+	if(ret < 0){
+		return -ret;
+	}
+
+	*length = ret;
+	return 0;
+}
+
+int sys_dup(int fd, int flags, int* newfd){
+	int ret = syscall(SYS_DUP, fd, flags, -1);
+	if(ret < 0){
+		return -ret;
+	}
+
+	*newfd = ret;
+	return 0;
+}
+
+int sys_dup2(int fd, int flags, int newfd){
+	int ret = syscall(SYS_DUP, fd, flags, newfd);
+	if(ret < 0){
+		return -ret;
+	}
+
+	return 0;
+}
+
+int sys_fcntl(int fd, int request, va_list args, int* result){
+	if(request == F_DUPFD){
+		return sys_dup(fd, 0, result);
+	} else if(request == F_GETFD){
+		*result = 0; // Lemon does not support O_CLOEXEC
+		return 0;
+	} else if(request == F_SETFD){
+		*result = 0; // Lemon does not support O_CLOEXEC
+		return 0;
+	} else if(request == F_GETFL){
+		int ret = syscall(SYS_GET_FILE_STATUS_FLAGS, fd);
 		if(ret < 0){
 			return -ret;
 		}
-
-		*num_events = ret;
+		
+		*result = ret;
 		return 0;
+	} else if(request == F_SETFL){
+		int ret = syscall(SYS_SET_FILE_STATUS_FLAGS, fd, va_arg(args, int));
+		return -ret;
+	} else {
+		infoLogger() << "mlibc: sys_fcntl unsupported request (" << request << ")" << frg::endlog;
+		return EINVAL;
+	}
+}
+
+int sys_pselect(int nfds, fd_set* readfds, fd_set* writefds,
+	fd_set *exceptfds, const struct timespec* timeout, const sigset_t* sigmask, int *num_events){
+	int ret = syscall(SYS_SELECT, nfds, readfds, writefds, exceptfds, timeout);
+	if(ret < 0){
+		return -ret;
 	}
 
-	int sys_chmod(const char *pathname, mode_t mode){
-		int ret = syscall(SYS_CHMOD, pathname, mode);
+	*num_events = ret;
+	return 0;
+}
 
-		if(ret < 0){
-			return -ret;
-		}
+int sys_chmod(const char *pathname, mode_t mode){
+	int ret = syscall(SYS_CHMOD, pathname, mode);
 
-		return 0;
+	if(ret < 0){
+		return -ret;
 	}
 
-	int sys_pipe(int *fds, int flags){
-		return -syscall(SYS_PIPE, fds, flags);
-	}
-	#endif
+	return 0;
+}
+
+int sys_pipe(int *fds, int flags){
+	return -syscall(SYS_PIPE, fds, flags);
+}
+#endif
+
 } 

--- a/sysdeps/lemon/generic/lemon.cpp
+++ b/sysdeps/lemon/generic/lemon.cpp
@@ -9,185 +9,187 @@
 #include <sys/resource.h>
 
 namespace mlibc{
-	int sys_futex_tid(){
-		return syscall(SYS_GETTID);
+
+int sys_futex_tid(){
+	return syscall(SYS_GETTID);
+}
+
+int sys_futex_wait(int *pointer, int expected){
+	return syscall(SYS_FUTEX_WAIT, pointer, expected);
+}
+
+int sys_futex_wake(int *pointer) {
+	return syscall(SYS_FUTEX_WAKE, pointer);
+}
+
+int sys_tcb_set(void* pointer){
+	syscall(SYS_SET_FS_BASE, (uintptr_t)pointer);
+	return 0;
+}
+
+int sys_vm_map(void *hint, size_t size, int prot, int flags, int fd, off_t offset, void **window) {
+	__ensure(flags & MAP_ANONYMOUS);
+
+	return syscall(SYS_MMAP, (uintptr_t)window, (size + 0xFFF) & ~static_cast<size_t>(0xFFF), (uintptr_t)hint, flags);
+}
+
+int sys_vm_unmap(void* address, size_t size) {
+	__ensure(!(size & 0xFFF));
+
+	long ret = syscall(SYS_MUNMAP, (uintptr_t)address, (size + 0xFFF) & ~static_cast<size_t>(0xFFF));
+
+	return ret;
+}
+
+int sys_anon_allocate(size_t size, void **pointer) {
+	return sys_vm_map(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0, pointer);
+}
+
+int sys_anon_free(void *pointer, size_t size) {
+	return sys_vm_unmap(pointer, size);
+}
+
+void sys_libc_panic(){
+	sys_libc_log("libc panic!");
+	__builtin_trap();
+	for(;;);
+}
+
+void sys_libc_log(const char* msg){
+	syscall(0, (uintptr_t)msg);
+}
+
+#ifndef MLIBC_BUILDING_RTDL
+
+void sys_exit(int status){
+	syscall(SYS_EXIT, status);
+
+	__builtin_unreachable();
+}
+
+pid_t sys_getpid(){
+	uint64_t _pid;
+	syscall(SYS_GETPID, (uintptr_t)&_pid);
+
+	pid_t pid = _pid;
+	return pid;
+}
+
+pid_t sys_getppid(){
+	return syscall(SYS_GETPPID);
+}
+
+int sys_clock_get(int clock, time_t *secs, long *nanos) {
+	uint64_t _secs, _millis;
+	syscall(SYS_UPTIME, (uintptr_t)&_secs, (uintptr_t)&_millis);
+
+	*secs = _secs;
+	*nanos = _millis * 1000000;
+	return 0;
+}
+
+int sys_getcwd(char *buffer, size_t size){
+	return syscall(SYS_GET_CWD, buffer, size);
+}
+
+int sys_chdir(const char *path){
+	syscall(SYS_CHDIR, path);
+	return 0;
+}
+
+int sys_sleep(time_t* sec, long* nanosec){
+	syscall(SYS_NANO_SLEEP, (*sec) * 1000000000 + (*nanosec));
+	return 0;
+}
+
+uid_t sys_getuid(){
+	return syscall(SYS_GETUID);
+}
+
+uid_t sys_geteuid(){
+	return syscall(SYS_GETEUID);
+}
+
+int sys_setuid(uid_t uid){
+	return -syscall(SYS_SETUID, uid);
+}
+
+int sys_seteuid(uid_t euid){
+	return -syscall(SYS_SETEUID, euid);
+}
+
+gid_t sys_getgid(){
+	return syscall(SYS_GETGID);
+}
+
+gid_t sys_getegid(){
+	return syscall(SYS_GETEGID);
+}
+
+int sys_setgid(gid_t gid){
+	mlibc::infoLogger() << "mlibc: sys_setgid is a stub" << frg::endlog;
+	return 0;
+}
+
+int sys_setegid(gid_t egid){
+	mlibc::infoLogger() << "mlibc: sys_setegid is a stub" << frg::endlog;
+	return 0;
+}
+
+void sys_yield(){
+	syscall(SYS_YIELD);
+}
+
+int sys_clone(void *entry, void *user_arg, void *tcb, pid_t *tid_out){
+	auto stack = prepare_stack(entry, user_arg, tcb);
+	pid_t tid = syscall(SYS_SPAWN_THREAD, __mlibc_start_thread, stack);
+
+	if(tid < 0){
+		errno = tid;
+		return -1;
 	}
 
-	int sys_futex_wait(int *pointer, int expected){
-		return syscall(SYS_FUTEX_WAIT, pointer, expected);
+	*tid_out = tid;
+
+	return 0;
+}
+
+void sys_thread_exit(){
+	syscall(SYS_EXIT_THREAD);
+
+	__builtin_unreachable();
+}
+
+int sys_waitpid(pid_t pid, int *status, int flags, pid_t *ret_pid){
+	pid_t ret = syscall(SYS_WAIT_PID, pid, status, flags);
+
+	if(ret < 0){
+		return -ret;
 	}
 
-	int sys_futex_wake(int *pointer) {
-		return syscall(SYS_FUTEX_WAKE, pointer);
+	*ret_pid = ret;
+
+	return 0;
+}
+
+int sys_fork(pid_t *child){
+	long pid = syscall(SYS_FORK, 0);
+	if(pid < 0){
+		errno = pid;
+		return -1;
 	}
 
-	int sys_tcb_set(void* pointer){
-		syscall(SYS_SET_FS_BASE, (uintptr_t)pointer);
-		return 0;
-	}
+	*child = pid;
+	return 0;
+}
 
-	int sys_vm_map(void *hint, size_t size, int prot, int flags, int fd, off_t offset, void **window) {
-		__ensure(flags & MAP_ANONYMOUS);
+int sys_execve(const char *path, char *const argv[], char *const envp[]){
+	return -syscall(SYS_EXECVE, path, argv, envp);
+}
 
-		return syscall(SYS_MMAP, (uintptr_t)window, (size + 0xFFF) & ~static_cast<size_t>(0xFFF), (uintptr_t)hint, flags);
-	}
+int sys_getentropy(void *buffer, size_t length){
+	return -syscall(SYS_GETENTROPY, buffer, length);
+}
+#endif
 
-	int sys_vm_unmap(void* address, size_t size) {
-		__ensure(!(size & 0xFFF));
-
-		long ret = syscall(SYS_MUNMAP, (uintptr_t)address, (size + 0xFFF) & ~static_cast<size_t>(0xFFF));
-
-		return ret;
-	}
-
-	int sys_anon_allocate(size_t size, void **pointer) {
-		return sys_vm_map(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0, pointer);
-	}
-
-	int sys_anon_free(void *pointer, size_t size) {
-		return sys_vm_unmap(pointer, size);
-	}
-
-	void sys_libc_panic(){
-		sys_libc_log("libc panic!");
-		__builtin_trap();
-		for(;;);
-	}
-
-	void sys_libc_log(const char* msg){
-		syscall(0, (uintptr_t)msg);
-	}
-
-	#ifndef MLIBC_BUILDING_RTDL
-
-	void sys_exit(int status){
-		syscall(SYS_EXIT, status);
-
-		__builtin_unreachable();
-	}
-
-	pid_t sys_getpid(){
-		uint64_t _pid;
-		syscall(SYS_GETPID, (uintptr_t)&_pid);
-
-		pid_t pid = _pid;
-		return pid;
-	}
-
-	pid_t sys_getppid(){
-		return syscall(SYS_GETPPID);
-	}
-	
-	int sys_clock_get(int clock, time_t *secs, long *nanos) {
-		uint64_t _secs, _millis;
-		syscall(SYS_UPTIME, (uintptr_t)&_secs, (uintptr_t)&_millis);
-
-		*secs = _secs;
-		*nanos = _millis * 1000000;
-		return 0;
-	}
-
-	int sys_getcwd(char *buffer, size_t size){
-		return syscall(SYS_GET_CWD, buffer, size);
-	}
-
-	int sys_chdir(const char *path){
-		syscall(SYS_CHDIR, path);
-		return 0;
-	}
-
-	int sys_sleep(time_t* sec, long* nanosec){
-		syscall(SYS_NANO_SLEEP, (*sec) * 1000000000 + (*nanosec));
-		return 0;
-	}
-	
-	uid_t sys_getuid(){
-		return syscall(SYS_GETUID);
-	}
-
-	uid_t sys_geteuid(){
-		return syscall(SYS_GETEUID);
-	}
-
-	int sys_setuid(uid_t uid){
-		return -syscall(SYS_SETUID, uid);
-	}
-
-	int sys_seteuid(uid_t euid){
-		return -syscall(SYS_SETEUID, euid);
-	}
-
-	gid_t sys_getgid(){
-		return syscall(SYS_GETGID);
-	}
-
-	gid_t sys_getegid(){
-		return syscall(SYS_GETEGID);
-	}
-
-	int sys_setgid(gid_t gid){
-		mlibc::infoLogger() << "mlibc: sys_setgid is a stub" << frg::endlog;
-		return 0;
-	}
-
-	int sys_setegid(gid_t egid){
-		mlibc::infoLogger() << "mlibc: sys_setegid is a stub" << frg::endlog;
-		return 0;
-	}
-
-	void sys_yield(){
-		syscall(SYS_YIELD);
-	}
-
-	int sys_clone(void *entry, void *user_arg, void *tcb, pid_t *tid_out){
-		auto stack = prepare_stack(entry, user_arg, tcb);
-		pid_t tid = syscall(SYS_SPAWN_THREAD, __mlibc_start_thread, stack);
-
-		if(tid < 0){
-			errno = tid;
-			return -1;
-		}
-
-		*tid_out = tid;
-
-		return 0;
-	}
-
-	void sys_thread_exit(){
-		syscall(SYS_EXIT_THREAD);
-
-		__builtin_unreachable();
-	}
-
-	int sys_waitpid(pid_t pid, int *status, int flags, pid_t *ret_pid){
-		pid_t ret = syscall(SYS_WAIT_PID, pid, status, flags);
-
-		if(ret < 0){
-			return ret;
-		}
-
-		*ret_pid = ret;
-
-		return 0;
-	}
-
-	int sys_fork(pid_t *child){
-		long pid = syscall(SYS_FORK, 0);
-		if(pid < 0){
-			errno = pid;
-			return -1;
-		}
-
-		*child = pid;
-		return 0;
-	}
-
-	int sys_execve(const char *path, char *const argv[], char *const envp[]){
-		return -syscall(SYS_EXECVE, path, argv, envp);
-	}
-
-	int sys_getentropy(void *buffer, size_t length){
-		return -syscall(SYS_GETENTROPY, buffer, length);
-	}
-	#endif
 } 

--- a/sysdeps/lemon/generic/signals.cpp
+++ b/sysdeps/lemon/generic/signals.cpp
@@ -1,0 +1,38 @@
+#include <lemon/syscall.h>
+
+#include <sys/types.h>
+
+#include <mlibc/ansi-sysdeps.hpp>
+
+namespace mlibc{
+
+int sys_sigprocmask(int how, const sigset_t *__restrict set,
+	sigset_t *__restrict retrieve){
+    int ret = syscall(SYS_SIGPROCMASK, how, set, retrieve);
+    if(ret < 0){
+        return -ret;
+    }
+
+    return 0;
+}
+
+int sys_sigaction(int signal, const struct sigaction *__restrict action,
+	struct sigaction *__restrict oldAction) {
+    int ret = syscall(SYS_SIGNAL_ACTION, signal, action, oldAction);
+    if(ret < 0){
+        return -ret;
+    }
+
+    return 0;
+}
+
+int sys_kill(int pid, int signal){
+    int ret = syscall(SYS_KILL, pid, signal);
+    if(ret < 0){
+        return -ret;
+    }
+
+    return 0;
+}
+
+}

--- a/sysdeps/lemon/generic/sockets.cpp
+++ b/sysdeps/lemon/generic/sockets.cpp
@@ -7,97 +7,99 @@
 #include <mlibc/all-sysdeps.hpp>
 
 namespace mlibc{
-    int sys_socket(int domain, int type, int protocol, int *fd){
-        long ret = syscall(SYS_SOCKET, domain, type, protocol);
 
-        if(ret < 0){
-            return -ret;
-        }
+int sys_socket(int domain, int type, int protocol, int *fd){
+    long ret = syscall(SYS_SOCKET, domain, type, protocol);
 
-        *fd = ret;
-
-        return 0;
+    if(ret < 0){
+        return -ret;
     }
 
-    int sys_bind(int sockfd, const struct sockaddr *addr_ptr, socklen_t addrlen){
-        return syscall(SYS_BIND, sockfd, addr_ptr, addrlen);
+    *fd = ret;
+
+    return 0;
+}
+
+int sys_bind(int sockfd, const struct sockaddr *addr_ptr, socklen_t addrlen){
+    return syscall(SYS_BIND, sockfd, addr_ptr, addrlen);
+}
+
+int sys_connect(int sockfd, const struct sockaddr *addr_ptr, socklen_t addrlen){
+    return syscall(SYS_CONNECT, sockfd, addr_ptr, addrlen);
+}
+
+int sys_accept(int fd, int *newfd){
+    long ret = syscall(SYS_ACCEPT, fd);
+
+    if(ret < 0){
+        return -ret;
     }
 
-    int sys_connect(int sockfd, const struct sockaddr *addr_ptr, socklen_t addrlen){
-        return syscall(SYS_CONNECT, sockfd, addr_ptr, addrlen);
+    *newfd = ret;
+
+    return 0;
+}
+
+int sys_listen(int fd, int backlog){
+    return syscall(SYS_LISTEN, fd, backlog);
+}
+
+int sys_msg_recv(int sockfd, struct msghdr *hdr, int flags, ssize_t *length){
+    long ret = syscall(SYS_RECVMSG, sockfd, hdr, flags);
+
+    if(ret < 0){
+        return -ret;
     }
 
-    int sys_accept(int fd, int *newfd){
-        long ret = syscall(SYS_ACCEPT, fd);
+    *length = ret;
 
-        if(ret < 0){
-            return -ret;
-        }
+    return 0;
+}
 
-        *newfd = ret;
+int sys_msg_send(int sockfd, const struct msghdr *hdr, int flags, ssize_t *length){
+    long ret = syscall(SYS_SENDMSG, sockfd, hdr, flags);
 
-        return 0;
+    if(ret < 0){
+        return -ret;
     }
 
-    int sys_listen(int fd, int backlog){
-        return syscall(SYS_LISTEN, fd, backlog);
+    *length = ret;
+
+    return 0;
+}
+
+int sys_setsockopt(int fd, int layer, int number, const void *buffer, socklen_t size){
+    long ret = syscall(SYS_SET_SOCKET_OPTIONS, fd, layer, number, buffer, size);
+
+    if(ret < 0){
+        return -ret;
     }
 
-    int sys_msg_recv(int sockfd, struct msghdr *hdr, int flags, ssize_t *length){
-        long ret = syscall(SYS_RECVMSG, sockfd, hdr, flags);
+    return 0;
+}
 
-        if(ret < 0){
-            return -ret;
-        }
+int sys_getsockopt(int fd, int layer, int number, void *__restrict buffer, socklen_t *__restrict size){
+    long ret = syscall(SYS_GET_SOCKET_OPTIONS, fd, layer, number, buffer, size);
 
-        *length = ret;
-
-        return 0;
+    if(ret < 0){
+        return -ret;
     }
 
-    int sys_msg_send(int sockfd, const struct msghdr *hdr, int flags, ssize_t *length){
-        long ret = syscall(SYS_SENDMSG, sockfd, hdr, flags);
+    return 0;
+}
 
-        if(ret < 0){
-            return -ret;
-        }
+int sys_socketpair(int domain, int type_and_flags, int proto, int *fds){
+    return -syscall(SYS_SOCKETPAIR, domain, type_and_flags, proto, fds);
+}
 
-        *length = ret;
+int sys_sockname(int fd, struct sockaddr *addr_ptr, socklen_t max_addr_length,
+    socklen_t *actual_length) {
+    return -syscall(SYS_SOCKNAME, fd, addr_ptr, max_addr_length);
+}
 
-        return 0;
-    }
+int sys_peername(int fd, struct sockaddr *addr_ptr, socklen_t max_addr_length,
+    socklen_t *actual_length) {
+    return -syscall(SYS_PEERNAME, fd, addr_ptr, max_addr_length);
+}
 
-	int sys_setsockopt(int fd, int layer, int number, const void *buffer, socklen_t size){
-        long ret = syscall(SYS_SET_SOCKET_OPTIONS, fd, layer, number, buffer, size);
-
-		if(ret < 0){
-            return -ret;
-        }
-
-		return 0;
-	}
-
-	int sys_getsockopt(int fd, int layer, int number, void *__restrict buffer, socklen_t *__restrict size){
-        long ret = syscall(SYS_GET_SOCKET_OPTIONS, fd, layer, number, buffer, size);
-
-		if(ret < 0){
-            return -ret;
-        }
-
-		return 0;
-	}
-
-	int sys_socketpair(int domain, int type_and_flags, int proto, int *fds){
-		return -syscall(SYS_SOCKETPAIR, domain, type_and_flags, proto, fds);
-	}
-
-    int sys_sockname(int fd, struct sockaddr *addr_ptr, socklen_t max_addr_length,
-		socklen_t *actual_length) {
-        return -syscall(SYS_SOCKNAME, fd, addr_ptr, max_addr_length);
-    }
-    
-    int sys_peername(int fd, struct sockaddr *addr_ptr, socklen_t max_addr_length,
-	    socklen_t *actual_length) {
-        return -syscall(SYS_PEERNAME, fd, addr_ptr, max_addr_length);
-    }
 }

--- a/sysdeps/lemon/include/lemon/syscall.h
+++ b/sysdeps/lemon/include/lemon/syscall.h
@@ -103,6 +103,10 @@
 #define SYS_SOCKETPAIR 99
 #define SYS_PEERNAME 100
 #define SYS_SOCKNAME 101
+#define SYS_SIGNAL_ACTION 102
+#define SYS_SIGPROCMASK 103
+#define SYS_KILL 104
+#define SYS_SIGNAL_RETURN 105
 
 #ifdef __cplusplus
 extern "C"{

--- a/sysdeps/lemon/meson.build
+++ b/sysdeps/lemon/meson.build
@@ -5,10 +5,11 @@ rtdl_sources += files(
 )
 
 libc_sources += files(
+	'generic/entry.cpp',
 	'generic/filesystem.cpp',
 	'generic/lemon.cpp',
+	'generic/signals.cpp',
 	'generic/sockets.cpp',
-	'generic/entry.cpp',
 	'generic/thread_entry.S',
 	'generic/thread.cpp'
 )


### PR DESCRIPTION
This is in line with the POSIX spec.
Programs such as zsh may pass an invalid signal number and crash on EINVAL.

Also updated lemon sysdeps.