### PR TITLE
options/posix: Implement execlp

### DIFF
--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -123,9 +123,24 @@ int execle(const char *path, const char *arg0, ...) {
 	return execve(path, argv, envp);
 }
 
-int execlp(const char *, const char *, ...) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+// This function is taken from musl
+int execlp(const char *file, const char *argv0, ...) {
+	int argc;
+	va_list ap;
+	va_start(ap, argv0);
+	for(argc = 1; va_arg(ap, const char *); argc++);
+	va_end(ap);
+	{
+		int i;
+		char *argv[argc + 1];
+		va_start(ap, argv0);
+		argv[0] = (char *)argv0;
+		for(i = 1; i < argc; i++)
+			argv[i] = va_arg(ap, char *);
+		argv[i] = NULL;
+		va_end(ap);
+		return execvp(file, argv);
+	}
 }
 
 int execv(const char *path, char *const argv[]) {


### PR DESCRIPTION
This PR implements `execlp()` which is needed for `havoc`.