### PR TITLE
options/posix: Refactor FD_SET and friends to work with wine

### DIFF
--- a/options/posix/generic/sys-select-stubs.cpp
+++ b/options/posix/generic/sys-select-stubs.cpp
@@ -9,19 +9,19 @@
 
 #include <mlibc/posix-sysdeps.hpp>
 
-void FD_CLR(int fd, fd_set *set) {
+void __FD_CLR(int fd, fd_set *set) {
 	__ensure(fd < FD_SETSIZE);
 	set->__mlibc_elems[fd / 8] &= ~(1 << (fd % 8));
 }
-int FD_ISSET(int fd, fd_set *set) {
+int __FD_ISSET(int fd, fd_set *set) {
 	__ensure(fd < FD_SETSIZE);
 	return set->__mlibc_elems[fd / 8] & (1 << (fd % 8));
 }
-void FD_SET(int fd, fd_set *set) {
+void __FD_SET(int fd, fd_set *set) {
 	__ensure(fd < FD_SETSIZE);
 	set->__mlibc_elems[fd / 8] |= 1 << (fd % 8);
 }
-void FD_ZERO(fd_set *set) {
+void __FD_ZERO(fd_set *set) {
 	memset(set->__mlibc_elems, 0, sizeof(fd_set));
 }
 

--- a/options/posix/include/sys/select.h
+++ b/options/posix/include/sys/select.h
@@ -22,15 +22,15 @@ typedef long int __fd_mask;
 typedef __fd_mask fd_mask;
 #define NFDBITS __NFDBITS
 
-void FD_CLR(int fd, fd_set *);
-int FD_ISSET(int fd, fd_set *);
-void FD_SET(int fd, fd_set *);
-void FD_ZERO(fd_set *);
+void __FD_CLR(int fd, fd_set *);
+int __FD_ISSET(int fd, fd_set *);
+void __FD_SET(int fd, fd_set *);
+void __FD_ZERO(fd_set *);
 
-#define FD_CLR FD_CLR
-#define FD_ISSET FD_ISSET
-#define FD_SET FD_SET
-#define FD_ZERO FD_ZERO
+#define FD_CLR(fd, set) __FD_CLR(fd, set)
+#define FD_ISSET(fd, set) __FD_ISSET(fd, set)
+#define FD_SET(fd, set) __FD_SET(fd, set)
+#define FD_ZERO(set) __FD_ZERO(set)
 
 int select(int, fd_set *__restrict, fd_set *__restrict, fd_set *__restrict,
 		struct timeval *__restrict);


### PR DESCRIPTION
This PR refactors FD_SET and friends to be consistent with the way glibc defines them, which makes wine happy during compilation. No functional changes are made.

Abi break counterpart of #374 