### PR TITLE
Warning fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ if not headers_only
 	add_project_arguments('-nostdinc', '-fno-builtin', language: ['c', 'cpp'])
 	add_project_arguments('-std=c++20', language: 'cpp')
 	add_project_arguments('-fno-rtti', '-fno-exceptions', language: 'cpp')
+	add_project_arguments('-Wall', '-Wextra', language: ['c', 'cpp'])
 	add_project_link_arguments('-nostdlib', language: ['c', 'cpp'])
 
 	if c_compiler.get_id() == 'gcc'

--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -623,7 +623,7 @@ int fflush(FILE *file_base) {
 	return 0;
 }
 
-int setvbuf(FILE *file_base, char *buffer, int mode, size_t size) {
+int setvbuf(FILE *file_base, char *, int mode, size_t) {
 	// TODO: We could also honor the buffer, but for now use just set the mode.
 	auto file = static_cast<mlibc::abstract_file *>(file_base);
 	if(mode == _IONBF) {

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -1120,6 +1120,7 @@ void funlockfile(FILE *) {
 
 int ftrylockfile(FILE *) {
 	mlibc::infoLogger() << "mlibc: File locking (ftrylockfile) is a no-op" << frg::endlog;
+    return 0;
 }
 
 void clearerr_unlocked(FILE *file_base) {

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -255,21 +255,24 @@ int renameat(int olddirfd, const char *old_path, int newdirfd, const char *new_p
     }
     return 0;
 }
+
 FILE *tmpfile(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-char *tmpnam(char *buffer) {
+
+char *tmpnam(char *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
 // fflush() is provided by the POSIX sublibrary
 // fopen() is provided by the POSIX sublibrary
-FILE *freopen(const char *__restrict filename, const char *__restrict mode, FILE *__restrict stream) {
+FILE *freopen(const char *__restrict, const char *__restrict, FILE *__restrict) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 void setbuf(FILE *__restrict stream, char *__restrict buffer) {
 	setvbuf(stream, buffer, buffer ? _IOFBF : _IONBF, BUFSIZ);
 }
@@ -286,6 +289,7 @@ int fprintf(FILE *__restrict stream, const char *__restrict format, ...) {
 	va_end(args);
 	return result;
 }
+
 int fscanf(FILE *__restrict stream, const char *__restrict format, ...) {
 	va_list args;
 	va_start(args, format);
@@ -678,10 +682,11 @@ static int do_scanf(H &handler, const char *fmt, __gnuc_va_list args) {
     return match_count;
 }
 
-int scanf(const char *__restrict format, ...) {
+int scanf(const char *__restrict, ...) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int snprintf(char *__restrict buffer, size_t max_size, const char *__restrict format, ...) {
 	va_list args;
 	va_start(args, format);
@@ -689,6 +694,7 @@ int snprintf(char *__restrict buffer, size_t max_size, const char *__restrict fo
 	va_end(args);
 	return result;
 }
+
 int sprintf(char *__restrict buffer, const char *__restrict format, ...) {
 	va_list args;
 	va_start(args, format);
@@ -696,6 +702,7 @@ int sprintf(char *__restrict buffer, const char *__restrict format, ...) {
 	va_end(args);
 	return result;
 }
+
 int sscanf(const char *__restrict buffer, const char *__restrict format, ...) {
 	va_list args;
 	va_start(args, format);
@@ -705,6 +712,7 @@ int sscanf(const char *__restrict buffer, const char *__restrict format, ...) {
 	va_end(args);
 	return result;
 }
+
 int vfprintf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_list args) {
 	frg::va_struct vs;
 	va_copy(vs.args, args);
@@ -718,6 +726,7 @@ int vfprintf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_l
 
 	return p.count;
 }
+
 int vfscanf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_list args) {
 	auto file = static_cast<mlibc::abstract_file *>(stream);
 	frg::unique_lock<FutexLock> lock(file->_lock);
@@ -747,13 +756,16 @@ int vfscanf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_li
 
 	return do_scanf(handler, format, args);
 }
+
 int vprintf(const char *__restrict format, __gnuc_va_list args){
 	return vfprintf(stdout, format, args);
 }
-int vscanf(const char *__restrict format, __gnuc_va_list args) {
+
+int vscanf(const char *__restrict, __gnuc_va_list) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int vsnprintf(char *__restrict buffer, size_t max_size,
 		const char *__restrict format, __gnuc_va_list args) {
 	frg::va_struct vs;
@@ -767,6 +779,7 @@ int vsnprintf(char *__restrict buffer, size_t max_size,
 		p.buffer[frg::min(max_size - 1, p.count)] = 0;
 	return p.count;
 }
+
 int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_list args) {
 	frg::va_struct vs;
 	va_copy(vs.args, args);
@@ -778,6 +791,7 @@ int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_l
 	p.buffer[p.count] = 0;
 	return p.count;
 }
+
 int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc_va_list args) {
 	struct {
 		char look_ahead() {
@@ -868,6 +882,7 @@ int fputc_unlocked(int c, FILE *stream) {
 		return EOF;
 	return 1;
 }
+
 int fputc(int c, FILE *stream) {
 	auto file = static_cast<mlibc::abstract_file *>(stream);
 	frg::unique_lock<FutexLock> lock(file->_lock);
@@ -879,6 +894,7 @@ int fputs_unlocked(const char *__restrict string, FILE *__restrict stream) {
 		return EOF;
 	return 1;
 }
+
 int fputs(const char *__restrict string, FILE *__restrict stream) {
 	auto file = static_cast<mlibc::abstract_file *>(stream);
 	frg::unique_lock<FutexLock> lock(file->_lock);
@@ -911,6 +927,7 @@ int putc_unlocked(int c, FILE *stream) {
 		return EOF;
 	return c;
 }
+
 int putc(int c, FILE *stream) {
 	auto file = static_cast<mlibc::abstract_file *>(stream);
 	frg::unique_lock<FutexLock> lock(file->_lock);
@@ -920,6 +937,7 @@ int putc(int c, FILE *stream) {
 int putchar_unlocked(int c) {
 	return putc_unlocked(c, stdout);
 }
+
 int putchar(int c) {
 	auto file = static_cast<mlibc::abstract_file *>(stdout);
 	frg::unique_lock<FutexLock> lock(file->_lock);
@@ -975,12 +993,13 @@ size_t fwrite(const void *buffer, size_t size , size_t count, FILE *file_base) {
 	return fwrite_unlocked(buffer, size, count, file_base);
 }
 
-int fgetpos(FILE *__restrict stream, fpos_t *__restrict position) {
+int fgetpos(FILE *__restrict, fpos_t *__restrict) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 // fseek() is provided by the POSIX sublibrary
-int fsetpos(FILE *stream, const fpos_t *position) {
+int fsetpos(FILE *, const fpos_t *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -40,7 +40,7 @@ struct PrintfAgent {
 			if (szmod == frg::printf_size_mod::long_size) {
 				char c_buf[sizeof(wchar_t)];
 				auto c = static_cast<wchar_t>(va_arg(_vsp->args, wint_t));
-				mbstate_t shift_state = {0};
+				mbstate_t shift_state = {};
 				if (wcrtomb(c_buf, c, &shift_state) == size_t(-1))
 					return frg::format_error::agent_error;
 				_formatter->append(c_buf);
@@ -752,7 +752,7 @@ int vfscanf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_li
 
 		mlibc::abstract_file *file;
 		int num_consumed;
-	} handler = {file};
+	} handler = {file, 0};
 
 	return do_scanf(handler, format, args);
 }
@@ -805,7 +805,7 @@ int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc
 
 		const char *buffer;
 		int num_consumed;
-	} handler = {buffer};
+	} handler = {buffer, 0};
 
 	int result = do_scanf(handler, format, args);
 

--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -242,6 +242,7 @@ int atexit(void (*func)(void)) {
 	return 0;
 }
 int at_quick_exit(void (*func)(void)) {
+	(void)func;
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -256,7 +257,7 @@ void _Exit(int status) {
 }
 
 // getenv() is provided by POSIX
-void quick_exit(int status) {
+void quick_exit(int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -395,11 +396,13 @@ div_t div(int number, int denom) {
 	r.rem = number % denom;
 	return r;
 }
-ldiv_t ldiv(long number, long denom) {
+
+ldiv_t ldiv(long, long) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-lldiv_t lldiv(long long number, long long denom) {
+
+lldiv_t lldiv(long long, long long) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -419,6 +422,7 @@ int mblen(const char *mbs, size_t mb_limit) {
 		__ensure(!"decode_wtranscode() errors are not handled");
 	return nseq.it - mbs;
 }
+
 int mbtowc(wchar_t *__restrict wc, const char *__restrict mbs, size_t max_size) {
 	mlibc::infoLogger() << "mlibc: Broken mbtowc() called" << frg::endlog;
 	__ensure(max_size);
@@ -432,7 +436,8 @@ int mbtowc(wchar_t *__restrict wc, const char *__restrict mbs, size_t max_size) 
 	}
 	return 1;
 }
-int wctomb(char *mb_chr, wchar_t wc) {
+
+int wctomb(char *, wchar_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -99,7 +99,8 @@ int strncmp(const char *a, const char *b, size_t max_size) {
 		i++;
 	}
 }
-size_t strxfrm(char *__restrict dest, const char *__restrict src, size_t max_size) {
+
+size_t strxfrm(char *__restrict, const char *__restrict, size_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -527,8 +527,10 @@ struct tm *localtime_r(const time_t *unix_gmt, struct tm *res) {
 	char *tm_zone;
 	frg::unique_lock<FutexLock> lock(__time_lock);
 	// TODO: Set errno if the conversion fails.
-	if(unix_local_from_gmt(*unix_gmt, &offset, &dst, &tm_zone))
+	if(unix_local_from_gmt(*unix_gmt, &offset, &dst, &tm_zone)) {
 		__ensure(!"Error parsing /etc/localtime");
+		__builtin_unreachable();
+	}
 	time_t unix_local = *unix_gmt + offset;
 
 	int days_since_epoch = unix_local / (60*60*24);

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -43,10 +43,11 @@ clock_t clock(void) {
 	return ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
 }
 
-double difftime(time_t a, time_t b){
+double difftime(time_t a, time_t b) {
 	return a - b;
 }
-time_t mktime(struct tm *ptr){
+
+time_t mktime(struct tm *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -61,11 +62,12 @@ int timespec_get(struct timespec *ts, int base) {
 	return ret < 0 ? 0 : base;
 }
 
-char *asctime(const struct tm *ptr){
+char *asctime(const struct tm *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-char *ctime(const time_t *timer){
+
+char *ctime(const time_t *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -549,7 +551,7 @@ struct tm *localtime_r(const time_t *unix_gmt, struct tm *res) {
 	return res;
 }
 
-char *asctime_r(const struct tm *tm, char *buf) {
+char *asctime_r(const struct tm *, char *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/ansi/include/wchar.h
+++ b/options/ansi/include/wchar.h
@@ -9,13 +9,11 @@
 #include <bits/null.h>
 #include <bits/size_t.h>
 #include <bits/wchar_t.h>
+#include <bits/wchar.h>
 #include <bits/wint_t.h>
 #include <bits/mbstate.h>
 
 #define WEOF 0xffffffffU
-// TODO: The following declaration should be independent of gcc.
-#define WCHAR_MIN __WCHAR_MIN__
-#define WCHAR_MAX __WCHAR_MAX__
 
 #ifdef __cplusplus
 extern "C" {

--- a/options/ansi/meson.build
+++ b/options/ansi/meson.build
@@ -266,5 +266,5 @@ if not headers_only
 		'musl-generic-math/truncl.c',
 		pic: true,
 		include_directories: libc_include_dirs,
-		c_args: ['-Wno-unused', '-Wno-implicit', '-Wno-parentheses'])
+		c_args: ['-Wno-unused', '-Wno-implicit', '-Wno-parentheses', '-Wno-sign-compare', '-Wno-attributes', '-Wno-unknown-pragmas'])
 endif

--- a/options/elf/generic/phdr.cpp
+++ b/options/elf/generic/phdr.cpp
@@ -3,7 +3,8 @@
 #include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 
-int dl_iterate_phdr(int (*callback)(struct dl_phdr_info*, size_t, void*), void* data){
+int dl_iterate_phdr(int (*callback)(struct dl_phdr_info*, size_t, void*), void *) {
+	(void)callback;
 	mlibc::infoLogger() << "mlibc: dl_iterate_phdr is a stub" << frg::endlog;
 	return 0;
 }

--- a/options/glibc/generic/shadow-stubs.cpp
+++ b/options/glibc/generic/shadow-stubs.cpp
@@ -4,21 +4,18 @@
 #include <mlibc/debug.hpp>
 
 // Code taken from musl
-int putspent(const struct spwd *sp, FILE *f) {
-	auto num = [] (int n) {
-		return ((n) == -1 ? 0 : -1) && ((n) == -1 ? 0 : (n));
-	};
+#define NUM(n) ((n) == -1 ? 0 : -1), ((n) == -1 ? 0 : (n))
 
+int putspent(const struct spwd *sp, FILE *f) {
 	auto str = [] (char *s) {
 		return ((s) ? (s) : "");
 	};
-	mlibc::infoLogger() << "mlibc: putspent is broken waiting on frigg!" << frg::endlog;
-	return 0;
 	return fprintf(f, "%s:%s:%.*ld:%.*ld:%.*ld:%.*ld:%.*ld:%.*ld:%.*lu\n",
-		str(sp->sp_namp), str(sp->sp_pwdp), num(sp->sp_lstchg),
-		num(sp->sp_min), num(sp->sp_max), num(sp->sp_warn),
-		num(sp->sp_inact), num(sp->sp_expire), num(sp->sp_flag)) < 0 ? -1 : 0;
+		str(sp->sp_namp), str(sp->sp_pwdp), NUM(sp->sp_lstchg),
+		NUM(sp->sp_min), NUM(sp->sp_max), NUM(sp->sp_warn),
+		NUM(sp->sp_inact), NUM(sp->sp_expire), NUM(sp->sp_flag)) < 0 ? -1 : 0;
 }
+#undef NUM
 
 int lckpwdf(void) {
 	mlibc::infoLogger() << "mlibc: lckpwdf is unimplemented like musl" << frg::endlog;

--- a/options/internal/include/bits/wchar.h
+++ b/options/internal/include/bits/wchar.h
@@ -1,0 +1,9 @@
+#ifndef MLIBC_WCHAR_H
+#define MLIBC_WCHAR_H
+
+#include <bits/types.h>
+
+#define WCHAR_MAX      __MLIBC_WCHAR_MAX
+#define WCHAR_MIN      __MLIBC_WCHAR_MIN
+
+#endif // MLIBC_WCHAR_H

--- a/options/internal/include/mlibc/charset.hpp
+++ b/options/internal/include/mlibc/charset.hpp
@@ -32,7 +32,7 @@ charset *current_charset();
 
 // The property if a character is a control character is locale-independent.
 inline bool generic_is_control(codepoint c) {
-	return (c >= 0x00 && c <= 0x1F) || (c == 0x7F) || (c >= 0x80 && c <= 0x9F);
+	return (c <= 0x1F) || (c == 0x7F) || (c >= 0x80 && c <= 0x9F);
 }
 
 } // namespace mlibc

--- a/options/internal/include/stdint.h
+++ b/options/internal/include/stdint.h
@@ -2,6 +2,7 @@
 #define _MLIBC_STDINT_H
 
 #include <bits/types.h>
+#include <bits/wchar.h>
 
 // ----------------------------------------------------------------------------
 // Type definitions.
@@ -138,8 +139,6 @@ typedef __mlibc_uintptr uintptr_t;
 #define PTRDIFF_MIN    __MLIBC_PTRDIFF_MIN
 #define SIG_ATOMIC_MAX __MLIBC_SIG_ATOMIC_MAX
 #define SIG_ATOMIC_MIN __MLIBC_SIG_ATOMIC_MIN
-#define WCHAR_MAX      __MLIBC_WCHAR_MAX
-#define WCHAR_MIN      __MLIBC_WCHAR_MIN
 #define WINT_MAX       __MLIBC_WINT_MAX
 #define WINT_MIN       __MLIBC_WINT_MIN
 

--- a/options/linux/generic/linux-unistd.cpp
+++ b/options/linux/generic/linux-unistd.cpp
@@ -1,7 +1,7 @@
 #include <bits/linux/linux_unistd.h>
 #include <bits/ensure.h>
 
-int dup3(int fd, int newfd, int flags) {
+int dup3(int, int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/linux/generic/sys-inotify-stubs.cpp
+++ b/options/linux/generic/sys-inotify-stubs.cpp
@@ -20,7 +20,7 @@ int inotify_init(void) {
 	return fd;
 }
 
-int inotify_init1(int flags) {
+int inotify_init1(int) {
 	int fd;
 	if(!mlibc::sys_inotify_create) {
 		MLIBC_MISSING_SYSDEP();

--- a/options/posix/generic/ftw-stubs.cpp
+++ b/options/posix/generic/ftw-stubs.cpp
@@ -3,13 +3,15 @@
 
 #include <bits/ensure.h>
 
-int ftw(const char *path, int (*fn)(const char *, const struct stat *, int), int fd_limit) {
+int ftw(const char *, int (*fn)(const char *, const struct stat *, int), int) {
+	(void)fn;
 	__ensure(!"ftw() not implemented");
 	__builtin_unreachable();
 }
 
-int nftw(const char *path, int (*fn)(const char *, const struct stat *, int, struct FTW *),
-		int fd_limit, int flags) {
+int nftw(const char *, int (*fn)(const char *, const struct stat *, int, struct FTW *),
+		int, int) {
+	(void)fn;
 	__ensure(!"nftw() not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/grp-stubs.cpp
+++ b/options/posix/generic/grp-stubs.cpp
@@ -168,10 +168,12 @@ void endgrent(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 struct group *getgrent(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 struct group *getgrgid(gid_t gid) {
 	int err = walk_file(&global_entry, [&] (group *entry) {
 		return entry->gr_gid == gid;
@@ -184,6 +186,7 @@ struct group *getgrgid(gid_t gid) {
 
 	return &global_entry;
 }
+
 int getgrgid_r(gid_t gid, struct group *grp, char *buffer, size_t size, struct group **result) {
 	*result = nullptr;
 	int err = walk_file(grp, [&] (group *entry) {
@@ -202,6 +205,7 @@ int getgrgid_r(gid_t gid, struct group *grp, char *buffer, size_t size, struct g
 	*result = grp;		
 	return 0;
 }
+
 struct group *getgrnam(const char *name) {
 	int err = walk_file(&global_entry, [&] (group *entry) {
 		return !strcmp(entry->gr_name, name);
@@ -214,6 +218,7 @@ struct group *getgrnam(const char *name) {
 
 	return &global_entry;
 }
+
 int getgrnam_r(const char *name, struct group *grp, char *buffer, size_t size, struct group **result) {
 	*result = nullptr;
 
@@ -233,17 +238,18 @@ int getgrnam_r(const char *name, struct group *grp, char *buffer, size_t size, s
 	*result = grp;		
 	return 0;
 }
+
 void setgrent(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int setgroups(size_t size, const gid_t *list) {
+int setgroups(size_t, const gid_t *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int initgroups(const char *user, gid_t group) {
+int initgroups(const char *, gid_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/langinfo-stubs.cpp
+++ b/options/posix/generic/langinfo-stubs.cpp
@@ -5,11 +5,11 @@
 
 char *nl_langinfo(nl_item item) {
 	if(item == CODESET) {
-		return "UTF-8";
+		return const_cast<char *>("UTF-8");
 	}else{
 		mlibc::infoLogger() << "mlibc: nl_langinfo item "
 				<< item << " is not implemented properly" << frg::endlog;
-		return "";
+		return const_cast<char *>("");
 	}
 }
 

--- a/options/posix/generic/libgen-stubs.cpp
+++ b/options/posix/generic/libgen-stubs.cpp
@@ -25,24 +25,24 @@ char *basename(char *s) {
 
 char *dirname(char *s) {
 	if (!s || !(*s))
-		return ".";
+		return const_cast<char *>(".");
 
 	auto i = strlen(s) - 1;
 
 	// Skip trailing slashes.
 	for (; s[i] == '/'; i--)
 		if(!i) // Path only consists of slashes.
-			return "/";
+			return const_cast<char *>("/");
 
 	// Skip the last non-slash path component.
 	for (; s[i] != '/'; i--)
 		if(!i) // Path only contains a single component.
-			return ".";
+			return const_cast<char *>(".");
 
 	// Skip slashes.
 	for (; s[i] == '/'; i--)
 		if(!i) // Path is entry in root directory.
-			return "/";
+			return const_cast<char *>("/");
 
 	s[i+1] = 0;
 

--- a/options/posix/generic/lookup.cpp
+++ b/options/posix/generic/lookup.cpp
@@ -192,7 +192,7 @@ int lookup_addr_dns(frg::span<char> name, frg::array<uint8_t, 16> &addr, int fam
 	size_t ptr = 0;
 	do {
 		size_t next = req_view.find_first('.', ptr);
-		size_t length = next != -1 ? next - ptr : req_view.size() - ptr;
+		size_t length = next != (size_t)-1 ? next - ptr : req_view.size() - ptr;
 		frg::string_view substring = req_view.sub_string(ptr, length);
 		request += char(length);
 		request += substring;

--- a/options/posix/generic/lookup.cpp
+++ b/options/posix/generic/lookup.cpp
@@ -130,6 +130,7 @@ int lookup_name_dns(struct lookup_result &buf, const char *name,
 			uint16_t rr_class = (it[2] << 8) | it[3];
 			uint16_t rr_length = (it[8] << 8) | it[9];
 			it += 10;
+			(void)rr_class;
 
 			switch (rr_type) {
 				case RECORD_A:
@@ -258,6 +259,8 @@ int lookup_addr_dns(frg::span<char> name, frg::array<uint8_t, 16> &addr, int fam
 			uint16_t rr_class = (it[2] << 8) | it[3];
 			uint16_t rr_length = (it[8] << 8) | it[9];
 			it += 10;
+			(void)rr_class;
+			(void)rr_length;
 
 			(void)dns_name;
 

--- a/options/posix/generic/posix-file-io.cpp
+++ b/options/posix/generic/posix-file-io.cpp
@@ -24,7 +24,7 @@ int mem_file::determine_bufmode(buffer_mode *mode) {
 	return 0;
 }
 
-int mem_file::io_read(char *buffer, size_t max_size, size_t *actual_size) {
+int mem_file::io_read(char *, size_t, size_t *) {
 	return EINVAL;
 }
 

--- a/options/posix/generic/posix_ctype.cpp
+++ b/options/posix/generic/posix_ctype.cpp
@@ -3,109 +3,134 @@
 
 #include <bits/ensure.h>
 
-int isalnum_l(int c, locale_t loc){
+int isalnum_l(int c, locale_t) {
     return isalnum(c);
 }
-int isalpha_l(int c, locale_t loc){
+
+int isalpha_l(int c, locale_t) {
     return isalpha(c);
 }
-int isblank_l(int c, locale_t loc){
+
+int isblank_l(int c, locale_t) {
     return isblank(c);
 }
-int iscntrl_l(int c, locale_t loc){
+
+int iscntrl_l(int c, locale_t) {
     return iscntrl(c);
 }
-int isdigit_l(int c, locale_t loc){
+
+int isdigit_l(int c, locale_t) {
     return isdigit(c);
 }
-int isgraph_l(int c, locale_t loc){
+
+int isgraph_l(int c, locale_t) {
     return isgraph(c);
 }
-int islower_l(int c, locale_t loc){
+
+int islower_l(int c, locale_t) {
     return islower(c);
 }
-int isprint_l(int c, locale_t loc){
+
+int isprint_l(int c, locale_t) {
     return isprint(c);
 }
-int ispunct_l(int c, locale_t loc){
+
+int ispunct_l(int c, locale_t) {
     return ispunct(c);
 }
-int isspace_l(int c, locale_t loc){
+
+int isspace_l(int c, locale_t) {
     return isspace(c);
 }
-int isupper_l(int c, locale_t loc){
+
+int isupper_l(int c, locale_t) {
     return isupper(c);
 }
-int isxdigit_l(int c, locale_t loc){
+
+int isxdigit_l(int c, locale_t) {
     return isxdigit(c);
 }
 
-int isascii_l(int c, locale_t loc){
+int isascii_l(int c, locale_t) {
     return isascii(c);
 }
 
-int tolower_l(int c, locale_t loc){
+int tolower_l(int c, locale_t) {
     return tolower(c);
 }
 
-int toupper_l(int c, locale_t loc){
+int toupper_l(int c, locale_t) {
     return toupper(c);
 }
 
-int iswalnum_l(wint_t c, locale_t){
+int iswalnum_l(wint_t c, locale_t) {
     return iswalnum(c);
 }
-int iswblank_l(wint_t c, locale_t){
+
+int iswblank_l(wint_t c, locale_t) {
     return iswblank(c);
 }
-int iswcntrl_l(wint_t c, locale_t){
+
+int iswcntrl_l(wint_t c, locale_t) {
     return iswcntrl(c);
 }
-int iswdigit_l(wint_t c, locale_t){
+
+int iswdigit_l(wint_t c, locale_t) {
     return iswdigit(c);
 }
-int iswgraph_l(wint_t c, locale_t){
+
+int iswgraph_l(wint_t c, locale_t) {
     return iswgraph(c);
 }
-int iswlower_l(wint_t c, locale_t){
+
+int iswlower_l(wint_t c, locale_t) {
     return iswlower(c);
 }
-int iswprint_l(wint_t c, locale_t){
+
+int iswprint_l(wint_t c, locale_t) {
     return iswprint(c);
 }
-int iswpunct_l(wint_t c, locale_t){
+
+int iswpunct_l(wint_t c, locale_t) {
     return iswpunct(c);
 }
-int iswspace_l(wint_t c, locale_t){
+
+int iswspace_l(wint_t c, locale_t) {
     return iswspace(c);
 }
-int iswupper_l(wint_t c, locale_t){
+
+int iswupper_l(wint_t c, locale_t) {
     return iswupper(c);
 }
-int iswxdigit_l(wint_t c, locale_t){
+
+int iswxdigit_l(wint_t c, locale_t) {
     return iswxdigit(c);
 }
-int iswalpha_l(wint_t c, locale_t){
+
+int iswalpha_l(wint_t c, locale_t) {
     return iswalpha(c);
 }
 
-wctype_t wctype_l(const char* p, locale_t){
+wctype_t wctype_l(const char* p, locale_t) {
     return wctype(p);
 }
-int iswctype_l(wint_t w, wctype_t t, locale_t){
+
+int iswctype_l(wint_t w, wctype_t t, locale_t) {
     return iswctype(w, t);
 }
 
-wint_t towlower_l(wint_t c, locale_t){
+wint_t towlower_l(wint_t c, locale_t) {
     return towlower(c);
 }
-wint_t towupper_l(wint_t c, locale_t){
+
+wint_t towupper_l(wint_t c, locale_t) {
     return towupper(c);
 }
 
-wctrans_t wctrans_l(const char* c, locale_t){
+wctrans_t wctrans_l(const char* c, locale_t) {
     return wctrans(c);
 }
-wint_t towctrans_l(wint_t c, wctrans_t desc, locale_t){
+
+wint_t towctrans_l(wint_t c, wctrans_t desc, locale_t) {
     return towctrans(c, desc);
 }

--- a/options/posix/generic/posix_locale.cpp
+++ b/options/posix/generic/posix_locale.cpp
@@ -1,20 +1,20 @@
 #include <bits/posix/posix_locale.h>
 #include <bits/ensure.h>
 
-locale_t newlocale(int category_mask, const char *locale, locale_t base) {
+locale_t newlocale(int, const char *, locale_t) {
 	// Due to all of the locale functions being stubs, the locale will not be used
 	return nullptr;
 }
 
-void freelocale(locale_t locobj) {
+void freelocale(locale_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-locale_t uselocale(locale_t locobj) {
+locale_t uselocale(locale_t) {
 	return nullptr;
 }
 
-locale_t duplocale(locale_t locobj) {
+locale_t duplocale(locale_t) {
 	return nullptr;
 }

--- a/options/posix/generic/posix_signal.cpp
+++ b/options/posix/generic/posix_signal.cpp
@@ -5,7 +5,7 @@
 
 #include <mlibc/posix-sysdeps.hpp>
 
-int sigsuspend(const sigset_t *sigmask) {
+int sigsuspend(const sigset_t *) {
 	__ensure(!"sigsuspend() not implemented");
 	__builtin_unreachable();
 }
@@ -21,7 +21,7 @@ int pthread_sigmask(int how, const sigset_t *__restrict set, sigset_t *__restric
 	return 0;
 }
 
-int pthread_kill(pthread_t thread, int sig) {
+int pthread_kill(pthread_t, int) {
 	__ensure(!"pthread_kill() not implemented");
 	__builtin_unreachable();
 }
@@ -71,12 +71,12 @@ int killpg(int, int) {
 	__builtin_unreachable();
 }
 
-int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec *timeout) {
+int sigtimedwait(const sigset_t *, siginfo_t *, const struct timespec *) {
 	__ensure(!"sigtimedwait() not implemented");
 	__builtin_unreachable();
 }
 
-int sigwait(const sigset_t *set, int *sig) {
+int sigwait(const sigset_t *, int *) {
 	__ensure(!"sigwait() not implemented");
 	__builtin_unreachable();
 }
@@ -85,5 +85,3 @@ int sigpending(sigset_t *) {
 	__ensure(!"sigpending() not implemented");
 	__builtin_unreachable();
 }
-
-

--- a/options/posix/generic/posix_stdio.cpp
+++ b/options/posix/generic/posix_stdio.cpp
@@ -76,6 +76,9 @@ FILE *popen(const char *command, const char *typestr) {
 		is_write = true;
 	} else if (strstr(typestr, "r") != NULL) {
 		is_write = false;
+	} else {
+		errno = EINVAL;
+		return nullptr;
 	}
 
 	bool cloexec = false;

--- a/options/posix/generic/posix_stdio.cpp
+++ b/options/posix/generic/posix_stdio.cpp
@@ -60,7 +60,7 @@ FILE *popen(const char *command, const char *typestr) {
 	pid_t child;
 	FILE *ret = nullptr;
 
-	if (!mlibc::sys_fork || !mlibc::sys_close || !mlibc::sys_dup2 || !mlibc::sys_execve
+	if (!mlibc::sys_fork || !mlibc::sys_dup2 || !mlibc::sys_execve
 			|| !mlibc::sys_sigprocmask || !mlibc::sys_sigaction || !mlibc::sys_pipe) {
 		MLIBC_MISSING_SYSDEP();
 		errno = ENOSYS;

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -79,7 +79,7 @@ double drand48(void) {
 	__builtin_unreachable();
 }
 
-void srand48(long int seedval) {
+void srand48(long int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -395,30 +395,30 @@ int posix_openpt(int flags) {
 	return fd;
 }
 
-int unlockpt(int fd) {
+int unlockpt(int) {
 	return 0;
 }
 
-int grantpt(int fd) {
+int grantpt(int) {
 	return 0;
 }
 
-double strtod_l(const char *__restrict__ nptr, char ** __restrict__ endptr, locale_t loc) {
+double strtod_l(const char *__restrict__, char ** __restrict__, locale_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-long double strtold_l(const char *__restrict__ nptr, char ** __restrict__ endptr, locale_t loc) {
+long double strtold_l(const char *__restrict__, char ** __restrict__, locale_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-float strtof_l(const char *__restrict string, char **__restrict end, locale_t loc){
+float strtof_l(const char *__restrict__, char **__restrict__, locale_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int strcoll_l(const char *s1, const char *s2, locale_t locale){
+int strcoll_l(const char *, const char *, locale_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -369,7 +369,7 @@ int ptsname_r(int fd, char *buffer, size_t length) {
 	int index;
 	if(ioctl(fd, TIOCGPTN, &index))
 		return -1;
-	if(snprintf(buffer, length, "/dev/pts/%d", index) >= length) {
+	if((size_t)snprintf(buffer, length, "/dev/pts/%d", index) >= length) {
 		errno = ERANGE;
 		return -1;
 	}

--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -30,7 +30,6 @@ char *strndup(const char *string, size_t max_size) {
 }
 
 size_t strnlen(const char *s, size_t n) {
-	__ensure(n >= 0);
 	size_t len = 0;
 	while(len < n && s[len])
 		++len;

--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -416,6 +416,7 @@ struct __mlibc_key_data {
 
 int pthread_key_create(pthread_key_t *out_key, void (*destructor) (void *)) {
 	SCOPE_TRACE();
+	(void)destructor;
 	// TODO: Invoke the destructor on thread exit.
 	*out_key = frg::construct<__mlibc_key_data>(getAllocator());
 	return 0;
@@ -758,6 +759,7 @@ int pthread_cond_wait(pthread_cond_t *__restrict cond, pthread_mutex_t *__restri
 		__ensure(!"Failed to lock the mutex");
 	return 0;
 }
+
 int pthread_cond_timedwait(pthread_cond_t *__restrict, pthread_mutex_t *__restrict,
 		const struct timespec *__restrict) {
 	__ensure(!"Not implemented");

--- a/options/posix/generic/sched-stubs.cpp
+++ b/options/posix/generic/sched-stubs.cpp
@@ -20,17 +20,17 @@ int sched_getaffinity(pid_t, size_t, cpu_set_t *) {
 	return -1;
 }
 
-int __mlibc_cpu_isset(int cpu, cpu_set_t *set) {
+int __mlibc_cpu_isset(int, cpu_set_t *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int __mlibc_cpu_count(cpu_set_t *set) {
+int __mlibc_cpu_count(cpu_set_t *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int unshare(int flags) {
+int unshare(int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/search.cpp
+++ b/options/posix/generic/search.cpp
@@ -111,16 +111,19 @@ void *tfind(const void *key, void *const *rootp, int (*compar)(const void *, con
 }
 
 void *tdelete(const void *, void **, int(*compar)(const void *, const void *)) {
+	(void)compar;
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
 void twalk(const void *, void (*action)(const void *, VISIT, int)) {
+	(void)action;
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
 void tdestroy(void *, void (*free_node)(void *)) {
+	(void)free_node;
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/semaphore-stubs.cpp
+++ b/options/posix/generic/semaphore-stubs.cpp
@@ -25,7 +25,7 @@ int sem_init(sem_t *sem, int pshared, unsigned int initial_count) {
 	return 0;
 }
 
-int sem_destroy(sem_t *sem) {
+int sem_destroy(sem_t *) {
 	return 0;
 }
 

--- a/options/posix/generic/spawn-stubs.cpp
+++ b/options/posix/generic/spawn-stubs.cpp
@@ -199,7 +199,7 @@ int posix_spawn(pid_t *__restrict res, const char *__restrict path,
 	sigset_t full_sigset;
 	sigfillset(&full_sigset);
 
-	//pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
 
 	args.path = path;
 	args.fa = file_actions;
@@ -244,7 +244,7 @@ int posix_spawn(pid_t *__restrict res, const char *__restrict path,
 
 fail:
 	pthread_sigmask(SIG_SETMASK, &args.oldmask, 0);
-	//pthread_setcancelstate(cs, 0);
+	pthread_setcancelstate(cs, 0);
 
 	return ec;
 }

--- a/options/posix/generic/spawn-stubs.cpp
+++ b/options/posix/generic/spawn-stubs.cpp
@@ -254,7 +254,7 @@ int posix_spawnattr_init(posix_spawnattr_t *attr) {
 	return 0;
 }
 
-int posix_spawnattr_destroy(posix_spawnattr_t *attr) {
+int posix_spawnattr_destroy(posix_spawnattr_t *) {
 	return 0;
 }
 
@@ -280,13 +280,13 @@ int posix_spawnattr_setsigdefault(posix_spawnattr_t *__restrict attr,
 	return 0;
 }
 
-int posix_spawnattr_setschedparam(posix_spawnattr_t *__restrict attr,
-		const struct sched_param *__restrict schedparam) {
+int posix_spawnattr_setschedparam(posix_spawnattr_t *__restrict,
+		const struct sched_param *__restrict) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int posix_spawnattr_setschedpolicy(posix_spawnattr_t *attr, int schedpolicy) {
+int posix_spawnattr_setschedpolicy(posix_spawnattr_t *, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/spawn-stubs.cpp
+++ b/options/posix/generic/spawn-stubs.cpp
@@ -53,7 +53,7 @@ struct args {
 
 static int child(void *args_vp) {
 	int i, ret;
-	struct sigaction sa = {0};
+	struct sigaction sa = {};
 	struct args *args = (struct args *)args_vp;
 	int p = args->p[1];
 	const posix_spawn_file_actions_t *fa = args->fa;
@@ -195,7 +195,7 @@ int posix_spawn(pid_t *__restrict res, const char *__restrict path,
 	pid_t pid;
 	int ec = 0, cs;
 	struct args args;
-	const posix_spawnattr_t empty_attr = {0};
+	const posix_spawnattr_t empty_attr = {};
 	sigset_t full_sigset;
 	sigfillset(&full_sigset);
 
@@ -250,7 +250,7 @@ fail:
 }
 
 int posix_spawnattr_init(posix_spawnattr_t *attr) {
-	*attr = (posix_spawnattr_t){0};
+	*attr = (posix_spawnattr_t){};
 	return 0;
 }
 
@@ -367,7 +367,7 @@ int posix_spawnp(pid_t *__restrict pid, const char *__restrict file,
 		const posix_spawn_file_actions_t *file_actions,
 		const posix_spawnattr_t *__restrict attrp,
 		char *const argv[], char *const envp[]) {
-	posix_spawnattr_t spawnp_attr = { 0 };
+	posix_spawnattr_t spawnp_attr = {};
 	if(attrp)
 		spawnp_attr = *attrp;
 	spawnp_attr.__fn = (void *)execvpe;	

--- a/options/posix/generic/strings-stubs.cpp
+++ b/options/posix/generic/strings-stubs.cpp
@@ -13,7 +13,7 @@ char *rindex(const char *s, int c) {
 	return strrchr(s, c);
 }
 
-int ffs(int word) {
+int ffs(int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/sys-select-stubs.cpp
+++ b/options/posix/generic/sys-select-stubs.cpp
@@ -36,7 +36,7 @@ int select(int num_fds, fd_set *__restrict read_set, fd_set *__restrict write_se
 	}
 
 	int num_events = 0;
-	struct timespec timeouts = {0};
+	struct timespec timeouts = {};
 	struct timespec *timeout_ptr = NULL;
 	if (timeout) {
 		timeouts.tv_sec = timeout->tv_sec;

--- a/options/posix/generic/sys-socket-stubs.cpp
+++ b/options/posix/generic/sys-socket-stubs.cpp
@@ -143,7 +143,7 @@ ssize_t recvmsg(int fd, struct msghdr *hdr, int flags) {
 	return length;
 }
 
-int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout) {
+int recvmmsg(int, struct mmsghdr *, unsigned int, int, struct timespec *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -181,7 +181,7 @@ ssize_t sendmsg(int fd, const struct msghdr *hdr, int flags) {
 	return length;
 }
 
-int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags) {
+int sendmmsg(int, struct mmsghdr *, unsigned int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/sys-time-stubs.cpp
+++ b/options/posix/generic/sys-time-stubs.cpp
@@ -21,22 +21,22 @@ int gettimeofday(struct timeval *__restrict result, void *__restrict unused) {
 	return 0;
 }
 
-void timeradd(struct timeval *a, struct timeval *b, struct timeval *res) {
+void timeradd(struct timeval *, struct timeval *, struct timeval *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-void timersub(struct timeval *a, struct timeval *b, struct timeval *res) {
+void timersub(struct timeval *, struct timeval *, struct timeval *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-void timerclear(struct timeval *tvp) {
+void timerclear(struct timeval *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-int timerisset(struct timeval *tvp) {
+int timerisset(struct timeval *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/sys-uio.cpp
+++ b/options/posix/generic/sys-uio.cpp
@@ -47,12 +47,12 @@ ssize_t writev(int fd, const struct iovec *iovs, int iovc) {
 	return written;
 }
 
-ssize_t preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+ssize_t preadv(int, const struct iovec *, int, off_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset) {
+ssize_t pwritev(int, const struct iovec *, int, off_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/sys-wait-stubs.cpp
+++ b/options/posix/generic/sys-wait-stubs.cpp
@@ -6,7 +6,7 @@
 #include <mlibc/posix-sysdeps.hpp>
 #include <mlibc/debug.hpp>
 
-int waitid(idtype_t idtype, id_t id, siginfo_t *siginfo, int flags) {
+int waitid(idtype_t, id_t, siginfo_t *, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -34,7 +34,7 @@ pid_t wait3(int *, int, struct rusage *) {
 	__builtin_unreachable();
 }
 
-pid_t wait4(pid_t pid, int *status, int options, struct rusage *ru){
+pid_t wait4(pid_t pid, int *status, int options, struct rusage *){
 	mlibc::infoLogger() << "\e[31mmlibc: wait4() is not implemented correctly\e[39m"
 		<< frg::endlog;
 	return waitpid(pid, status, options);

--- a/options/posix/generic/syslog-stubs.cpp
+++ b/options/posix/generic/syslog-stubs.cpp
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <time.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <bits/ensure.h>
@@ -135,8 +136,8 @@ void vsyslog(int priority, const char *message, va_list ap) {
 		mlibc::infoLogger() << "\e[31mmlibc: syslog: log_mask or priority out of range, not printing anything\e[39m" << frg::endlog;
 		return;
 	}
-	//pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
 	frg::unique_lock<FutexLock> lock(__syslog_lock);
 	_vsyslog(priority, message, ap);
-	//pthread_setcancelstate(cs, 0);
+	pthread_setcancelstate(cs, 0);
 }

--- a/options/posix/generic/syslog-stubs.cpp
+++ b/options/posix/generic/syslog-stubs.cpp
@@ -101,7 +101,7 @@ static void _vsyslog(int priority, const char *message, va_list ap) {
 	errno = errno_save;
 	l2 = vsnprintf(buf + l, sizeof buf - l, message, ap);
 	if(l2 >= 0) {
-		if(l2 >= sizeof buf - l)
+		if(l2 >= (long int)(sizeof buf - l))
 			l = sizeof buf - 1;
 		else
 			l += l2;

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -436,6 +436,7 @@ int lockf(int fd, int op, off_t size) {
 			return -1;
 		case F_ULOCK:
 			l.l_type = F_UNLCK;
+			[[fallthrough]];
 		case F_TLOCK:
 			return fcntl(fd, F_SETLK, &l);
 		case F_LOCK:

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -420,7 +420,9 @@ int lockf(int fd, int op, off_t size) {
 	struct flock l = {
 		.l_type = F_WRLCK,
 		.l_whence = SEEK_CUR,
+		.l_start = 0,
 		.l_len = size,
+		.l_pid = 0,
 	};
 
 	switch(op) {

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -820,7 +820,7 @@ char *getpass(const char *prompt) {
 
 	l = read(fdin, password, sizeof password);
 	if(l >= 0) {
-		if(l > 0 && password[l - 1] == '\n' || l == sizeof password)
+		if((l > 0 && password[l - 1] == '\n') || l == sizeof password)
 			l--;
 		password[l] = 0;
 	}

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -14,7 +14,7 @@
 #include <mlibc/debug.hpp>
 #include <mlibc/posix-sysdeps.hpp>
 
-unsigned int alarm(unsigned int seconds) {
+unsigned int alarm(unsigned int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -45,7 +45,7 @@ int fchdir(int fd) {
 	return 0;
 }
 
-int chown(const char *path, uid_t uid, gid_t gid) {
+int chown(const char *, uid_t, gid_t) {
 	mlibc::infoLogger() << "\e[31mmlibc: chown() is not implemented correctly\e[39m"
 			<< frg::endlog;
 	return 0;
@@ -70,9 +70,12 @@ ssize_t confstr(int name, char *buf, size_t len) {
 void _exit(int status) {
 	mlibc::sys_exit(status);
 }
-void encrypt(char block[64], int flags) {
+
+void encrypt(char[64], int) {
 	__ensure(!"Not implemented");
+	__builtin_unreachable();
 }
+
 int execl(const char *path, const char *arg0, ...) {
 	// TODO: It's a stupid idea to limit the number of arguments here.
 	char *argv[16];
@@ -93,10 +96,12 @@ int execl(const char *path, const char *arg0, ...) {
 
 	return execve(path, argv, environ);
 }
+
 int execle(const char *, const char *, ...) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int execlp(const char *, const char *, ...) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -190,13 +195,13 @@ int faccessat(int dirfd, const char *pathname, int mode, int flags) {
 	return 0;
 }
 
-int fchown(int fd, uid_t uid, gid_t gid) {
+int fchown(int, uid_t, gid_t) {
 	mlibc::infoLogger() << "\e[31mmlibc: fchown() is not implemented correctly\e[39m"
 			<< frg::endlog;
 	return 0;
 }
 
-int fchownat(int fd, const char *path, uid_t uid, gid_t gid, int flags) {
+int fchownat(int, const char *, uid_t, gid_t, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -218,6 +223,7 @@ int fexecve(int, char *const [], char *const []) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 long fpathconf(int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -248,6 +254,7 @@ int ftruncate(int fd, off_t size) {
 	}
 	return 0;
 }
+
 char *getcwd(char *buffer, size_t size) {
 	__ensure(buffer && "glibc extension for !buffer is not implemented");
 	if(!mlibc::sys_getcwd) {
@@ -261,10 +268,12 @@ char *getcwd(char *buffer, size_t size) {
 	}
 	return buffer;
 }
+
 int getgroups(int, gid_t []) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 long gethostid(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -375,7 +384,7 @@ pid_t getsid(pid_t pid) {
 	return sid;
 }
 
-int lchown(const char *path, uid_t uid, gid_t gid) {
+int lchown(const char *, uid_t, gid_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -439,7 +448,8 @@ int nice(int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-long pathconf(const char *path, int name) {
+
+long pathconf(const char *, int name) {
 	switch (name) {
 	case _PC_NAME_MAX:
 		return NAME_MAX;
@@ -449,6 +459,7 @@ long pathconf(const char *path, int name) {
 		return -1;
 	}
 }
+
 int pause(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -595,10 +606,12 @@ int setregid(gid_t, gid_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int setreuid(uid_t, uid_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 pid_t setsid(void) {
 	if(!mlibc::sys_setsid) {
 		MLIBC_MISSING_SYSDEP();
@@ -627,7 +640,9 @@ int setuid(uid_t uid) {
 
 void swab(const void *__restrict, void *__restrict, ssize_t) {
 	__ensure(!"Not implemented");
+	__builtin_unreachable();
 }
+
 int symlink(const char *target_path, const char *link_path) {
 	if(!mlibc::sys_symlink) {
 		MLIBC_MISSING_SYSDEP();
@@ -640,6 +655,7 @@ int symlink(const char *target_path, const char *link_path) {
 	}
 	return 0;
 }
+
 int symlinkat(const char *target_path, int dirfd, const char *link_path) {
 	if(!mlibc::sys_symlinkat) {
 		MLIBC_MISSING_SYSDEP();
@@ -742,6 +758,7 @@ int ttyname_r(int, char *, size_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int unlink(const char *path) {
 	if(!mlibc::sys_unlink) {
 		MLIBC_MISSING_SYSDEP();
@@ -754,6 +771,7 @@ int unlink(const char *path) {
 	}
 	return 0;
 }
+
 int unlinkat(int fd, const char *path, int flags) {
 	if(!mlibc::sys_unlinkat) {
 		MLIBC_MISSING_SYSDEP();

--- a/options/posix/include/sys/socket.h
+++ b/options/posix/include/sys/socket.h
@@ -58,7 +58,7 @@ struct cmsghdr {
 // Returns a pointer to the next header or nullptr if there is none.
 #define CMSG_NXTHDR(m, c) \
 	((c)->cmsg_len < sizeof(struct cmsghdr) || \
-		sizeof(struct cmsghdr) + CMSG_ALIGN((c)->cmsg_len) \
+		(ptrdiff_t)(sizeof(struct cmsghdr) + CMSG_ALIGN((c)->cmsg_len)) \
 			>= __MLIBC_MHDR_LIMIT(m) - (char *)(c) \
 	? (struct cmsghdr *)0 : (struct cmsghdr *)__MLIBC_CMSG_NEXT(c))
 

--- a/options/posix/musl-generic/fnmatch.cpp
+++ b/options/posix/musl-generic/fnmatch.cpp
@@ -32,7 +32,7 @@ static int str_next(const char *str, size_t n, size_t *step)
 		*step = 0;
 		return 0;
 	}
-	if (str[0] >= 128U) {
+	if ((unsigned char)str[0] >= 128U) {
 		wchar_t wc;
 		int k = mbtowc(&wc, str, n);
 		if (k<0) {
@@ -85,7 +85,7 @@ static int pat_next(const char *pat, size_t m, size_t *step, int flags)
 	if (pat[0] == '?')
 		return QUESTION;
 escaped:
-	if (pat[0] >= 128U) {
+	if ((unsigned char)pat[0] >= 128U) {
 		wchar_t wc;
 		int k = mbtowc(&wc, pat, m);
 		if (k<0) {
@@ -127,8 +127,8 @@ static int match_bracket(const char *p, int k, int kfold)
 			int l = mbtowc(&wc2, p+1, 4);
 			if (l < 0) return 0;
 			if (wc <= wc2)
-				if ((unsigned)k-wc <= wc2-wc ||
-				    (unsigned)kfold-wc <= wc2-wc)
+				if ((unsigned)k-wc <= (unsigned)wc2-wc ||
+				    (unsigned)kfold-wc <= (unsigned)wc2-wc)
 					return !inv;
 			p += l-1;
 			continue;
@@ -148,7 +148,7 @@ static int match_bracket(const char *p, int k, int kfold)
 			}
 			continue;
 		}
-		if (*p < 128U) {
+		if ((unsigned char)*p < 128U) {
 			wc = (unsigned char)*p;
 		} else {
 			int l = mbtowc(&wc, p, 4);
@@ -230,7 +230,7 @@ static int fnmatch_internal(const char *pat, size_t m, const char *str, size_t n
 	 * On illegal sequences we may get it wrong, but in that case
 	 * we necessarily have a matching failure anyway. */
 	for (s=endstr; s>str && tailcnt; tailcnt--) {
-		if (s[-1] < 128U || MB_CUR_MAX==1) s--;
+		if ((unsigned char)s[-1] < 128U || MB_CUR_MAX==1) s--;
 		else while ((unsigned char)*--s-0x80U<0x40 && s>str);
 	}
 	if (tailcnt) return FNM_NOMATCH;

--- a/options/posix/musl-generic/glob.cpp
+++ b/options/posix/musl-generic/glob.cpp
@@ -171,7 +171,7 @@ static int do_glob(char *buf, size_t pos, int type, char *pat, int flags, int (*
 	return 0;
 }
 
-static int ignore_err(const char *path, int err)
+static int ignore_err(const char *, int)
 {
 	return 0;
 }

--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -310,6 +310,7 @@ void ObjectRepository::_fetchFromPhdrs(SharedObject *object, void *phdr_pointer,
 			object->tlsAlignment = phdr->p_align;
 			object->tlsImageSize = phdr->p_filesz;
 			tls_offset = phdr->p_vaddr;
+			break;
 		case PT_INTERP:
 			object->interpreterPath = frg::string<MemoryAllocator>{
 				(char*)(object->baseAddress + phdr->p_vaddr),

--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -170,7 +170,7 @@ SharedObject *ObjectRepository::requestObjectWithName(frg::string_view name,
 		if (path.sub_string(0, 7) == "$ORIGIN") {
 			frg::string_view dirname = origin->path;
 			auto lastsl = dirname.find_last('/');
-			if (lastsl != -1) {
+			if (lastsl != (uint64_t)-1) {
 				dirname = dirname.sub_string(0, lastsl);
 			} else {
 				dirname = ".";

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -112,7 +112,7 @@ extern "C" {
 	}
 }
 
-extern "C" [[gnu::alias("dl_debug_state"), gnu::visibility("default")]] void _dl_debug_state();
+extern "C" [[gnu::alias("dl_debug_state"), gnu::visibility("default")]] void _dl_debug_state() noexcept;
 
 // This symbol can be used by GDB to find the global interface structure
 [[ gnu::visibility("default") ]] DebugInterface *_dl_debug_addr = &globalDebugInterface;

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -488,5 +488,7 @@ extern "C" [[ gnu::visibility("default") ]]
 void __dlapi_enter(uintptr_t *entry_stack) {
 #ifdef MLIBC_STATIC_BUILD
 	interpreterMain(entry_stack);
+#else
+	(void)entry_stack;
 #endif
 }

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1211,7 +1211,7 @@ int sys_msg_recv(int sockfd, struct msghdr *hdr, int flags, ssize_t *length) {
 	}
 }
 
-int sys_pselect(int num_fds, fd_set *read_set, fd_set *write_set,
+int sys_pselect(int, fd_set *read_set, fd_set *write_set,
 		fd_set *except_set, const struct timespec *timeout,
 		const sigset_t *sigmask, int *num_events) {
 	// TODO: Do not keep errors from epoll (?).
@@ -1544,7 +1544,7 @@ int sys_timerfd_create(int flags, int *fd) {
 	return 0;
 }
 
-int sys_timerfd_settime(int fd, int flags,
+int sys_timerfd_settime(int fd, int,
 		const struct itimerspec *value) {
 	SignalGuard sguard;
 	HelAction actions[3];
@@ -4115,7 +4115,7 @@ int sys_access(const char *path, int mode) {
 	return sys_faccessat(AT_FDCWD, path, mode, 0);
 }
 
-int sys_faccessat(int dirfd, const char *pathname, int mode, int flags) {
+int sys_faccessat(int dirfd, const char *pathname, int, int flags) {
 	SignalGuard sguard;
 	HelAction actions[3];
 

--- a/sysdeps/managarm/generic/mount.cpp
+++ b/sysdeps/managarm/generic/mount.cpp
@@ -12,7 +12,7 @@
 namespace mlibc {
 
 int sys_mount(const char *source, const char *target,
-		const char *fstype, unsigned long flags, const void *data) {
+		const char *fstype, unsigned long, const void *) {
 	SignalGuard sguard;
 
 	managarm::posix::MountRequest<MemoryAllocator> req(getSysdepsAllocator());

--- a/sysdeps/managarm/generic/time.cpp
+++ b/sysdeps/managarm/generic/time.cpp
@@ -48,7 +48,7 @@ int sys_clock_get(int clock, time_t *secs, long *nanos) {
 		// Calculate the current time.
 		uint64_t tick;
 		HEL_CHECK(helGetClock(&tick));
-		__ensure(tick >= __mlibc_clk_tracker_page->refClock); // TODO: Respect the seqlock!
+		__ensure(tick >= (uint64_t)__mlibc_clk_tracker_page->refClock); // TODO: Respect the seqlock!
 		tick -= ref;
 		tick += base;
 		*secs = tick / 1000000000;

--- a/sysdeps/managarm/include/mlibc/posix-pipe.hpp
+++ b/sysdeps/managarm/include/mlibc/posix-pipe.hpp
@@ -90,6 +90,7 @@ struct Queue {
 
 		// Setup the queue header.
 		HelQueueParameters params {
+			.flags = 0,
 			.ringShift = 1,
 			.numChunks = 2,
 			.chunkSize = 4096

--- a/sysdeps/managarm/rtdl-generic/support.cpp
+++ b/sysdeps/managarm/rtdl-generic/support.cpp
@@ -45,6 +45,7 @@ struct Queue {
 	Queue()
 	: _handle{kHelNullHandle}, _lastProgress(0) {
 		HelQueueParameters params {
+			.flags = 0,
 			.ringShift = 0,
 			.numChunks = 1,
 			.chunkSize = 4096

--- a/sysdeps/managarm/rtdl-generic/support.cpp
+++ b/sysdeps/managarm/rtdl-generic/support.cpp
@@ -182,7 +182,7 @@ int sys_tcb_set(void *pointer) {
 	return 0;
 }
 
-int sys_open(const char *path, int flags, int *fd) {
+int sys_open(const char *path, int, int *fd) {
 	cacheFileTable();
 	HelAction actions[4];
 


### PR DESCRIPTION
This PR aims to fix all warnings in the directories listed below, either by fixing or ignoring the warning in special cases. Furthermore, it adds `-Wall` and `-Wextra` to the global project flags.

Directories checked in this PR:
- `options/ansi`,
- `options/elf`,
- `options/glibc`,
- `options/internal`,
- `options/linux`,
- `options/lsb`,
- `options/posix`,
- `options/rtdl`,
- `sysdeps/managarm`.
