### PR TITLE
options/posix: Stub getloadavg

### DIFF
--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -463,3 +463,8 @@ int strcoll_l(const char *, const char *, locale_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+int getloadavg(double *, int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/include/bits/posix/posix_stdlib.h
+++ b/options/posix/include/bits/posix/posix_stdlib.h
@@ -47,6 +47,8 @@ double strtod_l(const char *__restrict__ nptr, char ** __restrict__ endptr, loca
 long double strtold_l(const char *__restrict__ nptr, char ** __restrict__ endptr, locale_t loc);
 float strtof_l(const char *__restrict string, char **__restrict end, locale_t loc);
 
+int getloadavg(double *, int);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is required for `ninja` to compile. I thought this was already upstreamed in a different PR but apparently I was wrong.