### PR TITLE
Make sys_ttyname() check for NOT_A_TTY

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -720,6 +720,8 @@ int sys_ttyname(int fd, char *buf, size_t size) {
 	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp->data, recv_resp->length);
 	if(resp.error() ==  managarm::posix::Errors::BAD_FD) {
+		return EBADF;
+	}else if(resp.error() == managarm::posix::Errors::NOT_A_TTY) {
 		return ENOTTY;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);


### PR DESCRIPTION
In the recently merged managarm PR 397 a specific NOT_A_TTY error got added to the POSIX protocol. This PR changes sys_ttyname() to not just check for BAD_FD as was done previously, but also properly check for NOT_A_TTY and return the correct error code.