### PR TITLE
options/ansi: fix strtol et al., implement wcstol et al.

### DIFF
--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -19,6 +19,7 @@
 #include <mlibc/charcode.hpp>
 #include <mlibc/ansi-sysdeps.hpp>
 #include <mlibc/strtofp.hpp>
+#include <mlibc/strtol.hpp>
 
 #ifdef __MLIBC_POSIX_OPTION
 #include <pthread.h>
@@ -76,87 +77,18 @@ float strtof(const char *__restrict string, char **__restrict end) {
 long double strtold(const char *__restrict string, char **__restrict end) {
 	return mlibc::strtofp<long double>(string, end);
 }
+
 long strtol(const char *__restrict string, char **__restrict end, int base) {
-//	mlibc::infoLogger() << "mlibc: strtol() called on string '" << string << "'" << frg::endlog;
-
-	// skip leading space
-	while(*string) {
-		if(*string == '+')
-			string++;
-		if(!isspace(*string))
-			break;
-		string++;
-	}
-
-	bool negative = false;
-	if(*string == '-') {
-		negative = true;
-		string++;
-	}
-
-	unsigned long number = strtoul(string, end, base);
-	if(negative)
-		return static_cast<long>((~number) + 1);
-	return number;
+	return mlibc::stringToInteger<long, char>(string, end, base);
 }
 long long strtoll(const char *__restrict string, char **__restrict end, int base) {
-	static_assert(sizeof(long long) == sizeof(long));
-	return strtol(string, end, base);
+	return mlibc::stringToInteger<long long, char>(string, end, base);
 }
-// this function is copied from newlib and available under a BSD license
-unsigned long strtoul(const char *__restrict nptr, char **__restrict endptr, int base) {
-	const unsigned char *s = (const unsigned char *)nptr;
-	unsigned long acc;
-	int c;
-	unsigned long cutoff;
-	int neg = 0, any, cutlim;
-
-	do {
-		c = *s++;
-	} while (isspace(c));
-	if (c == '-') {
-		neg = 1;
-		c = *s++;
-	} else if (c == '+')
-		c = *s++;
-	if ((base == 0 || base == 16) &&
-	    c == '0' && (*s == 'x' || *s == 'X')) {
-		c = s[1];
-		s += 2;
-		base = 16;
-	}
-	if (base == 0)
-		base = c == '0' ? 8 : 10;
-	cutoff = (unsigned long)ULONG_MAX / (unsigned long)base;
-	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
-	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit(c))
-			c -= '0';
-		else if (isalpha(c))
-			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
-		else
-			break;
-		if (c >= base)
-			break;
-               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
-			any = -1;
-		else {
-			any = 1;
-			acc *= base;
-			acc += c;
-		}
-	}
-	if (any < 0) {
-		acc = (unsigned long)ULONG_MAX;
-	} else if (neg)
-		acc = -acc;
-	if (endptr != 0)
-		*endptr = (char *) (any ? (char *)s - 1 : nptr);
-	return (acc);
+unsigned long strtoul(const char *__restrict string, char **__restrict end, int base) {
+	return mlibc::stringToInteger<unsigned long, char>(string, end, base);
 }
 unsigned long long strtoull(const char *__restrict string, char **__restrict end, int base) {
-	static_assert(sizeof(unsigned long long) == sizeof(unsigned long));
-	return strtoul(string, end, base);
+	return mlibc::stringToInteger<unsigned long long, char>(string, end, base);
 }
 
 frg::mt19937 __mlibc_rand_engine;

--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -4,6 +4,7 @@
 #include <ctype.h>
 
 #include <bits/ensure.h>
+#include <mlibc/strtol.hpp>
 
 // memset() is defined in options/internals.
 // memcpy() is defined in options/internals.
@@ -228,10 +229,18 @@ double wcstod(const wchar_t *__restrict, wchar_t **__restrict) MLIBC_STUB_BODY
 float wcstof(const wchar_t *__restrict, wchar_t **__restrict) MLIBC_STUB_BODY
 long double wcstold(const wchar_t *__restrict, wchar_t **__restrict) MLIBC_STUB_BODY
 
-long wcstol(const wchar_t *__restrict, wchar_t **__restrict, int) MLIBC_STUB_BODY
-long long wcstoll(const wchar_t *__restrict, wchar_t **__restrict, int) MLIBC_STUB_BODY
-unsigned long wcstoul(const wchar_t *__restrict, wchar_t **__restrict, int) MLIBC_STUB_BODY
-unsigned long long wcstoull(const wchar_t *__restrict, wchar_t **__restrict, int) MLIBC_STUB_BODY
+long wcstol(const wchar_t *__restrict nptr, wchar_t **__restrict endptr, int base)  {
+	return mlibc::stringToInteger<long, wchar_t>(nptr, endptr, base);
+}
+unsigned long wcstoul(const wchar_t *__restrict nptr, wchar_t **__restrict endptr, int base)  {
+	return mlibc::stringToInteger<unsigned long, wchar_t>(nptr, endptr, base);
+}
+long long wcstoll(const wchar_t *__restrict nptr, wchar_t **__restrict endptr, int base)  {
+	return mlibc::stringToInteger<long long, wchar_t>(nptr, endptr, base);
+}
+unsigned long long wcstoull(const wchar_t *__restrict nptr, wchar_t **__restrict endptr, int base)  {
+	return mlibc::stringToInteger<unsigned long long, wchar_t>(nptr, endptr, base);
+}
 
 wchar_t *wcscpy(wchar_t *__restrict dest, const wchar_t *__restrict src) {
 	wchar_t *a = dest;

--- a/options/internal/include/mlibc/strtol.hpp
+++ b/options/internal/include/mlibc/strtol.hpp
@@ -1,0 +1,148 @@
+#ifndef MLIBC_STRTOL_HPP
+#define MLIBC_STRTOL_HPP
+
+#include <type_traits>
+#include <ctype.h>
+#include <wctype.h>
+#include <limits.h>
+
+namespace mlibc {
+
+template<typename T> struct int_limits {};
+
+template<>
+struct int_limits<long> {
+	static long max() { return LONG_MAX; }
+	static long min() { return LONG_MIN; }
+};
+
+template<>
+struct int_limits<unsigned long> {
+	static unsigned long max() { return ULONG_MAX; }
+	static unsigned long min() { return 0; }
+};
+
+template<>
+struct int_limits<long long> {
+	static long long max() { return LLONG_MAX; }
+	static long long min() { return LLONG_MIN; }
+};
+
+template<>
+struct int_limits<unsigned long long> {
+	static unsigned long long max() { return ULLONG_MAX; }
+	static unsigned long long min() { return 0; }
+};
+
+template<typename T> struct char_detail {};
+
+template<>
+struct char_detail<char> {
+	static bool isSpace(char c) { return isspace(c); }
+	static bool isDigit(char c) { return isdigit(c); }
+	static bool isLower(char c) { return islower(c); }
+	static bool isUpper(char c) { return isupper(c); }
+};
+
+template<>
+struct char_detail<wchar_t> {
+	static bool isSpace(wchar_t c) { return iswspace(c); }
+	static bool isDigit(wchar_t c) { return iswdigit(c); }
+	static bool isLower(wchar_t c) { return iswlower(c); }
+	static bool isUpper(wchar_t c) { return iswupper(c); }
+};
+
+template<typename Char> Char widen(char c) { return static_cast<Char>(c); }
+
+template<typename Return, typename Char>
+Return stringToInteger(const Char *__restrict nptr, Char **__restrict endptr, int baseInt) {
+	auto base = static_cast<Return>(baseInt);
+	auto s = nptr;
+
+	if (base < 0 || base == 1) {
+		if (endptr)
+			*endptr = const_cast<Char *>(nptr);
+		return 0;
+	}
+
+	while (char_detail<Char>::isSpace(*s))
+		s++;
+
+	bool negative = false;
+	if (*s == widen<Char>('-')) {
+		negative = true;
+		s++;
+	} else if (*s == widen<Char>('+')) {
+		s++;
+	}
+
+	bool hasOctalPrefix = s[0] == widen<Char>('0');
+	bool hasHexPrefix = hasOctalPrefix && (s[1] == widen<Char>('x') || s[1] == widen<Char>('X'));
+	if ((base == 0 || base == 16) && hasHexPrefix) {
+		s += 2;
+		base = 16;
+	} else if ((base == 0 || base == 8) && hasOctalPrefix) {
+		base = 8;
+	} else if (base == 0) { 
+		base = 10;
+	}
+
+	// Compute the range of acceptable values.
+	Return cutoff, cutlim;
+	if (std::is_unsigned<Return>::value) {
+		cutoff = int_limits<Return>::max() / base;
+		cutlim = int_limits<Return>::max() % base;
+	} else {
+		cutoff = negative ? int_limits<Return>::min() : int_limits<Return>::max();
+		cutlim = negative ? -(cutoff % base) : cutoff % base;
+		cutoff /= negative ? -base : base;
+	}
+
+	Return totalValue = 0;
+	bool convertedAny = false;
+	bool outOfRange = false;
+	for (Char c = *s; c != widen<Char>('\0'); c = *++s) {
+		Return digitValue;
+		if (char_detail<Char>::isDigit(c))
+			digitValue = c - widen<Char>('0');
+		else if (char_detail<Char>::isUpper(c))
+			digitValue = c - widen<Char>('A') + 10;
+		else if (char_detail<Char>::isLower(c))
+			digitValue = c - widen<Char>('a') + 10;
+		else
+			break;
+
+		if (digitValue >= base)
+			break;
+
+		if (outOfRange) {
+			// The value is already known to be out of range, but we need to keep
+			// consuming characters until we can't (to set endptr correctly).
+		} else if (totalValue > cutoff || (totalValue == cutoff && digitValue > cutlim)) {
+			// The value will be out of range if we accumulate digitValue.
+			outOfRange = true;
+		} else {
+			totalValue = (totalValue * base) + digitValue;
+			convertedAny = true;
+		}
+	}
+
+	if (endptr)
+		*endptr = const_cast<Char *>(convertedAny ? s : nptr);
+
+	if (outOfRange) {
+		errno = ERANGE;
+
+		if (std::is_unsigned<Return>::value) {
+			return int_limits<Return>::max();
+		} else {
+			return negative ? int_limits<Return>::min() : int_limits<Return>::max();
+		}
+	}
+
+	return negative ? -totalValue : totalValue;
+}
+
+}
+
+#endif // MLIBC_STRTOL_HPP

--- a/options/posix/generic/lookup.cpp
+++ b/options/posix/generic/lookup.cpp
@@ -36,7 +36,7 @@ static frg::string<MemoryAllocator> read_dns_name(char *buf, char *&it) {
 			for (int i = 0; i < code; i++)
 				res += (*it++);
 
-			if (*(it + 1))
+			if (*it)
 				res += '.';
 		} else {
 			break;

--- a/tests/ansi/strtol.c
+++ b/tests/ansi/strtol.c
@@ -1,20 +1,106 @@
-// Code modified from https://cplusplus.com
 #include <stdlib.h>
 #include <assert.h>
+#include <limits.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <wchar.h>
+
+#define DO_TEST(str, value, func, base) ({ \
+	char s[] = (str); \
+	char *pEnd = NULL; \
+	errno = 0; \
+	assert(func(s, &pEnd, base) == (value)); \
+	assert(errno == 0); \
+	assert(pEnd == s + strlen(s)); })
+
+#define DO_ERR_TEST(str, value, err, func, base) ({ \
+	char s[] = (str); \
+	char *pEnd = NULL; \
+	errno = 0; \
+	assert(func(s, &pEnd, base) == (value)); \
+	assert(errno == err); \
+	assert(pEnd == (err == ERANGE ? s + strlen(s) : s)); })
+
+#define DO_TESTL(str, value, func, base) ({ \
+	wchar_t s[] = (str); \
+	wchar_t *pEnd = NULL; \
+	errno = 0; \
+	assert(func(s, &pEnd, base) == (value)); \
+	assert(errno == 0); \
+	assert(pEnd == s + wcslen(s)); })
+
+#define DO_ERR_TESTL(str, value, err, func, base) ({ \
+	wchar_t s[] = (str); \
+	wchar_t *pEnd = NULL; \
+	errno = 0; \
+	assert(func(s, &pEnd, base) == (value)); \
+	assert(errno == err); \
+	assert(pEnd == (err == ERANGE ? s + wcslen(s) : s)); })
 
 int main () {
-	char szNumbers[] = "2001 60c0c0 -1101110100110100100000 0x6fffff +2001";
-	char *pEnd;
-	long int li1, li2, li3, li4, li5;
-	li1 = strtol(szNumbers, &pEnd, 10);
-	li2 = strtol(pEnd, &pEnd, 16);
-	li3 = strtol(pEnd, &pEnd, 2);
-	li4 = strtol(pEnd, &pEnd, 0);
-	li5 = strtol(pEnd, NULL, 10);
-	assert(li1 == 2001);
-	assert(li2 == 6340800);
-	assert(li3 == -3624224);
-	assert(li4 == 7340031);
-	assert(li5 == 2001);
+	// A few generic checks.
+	DO_TEST("0", 0, strtol, 0);
+	DO_TEST("0", 0, strtol, 10);
+	DO_TEST("2001", 2001, strtol, 10);
+	DO_TEST("+2001", 2001, strtol, 10);
+	DO_TEST("60c0c0", 0x60c0c0, strtol, 16);
+	DO_TEST("-1101110100110100100000", -3624224, strtol, 2);
+	DO_TEST("0x6fffff", 0x6fffff, strtol, 0);
+	DO_TEST("0666", 0666, strtol, 0);
+	DO_ERR_TEST("", 0, 0, strtol, 10);
+	DO_ERR_TEST("asd", 0, 0, strtol, 10);
+	DO_ERR_TEST("0xzzz", 0, 0, strtol, 0);
+	DO_ERR_TEST("999999999999999999999999999", LONG_MAX, ERANGE, strtol, 10);
+	DO_ERR_TEST("-999999999999999999999999999", LONG_MIN, ERANGE, strtol, 10);
+
+	// strtol
+	DO_TEST("-9223372036854775808", LONG_MIN, strtol, 10);
+	DO_TEST("9223372036854775807", LONG_MAX, strtol, 10);
+	DO_ERR_TEST("9223372036854775808", LONG_MAX, ERANGE, strtol, 10);
+	DO_ERR_TEST("-9223372036854775809", LONG_MIN, ERANGE, strtol, 10);
+	// wcstol
+	DO_TESTL(L"-9223372036854775808", LONG_MIN, wcstol, 10);
+	DO_TESTL(L"9223372036854775807", LONG_MAX, wcstol, 10);
+	DO_ERR_TESTL(L"9223372036854775808", LONG_MAX, ERANGE, wcstol, 10);
+	DO_ERR_TESTL(L"-9223372036854775809", LONG_MIN, ERANGE, wcstol, 10);
+
+	// strtoll
+	DO_TEST("-9223372036854775808", LONG_MIN, strtoll, 10);
+	DO_TEST("9223372036854775807", LONG_MAX, strtoll, 10);
+	DO_ERR_TEST("9223372036854775808", LLONG_MAX, ERANGE, strtol, 10);
+	DO_ERR_TEST("-9223372036854775809", LLONG_MIN, ERANGE, strtol, 10);
+	// wcstoll
+	DO_TESTL(L"-9223372036854775808", LONG_MIN, wcstoll, 10);
+	DO_TESTL(L"9223372036854775807", LONG_MAX, wcstoll, 10);
+	DO_ERR_TESTL(L"9223372036854775808", LLONG_MAX, ERANGE, wcstol, 10);
+	DO_ERR_TESTL(L"-9223372036854775809", LLONG_MIN, ERANGE, wcstol, 10);
+
+	// strtoul
+	DO_TEST("-1", -(1UL), strtoul, 10);
+	DO_TEST("9223372036854775807", LONG_MAX, strtoul, 10);
+	DO_TEST("18446744073709551615", ULONG_MAX, strtoul, 10);
+	DO_TEST("-18446744073709551615", 1UL, strtoul, 10);
+	DO_ERR_TEST("18446744073709551616", ULONG_MAX, ERANGE, strtoul, 10);
+	// wcstoul
+	DO_TESTL(L"-1", -(1UL), wcstoul, 10);
+	DO_TESTL(L"9223372036854775807", LONG_MAX, wcstoul, 10);
+	DO_TESTL(L"18446744073709551615", ULONG_MAX, wcstoul, 10);
+	DO_TESTL(L"-18446744073709551615", 1UL, wcstoul, 10);
+	DO_ERR_TESTL(L"18446744073709551616", ULONG_MAX, ERANGE, wcstoul, 10);
+
+	// strtoull
+	DO_TEST("-1", -(1UL), strtoull, 10);
+	DO_TEST("9223372036854775807", LONG_MAX, strtoull, 10);
+	DO_TEST("18446744073709551615", ULONG_MAX, strtoull, 10);
+	DO_TEST("-18446744073709551615", 1UL, strtoull, 10);
+	DO_ERR_TEST("18446744073709551616", ULONG_MAX, ERANGE, strtoull, 10);
+	// wcstoull
+	DO_TESTL(L"-1", -(1UL), wcstoull, 10);
+	DO_TESTL(L"9223372036854775807", LONG_MAX, wcstoull, 10);
+	DO_TESTL(L"18446744073709551615", ULONG_MAX, wcstoull, 10);
+	DO_TESTL(L"-18446744073709551615", 1UL, wcstoull, 10);
+	DO_ERR_TESTL(L"18446744073709551616", ULONG_MAX, ERANGE, wcstoull, 10);
+
 	return 0;
 }


### PR DESCRIPTION
This PR fixes the current implementation of `strtol` and friends by replacing it with a generic implementation in idiomatic C++. It also adds a much more comprehensive set of tests.

When testing it was discovered that this commit somehow triggers an issue in `read_dns_name`, so we also fix that.

Fixes https://github.com/managarm/mlibc/issues/467.
