### PR TITLE
Various fixes to allow fuse3 to compile

### DIFF
--- a/abis/linux/x86_64/wait.h
+++ b/abis/linux/x86_64/wait.h
@@ -8,6 +8,8 @@
 #define WCONTINUED 8
 #define WNOWAIT 0x01000000
 
+#define __WCLONE 0x80000000
+
 #define WCOREFLAG 0x80
 
 #define WEXITSTATUS(x) (((x) & 0xff00) >> 8)

--- a/abis/mlibc/wait.h
+++ b/abis/mlibc/wait.h
@@ -8,6 +8,8 @@
 #define WNOWAIT 16
 #define WSTOPPED 32
 
+#define __WCLONE 0x80000000
+
 #define WCOREFLAG 0x80
 
 #define WEXITSTATUS(x) ((x) & 0x000000FF)

--- a/options/linux/generic/sys-fsuid.cpp
+++ b/options/linux/generic/sys-fsuid.cpp
@@ -1,0 +1,12 @@
+#include <bits/ensure.h>
+#include <sys/fsuid.h>
+
+int setfsuid(uid_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int setfsgid(gid_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/linux/include/sys/fsuid.h
+++ b/options/linux/include/sys/fsuid.h
@@ -1,0 +1,18 @@
+#ifndef _SYS_FSUID_H
+#define _SYS_FSUID_H
+
+#include <abi-bits/uid_t.h>
+#include <abi-bits/gid_t.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int setfsuid(uid_t uid);
+int setfsgid(gid_t gid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _SYS_FSUID_H

--- a/options/linux/include/sys/mount.h
+++ b/options/linux/include/sys/mount.h
@@ -6,6 +6,12 @@ extern "C" {
 #endif
 
 #define MS_BIND 1
+#define MS_RDONLY 2
+#define MS_NOSUID 4
+#define MS_NODEV 8
+#define MS_NOEXEC 16
+#define MS_SYNCHRONOUS 32
+#define MS_NOATIME 64
 
 int mount(const char *source, const char *target,
 		const char *fstype, unsigned long flags, const void *data);

--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -22,6 +22,7 @@ libc_sources += files(
 	'generic/utmpx.cpp',
 	'generic/linux-unistd.cpp',
 	'generic/malloc.cpp',
+	'generic/sys-fsuid.cpp',
 )
 
 if not no_headers
@@ -58,6 +59,7 @@ if not no_headers
 		'include/sys/timerfd.h',
 		'include/sys/eventfd.h',
 		'include/sys/reboot.h',
+		'include/sys/fsuid.h',
 		subdir: 'sys'
 	)
 endif


### PR DESCRIPTION
This PR adds some definitions and 2 new stubs that allows `fuse3` to compile, provided some parts related to capabilities and cloning with namespaces are `#ifdef` out.