### PR TITLE
sysdeps/managarm: Stub sys_madvise

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -4744,5 +4744,10 @@ int sys_uname(struct utsname *buf) {
 	return 0;
 }
 
+int sys_madvise(void *addr, size_t length, int advice) {
+	mlibc::infoLogger() << "mlibc: sys_madvise is a stub!" << frg::endlog;
+	return 0;
+}
+
 } //namespace mlibc
 


### PR DESCRIPTION
Chromium relies on `madvise()` returning 0, which we can only satisfy if we stub the actual sysdep.

Part of the Chromium on Managarm project.