### PR TITLE
options/posix: Implement memrchr

### DIFF
--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -121,7 +121,13 @@ char *strndupa(const char *, size_t) {
 	__builtin_unreachable();
 }
 
-void *memrchr(const void *, int, size_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+// This implementation was taken from musl
+void *memrchr(const void *m, int c, size_t n) {
+	const unsigned char *s = (const unsigned char *)m;
+	c = (unsigned char)c;
+	while(n--) {
+		if(s[n] == c)
+			return (void *)(s + n);
+	}
+	return 0;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -50,7 +50,8 @@ posix_test_cases = [
 	'sigaltstack',
 	'realpath',
 	'ffs',
-	'getcwd'
+	'getcwd',
+	'memrchr'
 ]
 
 posix_fail_test_cases = [

--- a/tests/posix/memrchr.c
+++ b/tests/posix/memrchr.c
@@ -1,0 +1,23 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+int main () {
+	char str[] = "The Last Supper by Leonardo da Vinci";
+	char *str_temp;
+
+	// Test strstr
+	str_temp = strstr(str, "Supper"); /* Find a substring in the string */
+	assert(!strcmp(str_temp, "Supper by Leonardo da Vinci"));
+
+	/* Following calls use memory APIs for the above tasks */
+	// Test memchr
+	str_temp = (char *)memchr((void *)str, 'L', strlen(str));
+	assert(!strcmp(str_temp, "Last Supper by Leonardo da Vinci"));
+
+	// Test memrchr
+	str_temp = (char *)memrchr((void *)str, 'L', strlen(str));
+	assert(!strcmp(str_temp, "Leonardo da Vinci"));
+	return 0;
+}


### PR DESCRIPTION
This PR implements `memrchr()` which is apparently used by `grep` now that is available.