### PR TITLE
options/ansi: fix alignment checks in aligned_alloc

### DIFF
--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -184,6 +184,11 @@ void srand(unsigned int s) {
 
 void *aligned_alloc(size_t alignment, size_t size) {
 	void *ptr;
+
+	// posix_memalign requires that the alignment is a multiple of sizeof(void *).
+	if (alignment < sizeof(void *))
+		alignment = sizeof(void *);
+
 	int ret = posix_memalign(&ptr, alignment, size);
 	if (ret) {
 		errno = ret;

--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -186,8 +186,10 @@ void *aligned_alloc(size_t alignment, size_t size) {
 	void *ptr;
 
 	// alignment must be a power of two, and size % alignment must be 0
-	if (alignment & (alignment - 1) || size & (alignment - 1))
+	if (alignment & (alignment - 1) || size & (alignment - 1)) {
+		errno = EINVAL;
 		return nullptr;
+	}
 
 	// posix_memalign requires that the alignment is a multiple of sizeof(void *)
 	if (alignment < sizeof(void *))

--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -185,7 +185,11 @@ void srand(unsigned int s) {
 void *aligned_alloc(size_t alignment, size_t size) {
 	void *ptr;
 
-	// posix_memalign requires that the alignment is a multiple of sizeof(void *).
+	// alignment must be a power of two, and size % alignment must be 0
+	if (alignment & (alignment - 1) || size & (alignment - 1))
+		return nullptr;
+
+	// posix_memalign requires that the alignment is a multiple of sizeof(void *)
 	if (alignment < sizeof(void *))
 		alignment = sizeof(void *);
 

--- a/tests/ansi/alloc.c
+++ b/tests/ansi/alloc.c
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+#include <assert.h>
+#include <stdint.h>
+#include <errno.h>
+
+int main() {
+	void *p;
+
+	p = aligned_alloc(sizeof(void *), sizeof(void *));
+	assert(p != NULL && (uintptr_t)p % sizeof(void *) == 0);
+
+	p = aligned_alloc(256, 256);
+	assert(p != NULL && (uintptr_t)p % 256 == 0);
+
+	// small alignments are okay
+	p = aligned_alloc(1, 8);
+	assert(p != NULL);
+	p = aligned_alloc(1, 1);
+	assert(p != NULL);
+
+	// size % align must be 0
+	p = aligned_alloc(256, 1);
+	assert(p == NULL);
+
+	// align must be a 'valid alignment supported by the implementation'
+	assert(aligned_alloc(3, 1) == NULL);
+}

--- a/tests/ansi/alloc.c
+++ b/tests/ansi/alloc.c
@@ -20,8 +20,11 @@ int main() {
 
 	// size % align must be 0
 	p = aligned_alloc(256, 1);
+	assert(errno == EINVAL);
 	assert(p == NULL);
 
 	// align must be a 'valid alignment supported by the implementation'
-	assert(aligned_alloc(3, 1) == NULL);
+	p = aligned_alloc(3, 1);
+	assert(errno == EINVAL);
+	assert(p == NULL);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,5 @@
 ansi_test_cases = [
+	'alloc',
 	'sscanf',
 	'sprintf',
 	'snprintf',
@@ -40,6 +41,7 @@ posix_test_cases = [
 	'getservbyport',
 	'grp',
 	'dprintf',
+	'posix_memalign',
 	'posix_spawn',
 	'index',
 	'rindex',

--- a/tests/posix/posix_memalign.c
+++ b/tests/posix/posix_memalign.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <assert.h>
+#include <stdint.h>
+#include <errno.h>
+
+int main() {
+	void *p = NULL;
+
+	// align must be a power of two
+	assert(posix_memalign(&p, 3, 1) == EINVAL && p == NULL);
+
+	// align must be a multiple of sizeof(void *)
+	assert(posix_memalign(&p, sizeof(void *) / 2, 8) == EINVAL && p == NULL);
+
+	assert(posix_memalign(&p, sizeof(void *), sizeof(void *)) == 0 && p != NULL && (uintptr_t)p % sizeof(void *) == 0);
+	assert(posix_memalign(&p, 256, 1) == 0 && p != NULL && (uintptr_t)p % 256 == 0);
+	assert(posix_memalign(&p, 256, 256) == 0 && p != NULL && (uintptr_t)p % 256 == 0);
+}


### PR DESCRIPTION
`posix_memalign` requires that align is a power of two multiple of `sizeof(void *)`, but C11's `aligned_alloc` does not. Hence we must make sure the alignment is adjusted correctly when passing to `posix_memalign`.

We also add an extra check for the case that a bad alignment is passed to `aligned_alloc`.

Also adds some regression tests for these cases.
