### PR TITLE
options/posix: Add GETALL and SETALL

### DIFF
--- a/options/posix/include/sys/sem.h
+++ b/options/posix/include/sys/sem.h
@@ -9,7 +9,9 @@
 extern "C" {
 #endif
 
+#define GETALL 13
 #define SETVAL 16
+#define SETALL 17
 
 #define SEM_UNDO 0x1000
 


### PR DESCRIPTION
This fixes a ci build failure for `perl`.