### PR TITLE
Various fixes on the way to wine

### DIFF
--- a/abis/mlibc/in.h
+++ b/abis/mlibc/in.h
@@ -89,6 +89,8 @@ struct group_source_req {
 #define IPPROTO_RAW 4
 #define IPPROTO_TCP 5
 #define IPPROTO_UDP 6
+#define IPPROTO_IGMP 7
+#define IPPROTO_IPIP 8
 #define IPPROTO_ESP 50
 #define IPPROTO_AH 51
 

--- a/abis/mlibc/in.h
+++ b/abis/mlibc/in.h
@@ -126,6 +126,8 @@ struct group_source_req {
 #define IP_MULTICAST_LOOP         34
 #define IP_ADD_MEMBERSHIP         35
 #define IP_DROP_MEMBERSHIP        36
+#define IP_UNBLOCK_SOURCE         37
+#define IP_BLOCK_SOURCE           38
 #define IP_ADD_SOURCE_MEMBERSHIP  39
 #define IP_DROP_SOURCE_MEMBERSHIP 40
 #define MCAST_JOIN_SOURCE_GROUP   46

--- a/options/linux-headers/include/asm/ioctls.h
+++ b/options/linux-headers/include/asm/ioctls.h
@@ -11,6 +11,7 @@
 #define TIOCSTI 0x5412
 #define TIOCGWINSZ 0x5413
 #define TIOCMGET 0x5415
+#define TIOCMSET 0x5418
 #define TIOCNOTTY 0x5422
 
 #define TIOCGPTN _IOR('T', 0x30, unsigned int)

--- a/options/linux-headers/include/linux/sockios.h
+++ b/options/linux-headers/include/linux/sockios.h
@@ -6,10 +6,10 @@
 extern "C" {
 #endif
 
+#define SIOCATMARK 0x8905
 #define SIOCGSTAMP 0x8906
 #define SIOCADDRT 0x890B
 #define SIOCDELRT 0x890C
-
 #define SIOCGIFNAME 0x8910
 #define SIOCSIFLINK 0x8911
 #define SIOCGIFCONF 0x8912

--- a/options/linux/generic/ifaddrs.cpp
+++ b/options/linux/generic/ifaddrs.cpp
@@ -1,0 +1,15 @@
+#include <bits/ensure.h>
+#include <mlibc/debug.hpp>
+#include <ifaddrs.h>
+#include <errno.h>
+
+int getifaddrs(struct ifaddrs **) {
+	mlibc::infoLogger() << "mlibc: getifaddrs fails unconditionally!" << frg::endlog;
+	errno = ENOSYS;
+	return -1;
+}
+
+void freeifaddrs(struct ifaddrs *) {
+	mlibc::infoLogger() << "mlibc: freeifaddrs is a stub!" << frg::endlog;
+	return;
+}

--- a/options/linux/include/ifaddrs.h
+++ b/options/linux/include/ifaddrs.h
@@ -21,6 +21,9 @@ struct ifaddrs {
 	void *ifa_data;
 };
 
+int getifaddrs(struct ifaddrs **);
+void freeifaddrs(struct ifaddrs *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -23,6 +23,7 @@ libc_sources += files(
 	'generic/linux-unistd.cpp',
 	'generic/malloc.cpp',
 	'generic/sys-fsuid.cpp',
+	'generic/ifaddrs.cpp',
 )
 
 if not no_headers

--- a/options/posix/include/bits/posix/posix_signal.h
+++ b/options/posix/include/bits/posix/posix_signal.h
@@ -12,6 +12,18 @@ extern "C" {
 #include <bits/sigset_t.h>
 #include <stddef.h>
 
+#define FPE_INTDIV      1       /* integer divide by zero */
+#define FPE_INTOVF      2       /* integer overflow */
+#define FPE_FLTDIV      3       /* floating point divide by zero */
+#define FPE_FLTOVF      4       /* floating point overflow */
+#define FPE_FLTUND      5       /* floating point underflow */
+#define FPE_FLTRES      6       /* floating point inexact result */
+#define FPE_FLTINV      7       /* floating point invalid operation */
+#define FPE_FLTSUB      8       /* subscript out of range */
+
+#define TRAP_BRKPT      1       /* process breakpoint */
+#define TRAP_TRACE      2       /* process trace trap */
+
 typedef struct __ucontext {
         unsigned long uc_flags;
         struct __ucontext *uc_link;

--- a/options/posix/include/dlfcn.h
+++ b/options/posix/include/dlfcn.h
@@ -11,6 +11,8 @@
 #define RTLD_NEXT ((void *)-1)
 #define RTLD_DEFAULT ((void *)0)
 
+#define RTLD_DI_LINKMAP 2
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This PR adds various constants, defines, structs and functions that `wine` requires. It certainly isn’t everything but this can already get reviewed and merged.

Has an abi-break counterpart in #452, which is not required for this to be merged, but is required for wine.
Also includes some fixes for Chromium incidentially, so part of the Chromium on Managarm project.