### PR TITLE
options/glibc: Add empty in_systm header to fix the cups port

### DIFF
--- a/options/glibc/include/netinet/in_systm.h
+++ b/options/glibc/include/netinet/in_systm.h
@@ -1,0 +1,7 @@
+
+#ifndef _NETINET_IN_SYSTM_H
+#define _NETINET_IN_SYSTM_H
+
+
+
+#endif // _NETINET_IN_SYSTM_H

--- a/options/glibc/meson.build
+++ b/options/glibc/meson.build
@@ -25,5 +25,9 @@ if not no_headers
 		'include/sys/ioctl.h',
 		subdir: 'sys'
 	)
+	install_headers(
+		'include/netinet/in_systm.h',
+		subdir: 'netinet'
+	)
 endif
 


### PR DESCRIPTION
`cups` really wants `netinet/in_systm.h` to exist, but it doesn't need anything from it. Provide an empty file to make it happy.