### PR TITLE
posix: Implement and stub more functions for shadow to function

### DIFF
--- a/options/posix/generic/grp-stubs.cpp
+++ b/options/posix/generic/grp-stubs.cpp
@@ -250,8 +250,8 @@ int setgroups(size_t, const gid_t *) {
 }
 
 int initgroups(const char *, gid_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "mlibc: initgroups is a stub" << frg::endlog;
+	return 0;
 }
 
 int putgrent(const struct group *, FILE *) {

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -97,9 +97,24 @@ int execl(const char *path, const char *arg0, ...) {
 	return execve(path, argv, environ);
 }
 
-int execle(const char *, const char *, ...) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+// This function is taken from musl.
+int execle(const char *path, const char *arg0, ...) {
+	int argc;
+	va_list ap;
+	va_start(ap, arg0);
+	for(argc = 1; va_arg(ap, const char *); argc++);
+	va_end(ap);
+
+	int i;
+	char *argv[argc + 1];
+	char **envp;
+	va_start(ap, arg0);
+	argv[0] = (char *)argv;
+	for(i = 1; i <= argc; i++)
+		argv[i] = va_arg(ap, char *);
+	envp = va_arg(ap, char **);
+	va_end(ap);
+	return execve(path, argv, envp);
 }
 
 int execlp(const char *, const char *, ...) {


### PR DESCRIPTION
This PR stubs `initgroups()` and implements `execle()` like musl. With this, I can run `su --login managarm` on Managarm to become the managarm user.