### PR TITLE
rtdl: initialize tls objects for new threads

### DIFF
--- a/options/rtdl/generic/linker.hpp
+++ b/options/rtdl/generic/linker.hpp
@@ -196,6 +196,7 @@ struct RuntimeTlsMap {
 extern frg::manual_box<RuntimeTlsMap> runtimeTlsMap;
 
 Tcb *allocateTcb();
+void initTlsObjects(Tcb *tcb, const frg::vector<SharedObject *, MemoryAllocator> &objects, bool checkInitialized);
 void *accessDtv(SharedObject *object);
 // Tries to access the DTV, if not allocated, or object doesn't have
 // PT_TLS, return nullptr.

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -101,7 +101,9 @@ extern "C" void *lazyRelocate(SharedObject *object, unsigned int rel_index) {
 }
 
 extern "C" [[ gnu::visibility("default") ]] void *__rtdl_allocateTcb() {
-	return allocateTcb();
+	auto tcb = allocateTcb();
+	initTlsObjects(tcb, globalScope->_objects, false);
+	return tcb;
 }
 
 extern "C" {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,6 +31,7 @@ posix_test_cases = [
 	'pthread_cleanup',
 	'pthread_kill',
 	'pthread_key',
+	'pthread_thread_local',
 	'pwd',
 	'getaddrinfo',
 	'getdelim',

--- a/tests/posix/pthread_thread_local.c
+++ b/tests/posix/pthread_thread_local.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <pthread.h>
+#include <assert.h>
+ 
+_Thread_local unsigned int rage = 9999; 
+_Thread_local unsigned int uninitialized;
+ 
+void *check_rage(void *arg)
+{
+	(void)arg;
+    fprintf(stderr, "Rage counter for thread a: %d\n", rage, &rage);
+	fflush(stderr);
+	assert(rage == 9999);
+	assert(uninitialized == 0);
+
+	++rage;
+	++uninitialized;
+    fprintf(stderr, "Rage counter for thread a: %d\n", rage);
+	fflush(stderr);
+	assert(rage == 10000);
+	assert(uninitialized == 1);
+	return NULL;
+}
+ 
+int main()
+{
+    fprintf(stderr, "Rage counter for main: %d\n", rage);
+	fflush(stderr);
+	assert(rage == 9999);
+	assert(uninitialized == 0);
+
+	++rage;
+	++uninitialized;
+    fprintf(stderr, "Rage counter for main: %d\n", rage);
+	fflush(stderr);
+	assert(rage == 10000);
+	assert(uninitialized == 1);
+
+	pthread_t thd;
+	pthread_create(&thd, NULL, check_rage, NULL);
+	pthread_join(thd, NULL);
+
+    fprintf(stderr, "Rage counter for main: %d\n", rage);
+	fflush(stderr);
+	assert(rage == 10000);
+	assert(uninitialized == 1);
+}


### PR DESCRIPTION
Fixes managarm/mlibc#389.

This still leaves the issue of managarm/mlibc#393, which might be trickier to fix.