### PR TITLE
options/posix: Implement pwrite

### DIFF
--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -588,9 +588,19 @@ ssize_t pread(int fd, void *buf, size_t n, off_t off) {
 	return num_read;
 }
 
-ssize_t pwrite(int, const void *, size_t, off_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+ssize_t pwrite(int fd, const void *buf, size_t n, off_t off) {
+	ssize_t num_written;
+
+	if(!mlibc::sys_pwrite) {
+		MLIBC_MISSING_SYSDEP();
+		errno = ENOSYS;
+		return -1;
+	}
+	if(int e = mlibc::sys_pwrite(fd, buf, n, off, &num_written); e) {
+		errno = e;
+		return -1;
+	}
+	return num_written;
 }
 
 ssize_t readlink(const char *__restrict path, char *__restrict buffer, size_t max_size) {

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -49,6 +49,7 @@ int sys_read(int fd, void *buf, size_t count, ssize_t *bytes_read);
 
 int sys_write(int fd, const void *buf, size_t count, ssize_t *bytes_written);
 [[gnu::weak]] int sys_pread(int fd, void *buf, size_t n, off_t off, ssize_t *bytes_read);
+[[gnu::weak]] int sys_pwrite(int fd, const void *buf, size_t n, off_t off, ssize_t *bytes_read);
 
 int sys_seek(int fd, off_t offset, int whence, off_t *new_offset);
 int sys_close(int fd);


### PR DESCRIPTION
This PR implements `pwrite()` as a sysdep, and adds an implementation of `sys_pwrite()` to the Managarm sysdeps.

Blocked on managarm/managarm#430