### PR TITLE
options/posix: make timer{add,sub} take 2 const args

### DIFF
--- a/options/posix/generic/sys-time-stubs.cpp
+++ b/options/posix/generic/sys-time-stubs.cpp
@@ -21,12 +21,12 @@ int gettimeofday(struct timeval *__restrict result, void *__restrict unused) {
 	return 0;
 }
 
-void timeradd(struct timeval *, struct timeval *, struct timeval *) {
+void timeradd(const struct timeval *, const struct timeval *, struct timeval *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
-void timersub(struct timeval *, struct timeval *, struct timeval *) {
+void timersub(const struct timeval *, const struct timeval *, struct timeval *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }

--- a/options/posix/include/sys/time.h
+++ b/options/posix/include/sys/time.h
@@ -20,8 +20,8 @@ struct timezone {
 // TODO: this function is [OB]. disable it by default and add a macro to enable it
 int gettimeofday(struct timeval *__restrict result, void *__restrict unused);
 
-void timeradd(struct timeval *a, struct timeval *b, struct timeval *res);
-void timersub(struct timeval *a, struct timeval *b, struct timeval *res);
+void timeradd(const struct timeval *a, const struct timeval *b, struct timeval *res);
+void timersub(const struct timeval *a, const struct timeval *b, struct timeval *res);
 void timerclear(struct timeval *tvp);
 int timerisset(struct timeval *tvp);
 


### PR DESCRIPTION
While making the first 2 args `const` is not required by the spec, some code seems to assume that they are. Because an implementation should not modify them anyways, making them const is justified to avoid patching.