### PR TITLE
options/glibc: Stub res_nclose and res_ninit

### DIFF
--- a/options/glibc/generic/resolv-stubs.cpp
+++ b/options/glibc/generic/resolv-stubs.cpp
@@ -1,5 +1,6 @@
 #include <resolv.h>
 #include <bits/ensure.h>
+#include <mlibc/debug.hpp>
 
 int dn_expand(const unsigned char *, const unsigned char *,
 		const unsigned char *, char *, int) {
@@ -13,7 +14,18 @@ int res_query(const char *, int, int, unsigned char *, int) {
 }
 
 int res_init() {
+	mlibc::infoLogger() << "mlibc: res_init is a stub!" << frg::endlog;
 	return 0;
+}
+
+int res_ninit(res_state) {
+	mlibc::infoLogger() << "mlibc: res_ninit is a stub!" << frg::endlog;
+	return 0;
+}
+
+void res_nclose(res_state) {
+	mlibc::infoLogger() << "mlibc: res_nclose is a stub!" << frg::endlog;
+	return;
 }
 
 /* This is completely unused, and exists purely to satisfy broken apps. */

--- a/options/glibc/include/resolv.h
+++ b/options/glibc/include/resolv.h
@@ -38,6 +38,9 @@ typedef struct __res_state {
 struct __res_state *__res_state(void);
 #define _res (*__res_state())
 
+int res_ninit(res_state);
+void res_nclose(res_state);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR stubs `res_nclose()` and `res_ninit()`. As far as I'm aware, we can safely leave them as no-ops for now.

Part of the Chromium on Managarm project.