### PR TITLE
Hi. Can I contribute this to mainstream for thread-safety of stdio?

### DIFF
--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -1118,12 +1118,12 @@ int vasprintf(char **out, const char *format, __gnuc_va_list args) {
 
 // Linux unlocked I/O extensions.
 
-void flockfile(FILE *) {
-	mlibc::infoLogger() << "mlibc: File locking (flockfile) is a no-op" << frg::endlog;
+void flockfile(FILE *file_base) {
+	static_cast<mlibc::abstract_file *>(file_base)->_lock.lock();
 }
 
-void funlockfile(FILE *) {
-	mlibc::infoLogger() << "mlibc: File locking (funlockfile) is a no-op" << frg::endlog;
+void funlockfile(FILE *file_base) {
+	static_cast<mlibc::abstract_file *>(file_base)->_lock.unlock();
 }
 
 int ftrylockfile(FILE *) {


### PR DESCRIPTION
Although ftrylockfile cannot be implemented without FutexLock adds a try_lock() method.

Also i do not know whether it would cause a self dead lock