### PR TITLE
rtdl: refactor `getCurrentTcb` and `__abi_tls_entry`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ libc_include_dirs = [
 	include_directories('options/internal/include'),
 	include_directories('options/elf/include'),
 	include_directories('options/lsb/include'),
+	include_directories('options/rtdl/include'),
 	include_directories('options/internal' / host_machine.cpu_family() + '-include')
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ fs = import('fs')
 
 rtdl_include_dirs = [
 	include_directories('options/internal/include'),
+	include_directories('options/internal' / host_machine.cpu_family() + '-include'),
 	include_directories('options/rtdl/include'),
 ]
 libc_include_dirs = [
@@ -217,7 +218,6 @@ internal_sources = [
 	'options/internal/gcc/initfini.cpp',
 	'options/internal/gcc-extra/cxxabi.cpp',
 	'options/internal' / host_machine.cpu_family() / 'setjmp.S',
-	'options/internal' / host_machine.cpu_family() / 'thread.cpp',
 ]
 
 if not static

--- a/options/internal/aarch64-include/mlibc/thread.hpp
+++ b/options/internal/aarch64-include/mlibc/thread.hpp
@@ -1,12 +1,13 @@
-#include <mlibc/thread.hpp>
+#pragma once
 
 #include <stdint.h>
+#include <mlibc/tcb.hpp>
 
 namespace mlibc {
 
-Tcb *get_current_tcb() {
+inline Tcb *get_current_tcb() {
 	uintptr_t ptr;
-	asm ("movq %%fs:0, %0" : "=r"(ptr));
+	asm ("mrs %0, tpidr_el0" : "=r"(ptr));
 	return reinterpret_cast<Tcb *>(ptr);
 }
 

--- a/options/internal/include/mlibc/thread.hpp
+++ b/options/internal/include/mlibc/thread.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <mlibc/tcb.hpp>
-
-namespace mlibc {
-
-Tcb *get_current_tcb();
-
-} // namespace mlibc

--- a/options/internal/x86_64-include/mlibc/thread.hpp
+++ b/options/internal/x86_64-include/mlibc/thread.hpp
@@ -1,12 +1,13 @@
-#include <mlibc/thread.hpp>
+#pragma once
 
 #include <stdint.h>
+#include <mlibc/tcb.hpp>
 
 namespace mlibc {
 
-Tcb *get_current_tcb() {
+inline Tcb *get_current_tcb() {
 	uintptr_t ptr;
-	asm ("mrs %0, tpidr_el0" : "=r"(ptr));
+	asm ("movq %%fs:0, %0" : "=r"(ptr));
 	return reinterpret_cast<Tcb *>(ptr);
 }
 

--- a/options/lsb/generic/tls.cpp
+++ b/options/lsb/generic/tls.cpp
@@ -1,3 +1,6 @@
+#include <internal-config.h>
+#include <mlibc/thread.hpp>
+#include <mlibc/rtdl-abi.hpp>
 
 struct __abi_tls_entry;
 

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -7,6 +7,7 @@
 #include <abi-bits/auxv.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/rtdl-sysdeps.hpp>
+#include <mlibc/rtdl-abi.hpp>
 #include <mlibc/stack_protector.hpp>
 #include <internal-config.h>
 #include "linker.hpp"
@@ -275,14 +276,6 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 				<< (void *)executableSO->entry << frg::endlog;
 	return executableSO->entry;
 }
-
-// the layout of this structure is dictated by the ABI
-struct __abi_tls_entry {
-	SharedObject *object;
-	uint64_t offset;
-};
-
-static_assert(sizeof(__abi_tls_entry) == 16, "Bad __abi_tls_entry size");
 
 const char *lastError;
 

--- a/options/rtdl/include/mlibc/rtdl-abi.hpp
+++ b/options/rtdl/include/mlibc/rtdl-abi.hpp
@@ -1,0 +1,20 @@
+#ifndef MLIBC_RTDL_ABI
+#define MLIBC_RTDL_ABI
+
+#include <stdint.h>
+
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__riscv)
+
+struct __abi_tls_entry {
+	struct SharedObject *object;
+	uint64_t offset;
+};
+static_assert(sizeof(__abi_tls_entry) == 16, "Bad __abi_tls_entry size");
+
+extern "C" void *__dlapi_get_tls(struct __abi_tls_entry *);
+
+#else
+#error "Missing architecture specific code."
+#endif
+
+#endif // MLIBC_RTDL_ABI


### PR DESCRIPTION
- use `get_current_tcb` instead of `getCurrentTcb`
- move `__abi_tls_entry` to header