### PR TITLE
options/glibc: Include byteswap.h in endian.h

### DIFF
--- a/options/glibc/include/endian.h
+++ b/options/glibc/include/endian.h
@@ -1,6 +1,8 @@
 #ifndef _ENDIAN_H
 #define _ENDIAN_H
 
+#include <byteswap.h>
+
 #ifdef __GNUC__
 # 	define BYTE_ORDER __BYTE_ORDER__
 #	define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__


### PR DESCRIPTION
Otherwise anyone including it will get build errors from the lack of __bswap family functions