### PR TITLE
options/{posix,glibc} changes for unzip

### DIFF
--- a/options/glibc/include/sys/dir.h
+++ b/options/glibc/include/sys/dir.h
@@ -1,0 +1,8 @@
+#ifndef _SYS_DIR_H
+#define _SYS_DIR_H
+
+#include <dirent.h>
+
+#define direct  dirent
+
+#endif

--- a/options/glibc/meson.build
+++ b/options/glibc/meson.build
@@ -25,6 +25,7 @@ if not no_headers
 		'include/gshadow.h'
 	)
 	install_headers(
+		'include/sys/dir.h',
 		'include/sys/ioctl.h',
 		subdir: 'sys'
 	)

--- a/options/posix/generic/termios-stubs.cpp
+++ b/options/posix/generic/termios-stubs.cpp
@@ -20,9 +20,15 @@ int cfsetospeed(struct termios *, speed_t) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
-void cfmakeraw(struct termios *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+
+void cfmakeraw(struct termios *t) {
+	t->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	t->c_oflag &= ~OPOST;
+	t->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	t->c_cflag &= ~(CSIZE | PARENB);
+	t->c_cflag |= CS8;
+	t->c_cc[VMIN] = 1;
+	t->c_cc[VTIME] = 0;
 }
 
 int tcdrain(int fd) {


### PR DESCRIPTION
This PR adds the `sys/dir.h` header, as found on Linux and is required for `unzip` to compile. It also implements `cfmakeraw()`, which allows `links` to progress further.