### PR TITLE
Fix getdelim and annotate fallthroughs

### DIFF
--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -470,7 +470,7 @@ static int do_scanf(H &handler, const char *fmt, __gnuc_va_list args) {
             case 'd':
             case 'u':
                 base = 10;
-                /* fallthrough */
+                [[fallthrough]];
             case 'i': {
                 unsigned long long res = 0;
                 char c = handler.look_ahead();

--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -1045,7 +1045,9 @@ ssize_t getdelim(char **line, size_t *n, int delim, FILE *stream) {
 	}
 
 	char *buffer = *line;
-	size_t capacity = *n, nwritten = 0;
+	/* set the starting capacity to 512 if buffer = NULL */
+	size_t capacity = (!buffer) ? 512 : *n;
+	size_t nwritten = 0;
 
 	auto file = static_cast<mlibc::abstract_file *>(stream);
 	frg::unique_lock<FutexLock> lock(file->_lock);

--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -536,7 +536,7 @@ void ObjectRepository::_parseDynamic(SharedObject *object) {
 			break;
 		case DT_RPATH:
 			mlibc::infoLogger() << "\e[31mrtdl: RUNPATH not preferred over RPATH properly\e[39m" << frg::endlog;
-			// fall through
+			[[fallthrough]];
 		case DT_RUNPATH:
 			runpath_offset = dynamic->d_un.d_val;
 			break;
@@ -553,6 +553,7 @@ void ObjectRepository::_parseDynamic(SharedObject *object) {
 			break;
 		case DT_DEBUG:
 			dynamic->d_un.d_val = reinterpret_cast<Elf64_Xword>(&globalDebugInterface);
+			break;
 		// ignore unimportant tags
 		case DT_SONAME: case DT_NEEDED: // we handle this later
 		case DT_FINI: case DT_FINI_ARRAY: case DT_FINI_ARRAYSZ:

--- a/tests/posix/getdelim.c
+++ b/tests/posix/getdelim.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <unistd.h>
+#include <string.h>
 
 #define TEST_FILE "getdelim.tmp"
 
@@ -50,6 +51,29 @@ int main(void) {
 
 	assert(getdelim(&line, &len, 'b', fp) == -1);
 	assert(feof(fp));
+
+	free(line);
+	fclose(fp);
+
+	fp = fopen(TEST_FILE, "w");
+	assert(fp);
+	assert(fwrite("1234ef\0f", 1, 8, fp) == 8);
+	fclose(fp);
+
+	fp = fopen(TEST_FILE, "r");
+	assert(fp);
+
+	/* test with line = NULL and large len */
+	line = NULL;
+	len = (size_t) ~0;
+	assert(getdelim(&line, &len, 'e', fp) == 5);
+	assert(!memcmp(line, "1234e", 6));
+	assert(5 < len);
+
+	/* test handling of EOF */
+	assert(getdelim(&line, &len, 'e', fp) == -1);
+	assert(!memcmp(line, "f\0f", 4));
+	assert(3 < len);
 
 	free(line);
 	fclose(fp);


### PR DESCRIPTION
This fixes minor issues with `getdelim` that prevented `xbps-reconfigure` from running for some. Fallthroughs were annotated or `break`s added, where appropriate.