### PR TITLE
abis: place {F,W,R,X}_OK in abi-bits

### DIFF
--- a/abis/linux/x86_64/access.h
+++ b/abis/linux/x86_64/access.h
@@ -1,0 +1,9 @@
+#ifndef _ABIBITS_ACCESS_H
+#define _ABIBITS_ACCESS_H
+
+#define F_OK 0
+#define X_OK 1
+#define W_OK 2
+#define R_OK 4
+
+#endif // _ABIBITS_ACCESS_H

--- a/abis/mlibc/access.h
+++ b/abis/mlibc/access.h
@@ -1,0 +1,9 @@
+#ifndef _ABIBITS_ACCESS_H
+#define _ABIBITS_ACCESS_H
+
+#define F_OK 1
+#define R_OK 2
+#define W_OK 4
+#define X_OK 8
+
+#endif // _ABIBITS_ACCESS_H

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -7,6 +7,7 @@
 #include <bits/size_t.h>
 #include <bits/ssize_t.h>
 #include <bits/off_t.h>
+#include <abi-bits/access.h>
 #include <abi-bits/uid_t.h>
 #include <abi-bits/gid_t.h>
 #include <abi-bits/pid_t.h>
@@ -34,11 +35,6 @@ extern "C" {
 
 // MISSING: additional _POSIX and _XOPEN feature macros
 // MISSING: _POSIX_TIMESTAMP_RESOLUTION and _POSIX2_SYMLINKS
-
-#define F_OK 1
-#define R_OK 2
-#define W_OK 4
-#define X_OK 8
 
 #define _CS_PATH 0
 #define _CS_POSIX_V6_WIDTH_RESTRICTED_ENVS 1

--- a/sysdeps/aero/include/abi-bits/access.h
+++ b/sysdeps/aero/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/access.h

--- a/sysdeps/aero/meson.build
+++ b/sysdeps/aero/meson.build
@@ -39,6 +39,7 @@ if not no_headers
 		'include/abi-bits/nlink_t.h',
 		'include/abi-bits/pid_t.h',
 		'include/abi-bits/uid_t.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/wait.h',
 		'include/abi-bits/limits.h',
 		'include/abi-bits/utsname.h',

--- a/sysdeps/dripos/include/abi-bits/access.h
+++ b/sysdeps/dripos/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/access.h

--- a/sysdeps/dripos/meson.build
+++ b/sysdeps/dripos/meson.build
@@ -33,6 +33,7 @@ if not no_headers
 		'include/abi-bits/nlink_t.h',
 		'include/abi-bits/pid_t.h',
 		'include/abi-bits/uid_t.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/wait.h',
 		'include/abi-bits/limits.h',
 		'include/abi-bits/utsname.h',

--- a/sysdeps/lemon/include/abi-bits/access.h
+++ b/sysdeps/lemon/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/access.h

--- a/sysdeps/lemon/meson.build
+++ b/sysdeps/lemon/meson.build
@@ -38,6 +38,7 @@ if not no_headers
 		'include/abi-bits/nlink_t.h',
 		'include/abi-bits/pid_t.h',
 		'include/abi-bits/uid_t.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/wait.h',
 		'include/abi-bits/limits.h',
 		'include/abi-bits/utsname.h',

--- a/sysdeps/linux/include/abi-bits/access.h
+++ b/sysdeps/linux/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/x86_64/access.h

--- a/sysdeps/linux/meson.build
+++ b/sysdeps/linux/meson.build
@@ -43,6 +43,7 @@ if not no_headers
 		'include/abi-bits/nlink_t.h',
 		'include/abi-bits/pid_t.h',
 		'include/abi-bits/uid_t.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/wait.h',
 		'include/abi-bits/limits.h',
 		'include/abi-bits/utsname.h',

--- a/sysdeps/managarm/include/abi-bits/access.h
+++ b/sysdeps/managarm/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/access.h

--- a/sysdeps/managarm/meson.build
+++ b/sysdeps/managarm/meson.build
@@ -66,6 +66,7 @@ endif
 if not no_headers
 	install_headers(
 		'include/abi-bits/abi.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/auxv.h',
 		'include/abi-bits/seek-whence.h',
 		'include/abi-bits/vm-flags.h',

--- a/sysdeps/qword/include/abi-bits/access.h
+++ b/sysdeps/qword/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/access.h

--- a/sysdeps/qword/meson.build
+++ b/sysdeps/qword/meson.build
@@ -34,6 +34,7 @@ if not no_headers
 		'include/abi-bits/nlink_t.h',
 		'include/abi-bits/pid_t.h',
 		'include/abi-bits/uid_t.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/wait.h',
 		'include/abi-bits/utsname.h',
 		subdir: 'abi-bits'

--- a/sysdeps/sigma/include/abi-bits/access.h
+++ b/sysdeps/sigma/include/abi-bits/access.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/access.h

--- a/sysdeps/sigma/meson.build
+++ b/sysdeps/sigma/meson.build
@@ -43,6 +43,7 @@ if not no_headers
 		'include/abi-bits/nlink_t.h',
 		'include/abi-bits/pid_t.h',
 		'include/abi-bits/uid_t.h',
+		'include/abi-bits/access.h',
 		'include/abi-bits/wait.h',
 		'include/abi-bits/limits.h',
 		'include/abi-bits/utsname.h',

--- a/tests/ansi/longjmp.c
+++ b/tests/ansi/longjmp.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <setjmp.h>
+#include <stdnoreturn.h>
+#include <assert.h>
+
+jmp_buf buf;
+ 
+noreturn void do_jump(int arg) {
+	longjmp(buf, 2 * arg);
+}
+ 
+int main(void) {
+	volatile int times_called = 0;
+
+	if (setjmp(buf) != 8) {
+		do_jump(++times_called);
+	}
+
+	assert(times_called == 4);
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,7 @@ ansi_test_cases = [
 	'utf8',
 	'strtol',
 	'abs',
+	'longjmp',
 	'strverscmp',
 	'strftime',
 	'strchr',
@@ -23,6 +24,7 @@ bsd_test_cases = [
 posix_test_cases = [
 	'inet_ntop',
 	'inet_pton',
+	'access',
 	'pthread_rwlock',
 	'pthread_cond',
 	'pthread_create',

--- a/tests/posix/access.c
+++ b/tests/posix/access.c
@@ -1,0 +1,26 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <fcntl.h>
+
+#define TEST_FILE "access.tmp"
+
+int main() {
+	// Make sure that it wasn't created by a previous test run
+	unlink(TEST_FILE);
+
+	assert(access(TEST_FILE, F_OK) == -1);
+	assert(access(TEST_FILE, W_OK) == -1);
+	assert(access(TEST_FILE, R_OK) == -1);
+	assert(access(TEST_FILE, X_OK) == -1);
+
+	close(open(TEST_FILE, O_CREAT));
+
+	assert(access(TEST_FILE, F_OK) == 0);
+	assert(access(TEST_FILE, W_OK) == 0);
+	assert(access(TEST_FILE, R_OK) == 0);
+	assert(access(TEST_FILE, X_OK) == -1);
+
+	unlink(TEST_FILE);
+}


### PR DESCRIPTION
Fixes the ABI for `access` on Linux. Also adds an `access` test (and one for `longjmp` too, because why not)