### PR TITLE
tests: fix getservby{name,port}

### DIFF
--- a/options/posix/generic/services.cpp
+++ b/options/posix/generic/services.cpp
@@ -46,8 +46,8 @@ static int lookup_serv_file_port(service_result &buf, int proto, int port) {
 
 	char line_buf[129] = {0};
 	char *line = line_buf + 1;
-	int name_length = 0;
 	while(fgets(line, 128, file)) {
+		int name_length = 0;
 		char *pos;
 		// easy way to handle comments, just move the end of the line
 		// to the beginning of the comment

--- a/tests/posix/getservbyname.c
+++ b/tests/posix/getservbyname.c
@@ -16,7 +16,9 @@ int main() {
 	assert(ret->s_port == htons(80));
 	assert(!strcmp("tcp", ret->s_proto));
 
-	ret = getservbyname("http", "udp");
+	ret = getservbyname("babel", "udp");
+	assert(ret);
+	ret = getservbyname("babel", "tcp");
 	assert(!ret);
 
 	ret = getservbyname("", NULL);

--- a/tests/posix/getservbyport.c
+++ b/tests/posix/getservbyport.c
@@ -17,7 +17,9 @@ int main() {
 	assert(ret->s_port == htons(80));
 	assert(!strcmp("tcp", ret->s_proto));
 
-	ret = getservbyport(htons(80), "udp");
+	ret = getservbyport(htons(6696), "udp");
+	assert(ret);
+	ret = getservbyport(htons(6696), "tcp");
 	assert(!ret);
 
 	ret = getservbyport(htons(0), NULL);


### PR DESCRIPTION
About the asserts, quoting the man page: `Port numbers are assigned by the IANA (Internet Assigned Numbers Authority), and their current policy is to assign both TCP and UDP protocols when assigning a port number. Therefore, most entries will have two entries, even for TCP-only services.`

In the loop, the name length did not get reset; this caused a reproducible segfault in local testing for me and @64.