### PR TITLE
options/internal: increase log stack buffer size

### DIFF
--- a/options/internal/generic/debug.cpp
+++ b/options/internal/generic/debug.cpp
@@ -5,8 +5,8 @@
 
 namespace mlibc {
 
-frg::stack_buffer_logger<InfoSink> infoLogger;
-frg::stack_buffer_logger<PanicSink> panicLogger;
+frg::stack_buffer_logger<InfoSink, 512> infoLogger;
+frg::stack_buffer_logger<PanicSink, 512> panicLogger;
 
 void InfoSink::operator() (const char *message) {
 	sys_libc_log(message);

--- a/options/internal/include/mlibc/debug.hpp
+++ b/options/internal/include/mlibc/debug.hpp
@@ -19,8 +19,8 @@ struct PanicSink {
 	void operator() (const char *message);
 };
 
-extern frg::stack_buffer_logger<InfoSink> infoLogger;
-extern frg::stack_buffer_logger<PanicSink> panicLogger;
+extern frg::stack_buffer_logger<InfoSink, 512> infoLogger;
+extern frg::stack_buffer_logger<PanicSink, 512> panicLogger;
 
 } // namespace mlibc
 


### PR DESCRIPTION
This should make some assertion failures more readable.