### PR TITLE
linux-headers: Add TCSETSF

### DIFF
--- a/options/linux-headers/include/asm/ioctls.h
+++ b/options/linux-headers/include/asm/ioctls.h
@@ -5,6 +5,7 @@
 
 #define TCGETS 0x5401
 #define TCSETS 0x5402
+#define TCSETSF 0x5404
 #define TIOCSCTTY 0x540E
 #define TIOCSTI 0x5412
 #define TIOCGWINSZ 0x5413


### PR DESCRIPTION
After merging this, Aero can drop the hardcoded hack from their sysdeps.