### PR TITLE
options/posix: Fix incorrect deadlock detection in pthread_mutex_trylock

### DIFF
--- a/options/posix/generic/pthread-stubs.cpp
+++ b/options/posix/generic/pthread-stubs.cpp
@@ -820,17 +820,13 @@ int pthread_mutex_trylock(pthread_mutex_t *mutex) {
 		}
 	} else {
 		// If this (recursive) mutex is already owned by us, increment the recursion level.
-        if((expected & mutex_owner_mask) == this_tid()) {
-            if(!(mutex->__mlibc_flags & mutexRecursive)) {
-                if (mutex->__mlibc_flags & mutexErrorCheck)
-                    return EDEADLK;
-                else
-                    mlibc::panicLogger() << "mlibc: pthread_mutex deadlock detected!"
-                        << frg::endlog;
-            }
-            ++mutex->__mlibc_recursion;
-            return 0;
-        }
+		if((expected & mutex_owner_mask) == this_tid()) {
+			if(!(mutex->__mlibc_flags & mutexRecursive)) {
+				return EBUSY;
+			}
+			++mutex->__mlibc_recursion;
+			return 0;
+		}
 	}
 
 	return EBUSY;


### PR DESCRIPTION
As discussed on discord [here](https://discord.com/channels/678608576151027731/678613510237978625/973180749144539156), I've fixed the issue with `pthread_mutex_trylock()`. Should be good to go now.

Part of the Chromium on Managarm project.