### PR TITLE
More work towards shadow support

### DIFF
--- a/options/glibc/generic/shadow-stubs.cpp
+++ b/options/glibc/generic/shadow-stubs.cpp
@@ -1,9 +1,24 @@
 #include <shadow.h>
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 #include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 
-// Code taken from musl
+/*
+ * The code in this file is largely based on or taken from musl.
+ * This includes:
+ * - xatol
+ * - __parsespent
+ * - cleanup
+ * - getspnam_r
+ * - getspnam
+ */
 #define NUM(n) ((n) == -1 ? 0 : -1), ((n) == -1 ? 0 : (n))
 
 int putspent(const struct spwd *sp, FILE *f) {
@@ -17,6 +32,150 @@ int putspent(const struct spwd *sp, FILE *f) {
 }
 #undef NUM
 
+static long xatol(char **s) {
+	long x;
+	if(**s == ':' || **s == '\n') {
+		return -1;
+	}
+	for(x = 0; (unsigned int)**s - '0' < 10U; ++*s) {
+		x = 10 * x + (**s - '0');
+	}
+	return x;
+}
+
+static int __parsespent(char *s, struct spwd *sp) {
+	sp->sp_namp = s;
+	if(!(s = strchr(s, ':'))) {
+		return -1;
+	}
+	*s = 0;
+
+	sp->sp_pwdp = ++s;
+	if(!(s = strchr(s, ':'))) {
+		return -1;
+	}
+	*s = 0;
+
+	s++;
+	sp->sp_lstchg = xatol(&s);
+	if(*s != ':') {
+		return -1;
+	}
+
+	s++;
+	sp->sp_min = xatol(&s);
+	if(*s != ':') {
+		return -1;
+	}
+
+	s++;
+	sp->sp_max = xatol(&s);
+	if(*s != ':') {
+		return -1;
+	}
+
+	s++;
+	sp->sp_warn = xatol(&s);
+	if(*s != ':') {
+		return -1;
+	}
+
+	s++;
+	sp->sp_inact = xatol(&s);
+	if(*s != ':') {
+		return -1;
+	}
+
+	s++;
+	sp->sp_expire = xatol(&s);
+	if(*s != ':') {
+		return -1;
+	}
+
+	s++;
+	sp->sp_flag = xatol(&s);
+	if(*s != '\n') {
+		return -1;
+	}
+	return 0;
+}
+
+static void cleanup(void *p) {
+	fclose((FILE *)p);
+}
+
+int getspnam_r(const char *name, struct spwd *sp, char *buf, size_t size, struct spwd **res) {
+	char path[20 + NAME_MAX];
+	FILE *f = 0;
+	int rv = 0;
+	int fd;
+	size_t k, l = strlen(name);
+	int skip = 0;
+	int cs;
+	int orig_errno = errno;
+
+	*res = 0;
+
+	/* Disallow potentially-malicious user names */
+	if(*name=='.' || strchr(name, '/') || !l) {
+		return errno = EINVAL;
+	}
+
+	/* Buffer size must at least be able to hold name, plus some.. */
+	if(size < l + 100) {
+		return errno = ERANGE;
+	}
+
+	/* Protect against truncation */
+	if(snprintf(path, sizeof path, "/etc/tcb/%s/shadow", name) >= (int)sizeof path) {
+		return errno = EINVAL;
+	}
+
+	fd = open(path, O_RDONLY|O_NOFOLLOW|O_NONBLOCK|O_CLOEXEC);
+	if(fd >= 0) {
+		struct stat st = {};
+		errno = EINVAL;
+		if(fstat(fd, &st) || !S_ISREG(st.st_mode) || !(f = fdopen(fd, "rb"))) {
+			pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+			close(fd);
+			pthread_setcancelstate(cs, 0);
+			return errno;
+		}
+	} else {
+		if(errno != ENOENT && errno != ENOTDIR) {
+			return errno;
+		}
+		f = fopen("/etc/shadow", "rbe");
+		if(!f) {
+			if(errno != ENOENT && errno != ENOTDIR) {
+				return errno;
+			}
+			return 0;
+		}
+	}
+
+	pthread_cleanup_push(cleanup, f);
+	while(fgets(buf, size, f) && (k = strlen(buf)) > 0) {
+		if(skip || strncmp(name, buf, l) || buf[l] != ':') {
+			skip = buf[k - 1] != '\n';
+			continue;
+		}
+		if(buf[k - 1] != '\n') {
+			rv = ERANGE;
+			break;
+		}
+
+		if(__parsespent(buf, sp) < 0) {
+			continue;
+		}
+		*res = sp;
+		break;
+	}
+	pthread_cleanup_pop(1);
+	errno = rv ? rv : orig_errno;
+	return rv;
+}
+
 int lckpwdf(void) {
 	mlibc::infoLogger() << "mlibc: lckpwdf is unimplemented like musl" << frg::endlog;
 	return 0;
@@ -27,7 +186,28 @@ int ulckpwdf(void) {
 	return 0;
 }
 
-struct spwd *getspnam(const char *) {
+// Musl defines LINE_LIM to 256
+#define LINE_LIM 256
+
+struct spwd *getspnam(const char *name) {
+	static struct spwd sp;
+	static char *line;
+	struct spwd *res;
+	int e;
+	int orig_errno = errno;
+
+	if(!line) {
+		line = (char *)malloc(LINE_LIM);
+	}
+	if(!line) {
+		return 0;
+	}
+	e = getspnam_r(name, &sp, line, LINE_LIM, &res);
+	errno = e ? e : orig_errno;
+	return res;
+}
+
+struct spwd *fgetspent(FILE *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/glibc/generic/shadow-stubs.cpp
+++ b/options/glibc/generic/shadow-stubs.cpp
@@ -213,6 +213,5 @@ struct spwd *fgetspent(FILE *) {
 }
 
 void endspent(void) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "mlibc: endspent is a stub" << frg::endlog;
 }

--- a/options/glibc/include/shadow.h
+++ b/options/glibc/include/shadow.h
@@ -27,6 +27,8 @@ int putspent(const struct spwd *, FILE *);
 int lckpwdf(void);
 int ulckpwdf(void);
 struct spwd *getspnam(const char *);
+int getspnam_r(const char *, struct spwd *, char *, size_t, struct spwd **);
+struct spwd *fgetspent(FILE *);
 void endspent(void);
 
 #ifdef __cplusplus

--- a/options/linux/generic/utmp-stubs.cpp
+++ b/options/linux/generic/utmp-stubs.cpp
@@ -1,9 +1,36 @@
-#include <bits/ensure.h>
 #include <utmp.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <bits/ensure.h>
+#include <mlibc/debug.hpp>
+
+/*
+ * The code in this file is largely based on glibc.
+ * This includes:
+ * - setutent
+ * - read_last_entry
+ * - getutent
+ * - getutent_r
+ * - endutent
+ */
+static int fd = -1;
+static off_t offset;
+
+static struct utmp last_entry;
 
 void setutent(void) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	if(fd < 0) {
+		fd = open("/run/utmp", O_RDONLY | O_LARGEFILE | O_CLOEXEC);
+		if(fd == -1) {
+			return;
+		}
+	}
+
+	lseek(fd, 0, SEEK_SET);
+	offset = 0;
 }
 
 struct utmp *getutent(void) {

--- a/options/linux/generic/utmp-stubs.cpp
+++ b/options/linux/generic/utmp-stubs.cpp
@@ -39,8 +39,10 @@ struct utmp *getutent(void) {
 }
 
 void endutent(void) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	if(fd >= 0) {
+		close(fd);
+		fd = -1;
+	}
 }
 
 struct utmp *pututline(const struct utmp *) {

--- a/options/linux/generic/utmp-stubs.cpp
+++ b/options/linux/generic/utmp-stubs.cpp
@@ -50,8 +50,19 @@ static ssize_t read_last_entry(void) {
 }
 
 struct utmp *getutent(void) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	struct utmp *result;
+	static struct utmp *buf;
+	if(buf == NULL) {
+		buf = (struct utmp *)malloc(sizeof(struct utmp));
+		if(buf == NULL) {
+			return NULL;
+		}
+	}
+
+	if(getutent_r(buf, &result) < 0) {
+		return NULL;
+	}
+	return result;
 }
 
 int getutent_r(struct utmp *buf, struct utmp **res) {

--- a/options/linux/include/utmp.h
+++ b/options/linux/include/utmp.h
@@ -59,6 +59,7 @@ struct lastlog {
 
 void setutent(void);
 struct utmp *getutent(void);
+int getutent_r(struct utmp *, struct utmp **);
 void endutent(void);
 struct utmp *pututline(const struct utmp *);
 struct utmp *getutline(const struct utmp *);

--- a/options/posix/generic/unistd-stubs.cpp
+++ b/options/posix/generic/unistd-stubs.cpp
@@ -597,8 +597,8 @@ int setpgid(pid_t pid, pid_t pgid) {
 	return 0;
 }
 
-pid_t setpgrp(pid_t pid, pid_t pgid) {
-	return setpgid(pid, pgid);
+pid_t setpgrp(void) {
+	return setpgid(0, 0);
 }
 
 int setregid(gid_t rgid, gid_t egid) {

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -205,7 +205,7 @@ int setegid(gid_t);
 int seteuid(uid_t);
 int setgid(gid_t);
 int setpgid(pid_t, pid_t);
-pid_t setpgrp(pid_t, pid_t);
+pid_t setpgrp(void);
 int setregid(gid_t, gid_t);
 int setreuid(uid_t, uid_t);
 pid_t setsid(void);


### PR DESCRIPTION
This PR implements `getspnam()` and `getspnam_r`, fixes the function signature of `setpgrp` to match the System V version, just like glibc and musl do, adds a stub `fgetspent` and stubs `sys_tcdrain` in Managarm. All of this works towards running the `shadow` package on Managarm.

As more work is expected, this is a draft for now.