### PR TITLE
Add several stubs and implement `getdtablesize()`

### DIFF
--- a/options/glibc/generic/shadow-stubs.cpp
+++ b/options/glibc/generic/shadow-stubs.cpp
@@ -31,3 +31,8 @@ struct spwd *getspnam(const char *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+void endspent(void) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/glibc/include/shadow.h
+++ b/options/glibc/include/shadow.h
@@ -27,6 +27,7 @@ int putspent(const struct spwd *, FILE *);
 int lckpwdf(void);
 int ulckpwdf(void);
 struct spwd *getspnam(const char *);
+void endspent(void);
 
 #ifdef __cplusplus
 }

--- a/options/linux/generic/linux-unistd.cpp
+++ b/options/linux/generic/linux-unistd.cpp
@@ -1,6 +1,8 @@
 #include <bits/linux/linux_unistd.h>
 #include <bits/ensure.h>
 
+#include <unistd.h>
+
 int dup3(int, int, int) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
@@ -9,4 +11,8 @@ int dup3(int, int, int) {
 int vhangup(void) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
+}
+
+int getdtablesize(void){
+	return sysconf(_SC_OPEN_MAX);
 }

--- a/options/linux/generic/utmp-stubs.cpp
+++ b/options/linux/generic/utmp-stubs.cpp
@@ -20,3 +20,8 @@ struct utmp *pututline(const struct utmp *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+struct utmp *getutline(const struct utmp *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/include/bits/linux/linux_unistd.h
+++ b/options/linux/include/bits/linux/linux_unistd.h
@@ -7,6 +7,7 @@ extern "C" {
 
 int dup3(int fd, int newfd, int flags);
 int vhangup(void);
+int getdtablesize(void);
 
 #ifdef __cplusplus
 }

--- a/options/linux/include/utmp.h
+++ b/options/linux/include/utmp.h
@@ -61,6 +61,7 @@ void setutent(void);
 struct utmp *getutent(void);
 void endutent(void);
 struct utmp *pututline(const struct utmp *);
+struct utmp *getutline(const struct utmp *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Does what it says on the tin. However, `getdtablesize()` does only return the arbitrary value that sysconf returns.