### PR TITLE
Various changes to compile and run WebKitGTK

### DIFF
--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -413,3 +413,8 @@ int strverscmp(const char *l0, const char *r0) {
 
 	return l[i] - r[i];
 }
+
+void *memmem(const void *, size_t, const void *, size_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -349,9 +349,17 @@ int nanosleep(const struct timespec *req, struct timespec *) {
 	}
 }
 
-int clock_getres(clockid_t, struct timespec *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int clock_getres(clockid_t clockid, struct timespec *res) {
+	if(!mlibc::sys_clock_getres) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_clock_getres(clockid, &res->tv_sec, &res->tv_nsec); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int clock_gettime(clockid_t clock, struct timespec *time) {

--- a/options/ansi/include/mlibc/ansi-sysdeps.hpp
+++ b/options/ansi/include/mlibc/ansi-sysdeps.hpp
@@ -33,6 +33,7 @@ int sys_seek(int fd, off_t offset, int whence, off_t *new_offset);
 int sys_close(int fd);
 
 int sys_clock_get(int clock, time_t *secs, long *nanos);
+[[gnu::weak]] int sys_clock_getres(int clock, time_t *secs, long *nanos);
 [[gnu::weak]] int sys_sleep(time_t *secs, long *nanos);
 // In contrast to the isatty() library function, the sysdep function uses return value
 // zero (and not one) to indicate that the file is a terminal.

--- a/options/ansi/include/string.h
+++ b/options/ansi/include/string.h
@@ -59,6 +59,7 @@ char *stpcpy(char *__restrict, const char *__restrict);
 int strverscmp(const char *l0, const char *r0);
 int ffsl(long i);
 int ffsll(long long i);
+void *memmem(const void *, size_t, const void *, size_t);
 
 #ifdef __cplusplus
 }

--- a/options/internal/include/bits/types.h
+++ b/options/internal/include/bits/types.h
@@ -25,6 +25,9 @@ typedef __INT64_TYPE__ __mlibc_int64;
 #	define __MLIBC_UINT16_C(x) __MLIBC_C_JOIN(x, __UINT16_C_SUFFIX__)
 #	define __MLIBC_UINT32_C(x) __MLIBC_C_JOIN(x, __UINT32_C_SUFFIX__)
 #	define __MLIBC_UINT64_C(x) __MLIBC_C_JOIN(x, __UINT64_C_SUFFIX__)
+
+#	define __MLIBC_INTMAX_C(x) __MLIBC_C_JOIN(x, __INTMAX_C_SUFFIX__)
+#	define __MLIBC_UINTMAX_C(x) __MLIBC_C_JOIN(x, __UINTMAX_C_SUFFIX__)
 #else
 #	define __MLIBC_INT8_C(x)  __INT8_C(x)
 #	define __MLIBC_INT16_C(x) __INT16_C(x)
@@ -35,6 +38,9 @@ typedef __INT64_TYPE__ __mlibc_int64;
 #	define __MLIBC_UINT16_C(x) __UINT16_C(x)
 #	define __MLIBC_UINT32_C(x) __UINT32_C(x)
 #	define __MLIBC_UINT64_C(x) __UINT64_C(x)
+
+#	define __MLIBC_INTMAX_C(x) __INTMAX_C(x)
+#	define __MLIBC_UINTMAX_C(x) __UINTMAX_C(x)
 #endif
 
 #define __MLIBC_INT8_MAX  __INT8_MAX__

--- a/options/internal/include/mlibc/internal-sysdeps.hpp
+++ b/options/internal/include/mlibc/internal-sysdeps.hpp
@@ -18,7 +18,7 @@ void sys_libc_log(const char *message);
 int sys_tcb_set(void *pointer);
 
 [[gnu::weak]] int sys_futex_tid();
-int sys_futex_wait(int *pointer, int expected);
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time);
 int sys_futex_wake(int *pointer);
 
 int sys_anon_allocate(size_t size, void **pointer);

--- a/options/internal/include/mlibc/lock.hpp
+++ b/options/internal/include/mlibc/lock.hpp
@@ -27,7 +27,7 @@ struct FutexLock {
 				}
 			}else{
 				if(expected & waitersBit) {
-					if(int e = mlibc::sys_futex_wait(&_futex, expected); e)
+					if(int e = mlibc::sys_futex_wait(&_futex, expected, nullptr); e)
 						__ensure(!"sys_futex_wait() failed");
 
 					expected = 0;

--- a/options/internal/include/stdint.h
+++ b/options/internal/include/stdint.h
@@ -61,12 +61,14 @@ typedef __mlibc_uintptr uintptr_t;
 #define INT16_C(x) __MLIBC_INT16_C(x)
 #define INT32_C(x) __MLIBC_INT32_C(x)
 #define INT64_C(x) __MLIBC_INT64_C(x)
+#define INTMAX_C(x) __MLIBC_INTMAX_C(x)
 
 // Fixed-width (unsigned).
 #define UINT8_C(x)  __MLIBC_UINT8_C(x)
 #define UINT16_C(x) __MLIBC_UINT16_C(x)
 #define UINT32_C(x) __MLIBC_UINT32_C(x)
 #define UINT64_C(x) __MLIBC_UINT64_C(x)
+#define UINTMAX_C(x) __MLIBC_UINTMAX_C(x)
 
 // ----------------------------------------------------------------------------
 // Limits.

--- a/options/posix/generic/grp-stubs.cpp
+++ b/options/posix/generic/grp-stubs.cpp
@@ -7,6 +7,7 @@
 #include <bits/ensure.h>
 
 #include <mlibc/debug.hpp>
+#include <mlibc/posix-sysdeps.hpp>
 
 namespace {
 	thread_local group global_entry;
@@ -244,9 +245,17 @@ void setgrent(void) {
 	__builtin_unreachable();
 }
 
-int setgroups(size_t, const gid_t *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int setgroups(size_t size, const gid_t *list) {
+	if(!mlibc::sys_setgroups) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_setgroups(size, list); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int initgroups(const char *, gid_t) {
@@ -265,6 +274,6 @@ struct group *fgetgrent(FILE *) {
 }
 
 int getgrouplist(const char *, gid_t, gid_t *, int *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "mlibc: getgrouplist is a stub" << frg::endlog;
+	return 0;
 }

--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -71,6 +71,7 @@ static constexpr unsigned int rc_waiters_bit = static_cast<uint32_t>(1) << 31;
 int pthread_attr_init(pthread_attr_t *) {
 	return 0;
 }
+
 int pthread_attr_destroy(pthread_attr_t *) {
 	return 0;
 }
@@ -79,6 +80,7 @@ int pthread_attr_getdetachstate(const pthread_attr_t *, int *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int pthread_attr_setdetachstate(pthread_attr_t *, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -88,6 +90,7 @@ int pthread_attr_getstacksize(const pthread_attr_t *__restrict, size_t *__restri
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int pthread_attr_setstacksize(pthread_attr_t *, size_t) {
 	mlibc::infoLogger() << "mlibc: pthread_attr_setstacksize() is not implemented correctly" << frg::endlog;
 	return 0;
@@ -97,15 +100,48 @@ int pthread_attr_getguardsize(const pthread_attr_t *__restrict, size_t *__restri
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int pthread_attr_setguardsize(pthread_attr_t *, size_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int pthread_attr_getscope(const pthread_attr_t *, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
 int pthread_attr_setscope(pthread_attr_t *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_getschedpolicy(const pthread_attr_t *__restrict, int *__restrict) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_setschedpolicy(pthread_attr_t *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_getschedparam(const pthread_attr_t *__restrict, struct sched_param *__restrict) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_setschedparam(pthread_attr_t *__restrict, const struct sched_param *__restrict) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_getinheritsched(const pthread_attr_t *__restrict, int *__restrict) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_setinheritsched(pthread_attr_t *, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
@@ -267,10 +303,36 @@ void pthread_cleanup_pop(int execute) {
 }
 
 int pthread_setname_np(pthread_t, const char *) {
+	mlibc::infoLogger() << "mlibc: pthread_setname_np is a stub" << frg::endlog;
+	return 0;
+}
+
+int pthread_getname_np(pthread_t, char *, size_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-int pthread_getname_np(pthread_t, char *, size_t) {
+
+int pthread_attr_setstack(pthread_attr_t *, void *, size_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_attr_getstack(const pthread_attr_t *, void **, size_t *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_getattr_np(pthread_t, pthread_attr_t *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_setschedparam(pthread_t, int, const struct sched_param *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int pthread_getschedparam(pthread_t, int *, struct sched_param *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/generic/semaphore-stubs.cpp
+++ b/options/posix/generic/semaphore-stubs.cpp
@@ -36,7 +36,7 @@ int sem_wait(sem_t *sem) {
 		if (!(state & semaphoreCountMask)) {
 			if (__atomic_compare_exchange_n(&sem->__mlibc_count, &state, semaphoreHasWaiters,
 						false, __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE)) {
-				if(int e = mlibc::sys_futex_wait((int *)&sem->__mlibc_count, state); e)
+				if(int e = mlibc::sys_futex_wait((int *)&sem->__mlibc_count, state, nullptr); e)
 					__ensure(!"sys_futex_wait() failed");
 			}
 		} else {

--- a/options/posix/generic/sys-mman-stubs.cpp
+++ b/options/posix/generic/sys-mman-stubs.cpp
@@ -1,5 +1,8 @@
 
 #include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <unistd.h>
 #include <sys/mman.h>
 #include <bits/ensure.h>
 
@@ -89,4 +92,41 @@ int munmap(void *pointer, size_t size) {
 	return 0;
 }
 
+// The implementation of shm_open and shm_unlink is taken from musl.
+namespace {
+	char *shm_mapname(const char *name, char *buf) {
+		char *p;
+		while(*name == '/')
+			name++;
+		if(*(p = strchrnul(name, '/')) || p == name ||
+			(p - name <= 2 && name[0] == '.' && p[-1] == '.')) {
+			errno = EINVAL;
+			return 0;
+		}
+		if(p - name > NAME_MAX) {
+			errno = ENAMETOOLONG;
+			return 0;
+		}
+		memcpy(buf, "/dev/shm/", 9);
+		memcpy(buf + 9, name, p - name + 1);
+		return buf;
+	}
+}
 
+int shm_open(const char *name, int flags, mode_t mode) {
+	int cs;
+	char buf[NAME_MAX + 10];
+	if(!(name = shm_mapname(name, buf)))
+		return -1;
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	int fd = open(name, flags | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, mode);
+	pthread_setcancelstate(cs, 0);
+	return fd;
+}
+
+int shm_unlink(const char *name) {
+	char buf[NAME_MAX + 10];
+	if(!(name = shm_mapname(name, buf)))
+		return -1;
+	return unlink(name);
+}

--- a/options/posix/generic/sys-statfs-stubs.cpp
+++ b/options/posix/generic/sys-statfs-stubs.cpp
@@ -1,10 +1,22 @@
 
+#include <errno.h>
 #include <sys/statfs.h>
 #include <bits/ensure.h>
 
-int statfs(const char *, struct statfs *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+#include <mlibc/debug.hpp>
+#include <mlibc/posix-sysdeps.hpp>
+
+int statfs(const char *path, struct statfs *buf) {
+	if(!mlibc::sys_statfs) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_statfs(path, buf); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int fstatfs(int, struct statfs *) {

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -20,6 +20,7 @@
 #include <sys/resource.h>
 #include <sys/select.h>
 #include <sys/statvfs.h>
+#include <sys/statfs.h>
 #include <termios.h>
 #include <time.h>
 #include <ucontext.h>
@@ -165,6 +166,8 @@ int sys_vm_unmap(void *pointer, size_t size);
 [[gnu::weak]] int sys_fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flags);
 [[gnu::weak]] int sys_sigaltstack(const stack_t *ss, stack_t *oss);
 [[gnu::weak]] int sys_sigsuspend(const sigset_t *set);
+[[gnu::weak]] int sys_setgroups(size_t size, const gid_t *list);
+[[gnu::weak]] int sys_statfs(const char *path, struct statfs *buf);
 
 } //namespace mlibc
 

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -30,7 +30,7 @@ namespace [[gnu::visibility("hidden")]] mlibc {
 void sys_libc_log(const char *message);
 [[noreturn]] void sys_libc_panic();
 
-int sys_futex_wait(int *pointer, int expected);
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time);
 int sys_futex_wake(int *pointer);
 
 [[noreturn]] void sys_exit(int status);

--- a/options/posix/include/pthread.h
+++ b/options/posix/include/pthread.h
@@ -58,6 +58,9 @@ extern "C" {
 #define PTHREAD_KEYS_MAX 1024
 #define PTHREAD_DESTRUCTOR_ITERATIONS 8
 
+#define PTHREAD_INHERIT_SCHED 0
+#define PTHREAD_EXPLICIT_SCHED 1
+
 // TODO: move to own file and include in sys/types.h
 struct __mlibc_threadattr {
 	// TODO: the guardsize attribute needs to be supported here.
@@ -139,6 +142,15 @@ int pthread_attr_setguardsize(pthread_attr_t *, size_t);
 int pthread_attr_getscope(const pthread_attr_t *, int);
 int pthread_attr_setscope(pthread_attr_t *, int);
 
+int pthread_attr_getschedpolicy(const pthread_attr_t *__restrict, int *__restrict);
+int pthread_attr_setschedpolicy(pthread_attr_t *, int);
+
+int pthread_attr_getschedparam(const pthread_attr_t *__restrict, struct sched_param *__restrict);
+int pthread_attr_setschedparam(pthread_attr_t *__restrict, const struct sched_param *__restrict);
+
+int pthread_attr_getinheritsched(const pthread_attr_t *__restrict, int *__restrict);
+int pthread_attr_setinheritsched(pthread_attr_t *, int);
+
 // pthread functions.
 int pthread_create(pthread_t *__restrict, const pthread_attr_t *__restrict,
 		void *(*) (void *), void *__restrict);
@@ -154,6 +166,14 @@ void pthread_cleanup_pop(int);
 
 int pthread_setname_np(pthread_t, const char *);
 int pthread_getname_np(pthread_t, char *, size_t);
+
+int pthread_attr_setstack(pthread_attr_t *, void *, size_t);
+int pthread_attr_getstack(const pthread_attr_t *, void **, size_t *);
+
+int pthread_getattr_np(pthread_t, pthread_attr_t *);
+
+int pthread_setschedparam(pthread_t, int, const struct sched_param *);
+int pthread_getschedparam(pthread_t, int *, struct sched_param *);
 
 int pthread_setcanceltype(int, int *);
 int pthread_setcancelstate(int, int *);

--- a/options/posix/include/sys/mman.h
+++ b/options/posix/include/sys/mman.h
@@ -1,12 +1,14 @@
 #ifndef _SYS_MMAN_H
 #define _SYS_MMAN_H
 
+#include <abi-bits/mode_t.h>
 #include <abi-bits/vm-flags.h>
 #include <bits/off_t.h>
 #include <bits/size_t.h>
 
 #define MAP_FAILED ((void *)(-1))
 
+#define MAP_FILE 0
 #define MS_ASYNC 0x01
 #define MS_SYNC 0x02
 #define MS_INVALIDATE 0x04
@@ -41,6 +43,9 @@ int munlockall(void);
 
 int posix_madvise(void *, size_t, int);
 int msync(void *, size_t, int);
+
+int shm_open(const char *, int, mode_t);
+int shm_unlink(const char *);
 
 // Linux extension:
 void *mremap(void *, size_t, size_t, int, ...);

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -411,6 +411,7 @@ void *__dlapi_resolve(void *handle, const char *string) {
 
 	if (!target) {
 		mlibc::infoLogger() << "rtdl: could not resolve \"" << string << "\"" << frg::endlog;
+		lastError = "Cannot resolve requested symbol";
 		return nullptr;
 	}
 	return reinterpret_cast<void *>(target->virtualAddress());

--- a/sysdeps/dripos/generic/generic.cpp
+++ b/sysdeps/dripos/generic/generic.cpp
@@ -183,7 +183,7 @@ int sys_vm_unmap(void *pointer, size_t size) {
     return sys_anon_free(pointer, size);
 }
 
-int sys_futex_wait(int *pointer, int expected) {
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time) {
     uint64_t err;
     asm volatile ("syscall"
             : "=d"(err)

--- a/sysdeps/dripos/generic/thread.cpp
+++ b/sysdeps/dripos/generic/thread.cpp
@@ -9,7 +9,7 @@
 extern "C" void __mlibc_enter_thread(void *entry, void *user_arg, Tcb *tcb) {
 	// Wait until our parent sets up the TID.
 	while(!__atomic_load_n(&tcb->tid, __ATOMIC_RELAXED))
-		mlibc::sys_futex_wait(&tcb->tid, 0);
+		mlibc::sys_futex_wait(&tcb->tid, 0, nullptr);
 
 	if(mlibc::sys_tcb_set(tcb))
 		__ensure(!"sys_tcb_set() failed");

--- a/sysdeps/lemon/generic/lemon.cpp
+++ b/sysdeps/lemon/generic/lemon.cpp
@@ -14,7 +14,7 @@ int sys_futex_tid(){
 	return syscall(SYS_GETTID);
 }
 
-int sys_futex_wait(int *pointer, int expected){
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time){
 	return syscall(SYS_FUTEX_WAIT, pointer, expected);
 }
 

--- a/sysdeps/lemon/generic/thread.cpp
+++ b/sysdeps/lemon/generic/thread.cpp
@@ -9,7 +9,7 @@
 extern "C" void __mlibc_enter_thread(void *entry, void *user_arg, Tcb *tcb) {
 	// Wait until our parent sets up the TID.
 	while(!__atomic_load_n(&tcb->tid, __ATOMIC_RELAXED))
-		mlibc::sys_futex_wait(&tcb->tid, 0);
+		mlibc::sys_futex_wait(&tcb->tid, 0, nullptr);
 
 	if(mlibc::sys_tcb_set(tcb))
 		__ensure(!"sys_tcb_set() failed");

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -449,8 +449,8 @@ void sys_exit(int status) {
 #define FUTEX_WAIT 0
 #define FUTEX_WAKE 1
 
-int sys_futex_wait(int *pointer, int expected) {
-	auto ret = do_cp_syscall(NR_sys_futex, pointer, FUTEX_WAIT, expected, nullptr);
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time) {
+	auto ret = do_cp_syscall(NR_sys_futex, pointer, FUTEX_WAIT, expected, time);
 	if (int e = sc_error(ret); e)
 		return e;
 	return 0;

--- a/sysdeps/linux/x86_64/thread.cpp
+++ b/sysdeps/linux/x86_64/thread.cpp
@@ -17,7 +17,7 @@ extern "C" void __mlibc_enter_thread(void *entry, void *user_arg) {
 
 	// Wait until our parent sets up the TID.
 	while(!__atomic_load_n(&tcb->tid, __ATOMIC_RELAXED))
-		mlibc::sys_futex_wait(&tcb->tid, 0);
+		mlibc::sys_futex_wait(&tcb->tid, 0, nullptr);
 
 	void *(*func)(void *) = reinterpret_cast<void *(*)(void *)>(entry);
 	auto result = func(user_arg);

--- a/sysdeps/managarm/aarch64/thread.cpp
+++ b/sysdeps/managarm/aarch64/thread.cpp
@@ -9,7 +9,7 @@
 extern "C" void __mlibc_enter_thread(void *entry, void *user_arg, Tcb *tcb) {
 	// Wait until our parent sets up the TID.
 	while(!__atomic_load_n(&tcb->tid, __ATOMIC_RELAXED))
-		mlibc::sys_futex_wait(&tcb->tid, 0);
+		mlibc::sys_futex_wait(&tcb->tid, 0, nullptr);
 
 	if(mlibc::sys_tcb_set(tcb))
 		__ensure(!"sys_tcb_set() failed");

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -4415,5 +4415,10 @@ int sys_gethostname(char *buffer, size_t bufsize) {
 	return 0;
 }
 
+int sys_fsync(int) {
+	mlibc::infoLogger() << "mlibc: fsync is a stub" << frg::endlog;
+	return 0;
+}
+
 } //namespace mlibc
 

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -48,8 +48,13 @@ int sys_futex_tid() {
 	return resp.pid();
 }
 
-int sys_futex_wait(int *pointer, int expected) {
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time) {
 	// This implementation is inherently signal-safe.
+	if(time) {
+		if(helFutexWait(pointer, expected, time->tv_nsec + time->tv_sec * 1000000000))
+			return -1;
+		return 0;
+	}
 	if(helFutexWait(pointer, expected, -1))
 		return -1;
 	return 0;

--- a/sysdeps/managarm/generic/signals.cpp
+++ b/sysdeps/managarm/generic/signals.cpp
@@ -45,10 +45,10 @@ int sys_sigaction(int number, const struct sigaction *__restrict action,
 
 	managarm::posix::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
 	req.set_request_type(managarm::posix::CntReqType::SIG_ACTION);
+	req.set_sig_number(number);
 	if(action) {
 		req.set_mode(1);
 		req.set_flags(action->sa_flags);
-		req.set_sig_number(number);
 		req.set_sig_mask(action->sa_mask);
 		if(action->sa_flags & SA_SIGINFO) {
 			req.set_sig_handler(reinterpret_cast<uintptr_t>(action->sa_sigaction));
@@ -56,6 +56,8 @@ int sys_sigaction(int number, const struct sigaction *__restrict action,
 			req.set_sig_handler(reinterpret_cast<uintptr_t>(action->sa_handler));
 		}
 		req.set_sig_restorer(reinterpret_cast<uintptr_t>(&__mlibc_signal_restore));
+	} else {
+		req.set_mode(0);
 	}
 
 	frg::string<MemoryAllocator> ser(getSysdepsAllocator());

--- a/sysdeps/managarm/rtdl-generic/support.cpp
+++ b/sysdeps/managarm/rtdl-generic/support.cpp
@@ -444,8 +444,13 @@ int sys_futex_tid() {
 	return resp.pid();
 }
 
-int sys_futex_wait(int *pointer, int expected) {
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time) {
 	// This implementation is inherently signal-safe.
+	if(time) {
+		if(helFutexWait(pointer, expected, time->tv_nsec + time->tv_sec * 1000000000))
+			return -1;
+		return 0;
+	}
 	if(helFutexWait(pointer, expected, -1))
 		return -1;
 	return 0;

--- a/sysdeps/managarm/x86_64/thread.cpp
+++ b/sysdeps/managarm/x86_64/thread.cpp
@@ -9,7 +9,7 @@
 extern "C" void __mlibc_enter_thread(void *entry, void *user_arg, Tcb *tcb) {
 	// Wait until our parent sets up the TID.
 	while(!__atomic_load_n(&tcb->tid, __ATOMIC_RELAXED))
-		mlibc::sys_futex_wait(&tcb->tid, 0);
+		mlibc::sys_futex_wait(&tcb->tid, 0, nullptr);
 
 	if(mlibc::sys_tcb_set(tcb))
 		__ensure(!"sys_tcb_set() failed");

--- a/sysdeps/qword/generic/generic.cpp
+++ b/sysdeps/qword/generic/generic.cpp
@@ -326,7 +326,7 @@ int sys_sigaction(int signum, const struct sigaction *act, struct sigaction *old
 }
 #endif
 
-int sys_futex_wait(int *pointer, int expected) {
+int sys_futex_wait(int *pointer, int expected, const struct timespec *time) {
     int ret;
     int sys_errno;
     asm volatile ("syscall"

--- a/sysdeps/sigma/generic/generic.cpp
+++ b/sysdeps/sigma/generic/generic.cpp
@@ -37,7 +37,7 @@ namespace mlibc {
     #endif
 
     // TODO: Actually implement this
-    int sys_futex_wait(int *pointer, int expected){
+    int sys_futex_wait(int *pointer, int expected, const struct timespec *time){
         return 0;
     }
 


### PR DESCRIPTION
This PR adds the necessary functions and definitions to compile `WebKitGTK` on Managarm. So far, it consists of a bunch of stubs, mostly in pthread related code, 2 new macro's, a bugfix in rtdl and improved handling of arguments in `sys_sigaction` for Managarm. It is missing some ucontext related things, but I heard @Geertiebear was working on that, which is why I left that out.

~~This PR remains in draft until the porting of `WebKitGTK` has finished.~~ As this PR is getting big, and considering the fact it contains bugfixes and enables `GTK+3` to work, I've marked this as ready for review. If needed, a second PR can finish off the support for `WebKitGTK`.

This PR is blocked on managarm/managarm#393