### PR TITLE
posix: multiple resolv.conf entries, avoid ipv6 failure on dns functions

### DIFF
--- a/options/posix/include/mlibc/resolv_conf.hpp
+++ b/options/posix/include/mlibc/resolv_conf.hpp
@@ -10,11 +10,15 @@ namespace mlibc {
 struct nameserver_data {
 	nameserver_data()
 	: name(getAllocator()) {}
+	nameserver_data(const char *name_, int af_)
+	: name(name_, getAllocator()), af(af_) {}
+
 	frg::string<MemoryAllocator> name;
+	int af;
 	// for in the future we can also store options here
 };
 
-frg::optional<struct nameserver_data> get_nameserver();
+frg::optional<struct nameserver_data> get_nameserver(int idx);
 
 } // namespace mlibc
 


### PR DESCRIPTION
* Allow any resolv.conf entry to be retrieved.
* Allow only IPV4 resolv.conf entries on lookup_name_dns() and lookup_addr_dns().
* If one resolv.conf entry doesn't work on lookup_nane_dns() and lookup_addr_dns(), use the next one.