### PR TITLE
Small fixes to fix CI

### DIFF
--- a/options/glibc/meson.build
+++ b/options/glibc/meson.build
@@ -29,9 +29,12 @@ if not no_headers
 		subdir: 'sys'
 	)
 	install_headers(
-		'include/netinet/in_systm.h',
 		'include/net/ethernet.h',
 		subdir: 'net'
+	)
+	install_headers(
+		'include/netinet/in_systm.h',
+		subdir: 'netinet'
 	)
 endif
 

--- a/options/linux-headers/include/linux/ip.h
+++ b/options/linux-headers/include/linux/ip.h
@@ -1,6 +1,19 @@
 #ifndef _LINUX_IP_H
 #define _LINUX_IP_H
 
+#include <stdint.h>
 
+struct iphdr {
+	uint8_t ihl:4, version:4;
+	uint8_t tos;
+	uint16_t tot_len;
+	uint16_t id;
+	uint16_t frag_off;
+	uint8_t ttl;
+	uint8_t protocol;
+	uint16_t check;
+	uint32_t saddr;
+	uint32_t daddr;
+};
 
 #endif


### PR DESCRIPTION
This PR fixes an error in 060b995c318c2fb08e88525815a32719f5236b81 where the installation directory of `in_systm.h` was inadvertently changed to go to the wrong location, breaking the `cups` port. It also adds a `struct iphdr` to the `ip.h` linux kernel header in order to satisfy `qemu` picking up said header and wanting to use its contents.