### PR TITLE
options/posix: Define MADV_SEQUENTIAL and MADV_WILLNEED

### DIFF
--- a/options/posix/include/sys/mman.h
+++ b/options/posix/include/sys/mman.h
@@ -29,6 +29,9 @@
 // Linux extension:
 #define MREMAP_MAYMOVE 1
 #define MREMAP_FIXED 2
+
+#define MADV_SEQUENTIAL 2
+#define MADV_WILLNEED 3
 #define MADV_DONTNEED 4
 
 // Missing: posix_typed_mem_open(), POSIX_TYPED constants and related stuff.


### PR DESCRIPTION
This fixes the Managarm builds for `mednafen` and `qemu`.