### PR TITLE
meson.build: Make sure only first clang search dir is grabbed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,7 +67,7 @@ if not headers_only
 	elif c_compiler.get_id() == 'clang'
 		clangdir = run_command('/bin/sh', '-c',
 			' '.join(c_compiler.cmd_array())
-					+ ' -print-search-dirs | sed -ne "s/libraries: =\(.*\):.*/\\1/p"',
+					+ ' -print-search-dirs | sed -ne "s/libraries: =\([^:]*\).*/\\1/p"',
 			env: ['LANG=C'],
 			check: true).stdout().strip()
 


### PR DESCRIPTION
The regex only works when there is two search dirs. It would previously grab anything before the last `:`.