### PR TITLE
options/ansi: Implement timegm

### DIFF
--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -275,7 +275,11 @@ size_t strftime(char *__restrict dest, size_t max_size,
 }
 
 size_t wcsftime(wchar_t *__restrict, size_t, const wchar_t *__restrict,
-		const struct tm *__restrict) MLIBC_STUB_BODY
+		const struct tm *__restrict) {
+	mlibc::infoLogger() << "mlibc: wcsftime is a stub" << frg::endlog;
+	return 0;
+}
+
 namespace {
 
 struct tzfile {

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -48,9 +48,8 @@ double difftime(time_t a, time_t b) {
 	return a - b;
 }
 
-time_t mktime(struct tm *) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+time_t mktime(struct tm *tm) {
+	return timegm(tm);
 }
 
 /* There is no other implemented value than TIME_UTC; all other values

--- a/tests/ansi/timegm.c
+++ b/tests/ansi/timegm.c
@@ -1,0 +1,45 @@
+#include <time.h>
+#include <stdio.h>
+#include <assert.h>
+
+int main() {
+	struct tm soon = {};
+	soon.tm_sec = 0;
+	soon.tm_min = 0;
+	soon.tm_hour = 0;
+	soon.tm_mday = 1;
+	soon.tm_mon = 0;
+	soon.tm_year = 70;
+	time_t result;
+	time_t expected_result = 0;
+	// This should be epoch.
+	result = timegm(&soon);
+	printf("epoch: %ld\n", result);
+	assert(result == expected_result);
+
+	soon.tm_sec = 12;
+	soon.tm_min = 8;
+	soon.tm_hour = 16;
+	soon.tm_mday = 17;
+	soon.tm_mon = 4;
+	soon.tm_year = 122;
+	expected_result = 1652803692;
+	result = timegm(&soon);
+	// On my host, this returned 1652803692, verify this.
+	printf("epoch: %ld\n", result);
+	assert(result == expected_result);
+
+	soon.tm_sec = 45;
+	soon.tm_min = 42;
+	soon.tm_hour = 17;
+	soon.tm_mday = 16;
+	soon.tm_mon = 8;
+	soon.tm_year = 69;
+	expected_result = -9181035;
+	result = timegm(&soon);
+	// On my host, this returned -9181035, verify this.
+	printf("epoch: %ld\n", result);
+	assert(result == expected_result);
+
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,7 @@ ansi_test_cases = [
 	'wcsrtombs',
 	'wmemcmp',
 	'time',
+	'timegm',
 	'ungetc',
 	'wcsdup',
 	'wcsncasecmp',


### PR DESCRIPTION
This PR implements `timegm()` as implemented by Sortix.

Part of the Chromium on Managarm project.