### PR TITLE
Various additions for ffmpeg to compile

### DIFF
--- a/options/ansi/include/inttypes.h
+++ b/options/ansi/include/inttypes.h
@@ -96,6 +96,10 @@
 #define SCNx64 "lx"
 #define SCNxMAX "lx"
 
+#define SCNi8 "hhi"
+#define SCNi64 "li"
+
+#define SCNd32 "d"
 #define SCNd64 "ld"
 
 #ifdef __cplusplus

--- a/options/linux/generic/malloc.cpp
+++ b/options/linux/generic/malloc.cpp
@@ -5,3 +5,8 @@ size_t malloc_usable_size(void *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+void *memalign(size_t, size_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/generic/sched-stubs.cpp
+++ b/options/posix/generic/sched-stubs.cpp
@@ -20,6 +20,16 @@ int sched_getaffinity(pid_t, size_t, cpu_set_t *) {
 	return -1;
 }
 
+int sched_get_priority_max(int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int sched_get_priority_min(int) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
 int __mlibc_cpu_isset(int, cpu_set_t *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -804,6 +804,10 @@ unsigned long sysconf(int number) {
 #else
 			return -1;
 #endif
+		case _SC_NPROCESSORS_CONF:
+			// TODO: actually return a proper value for _SC_NPROCESSORS_CONF
+			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_NPROCESSORS_CONF) unconditionally returns 1\e[39m" << frg::endlog;
+			return 1;
 		default:
 			mlibc::panicLogger() << "\e[31mmlibc: sysconf() call is not implemented, number: " << number << "\e[39m" << frg::endlog;
 			__builtin_unreachable();

--- a/options/posix/include/netinet/tcp.h
+++ b/options/posix/include/netinet/tcp.h
@@ -7,6 +7,7 @@ extern "C" {
 
 // Define some macros using same ABI as Linux
 #define TCP_NODELAY 1
+#define TCP_MAXSEG 2
 
 #ifdef __cplusplus
 }

--- a/options/posix/include/sched.h
+++ b/options/posix/include/sched.h
@@ -62,6 +62,9 @@ typedef struct __mlibc_cpu_set cpu_set_t;
 
 int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
 
+int sched_get_priority_max(int policy);
+int sched_get_priority_min(int policy);
+
 int unshare(int flags);
 
 int __mlibc_cpu_isset(int cpu, cpu_set_t *set);

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -120,6 +120,7 @@ extern "C" {
 #define _SC_HOST_NAME_MAX 14
 #define _SC_LINE_MAX 15
 #define _SC_XOPEN_CRYPT 16
+#define _SC_NPROCESSORS_CONF 17
 
 #define STDERR_FILENO 2
 #define STDIN_FILENO 0

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -4303,8 +4303,12 @@ int sys_ftruncate(int fd, size_t size) {
 
 	managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
-	__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
-	return 0;
+	if(resp.error() == managarm::fs::Errors::ILLEGAL_OPERATION_TARGET) {
+		return EINVAL;
+	} else {
+		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
+		return 0;
+	}
 }
 
 int sys_fallocate(int fd, off_t offset, size_t size) {


### PR DESCRIPTION
This PR adds a few small stubs and defines that `ffmpeg` uses. It also adds a missing error handling case to Managarm's `sys_ftruncate()`.