### PR TITLE
options/ansi: Handle EOF in ungetc properly

### DIFF
--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -39,6 +39,9 @@ namespace {
 	// Useful when debugging the FILE implementation.
 	constexpr bool globallyDisableBuffering = false;
 
+	// The maximum number of characters we permit the user to ungetc.
+	constexpr size_t ungetBufferSize = 8;
+
 	// List of files that will be flushed before exit().
 	file_list &global_file_list() {
 		static frg::eternal<file_list> list;
@@ -56,6 +59,7 @@ abstract_file::abstract_file(void (*do_dispose)(abstract_file *))
 : _type{stream_type::unknown}, _bufmode{buffer_mode::unknown}, _do_dispose{do_dispose} {
 	// TODO: For __fwriting to work correctly, set the __io_mode to 1 if the write is write-only.
 	__buffer_ptr = nullptr;
+	__unget_ptr = nullptr;
 	__buffer_size = 4096;
 	__offset = 0;
 	__io_offset = 0;
@@ -74,7 +78,7 @@ abstract_file::~abstract_file() {
 				<< frg::endlog;
 
 	if(__buffer_ptr)
-		getAllocator().free(__buffer_ptr);
+		getAllocator().free(__buffer_ptr - ungetBufferSize);
 
 	auto it = global_file_list().iterator_to(this);
 	global_file_list().erase(it);
@@ -96,16 +100,17 @@ int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 	if(_init_bufmode())
 		return -1;
 
-	bool wroteUngetc = false;
-	if (_ungetStorage) {
-		buffer[0] = _ungetStorage.value();
-		buffer++;
-		max_size--;
-		_ungetStorage = {};
-		wroteUngetc = true;
+	size_t unget_length = 0;
+	if (__unget_ptr != __buffer_ptr) {
+		unget_length = frg::min(max_size, (size_t)(__unget_ptr - __buffer_ptr));
+		memcpy(buffer, __unget_ptr, unget_length);
+
+		__unget_ptr += unget_length;
+		buffer += unget_length;
+		max_size -= unget_length;
 
 		if (max_size == 0) {
-			*actual_size = 1;
+			*actual_size = unget_length;
 			return 0;
 		}
 	}
@@ -118,7 +123,7 @@ int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 		}
 		if(!io_size)
 			__status_bits |= __MLIBC_EOF_BIT;
-		*actual_size = io_size + (wroteUngetc ? 1 : 0);
+		*actual_size = io_size + unget_length;
 		return 0;
 	}
 
@@ -161,7 +166,7 @@ int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 	memcpy(buffer, __buffer_ptr + __offset, chunk);
 	__offset += chunk;
 
-	*actual_size = chunk + (wroteUngetc ? 1 : 0);
+	*actual_size = chunk + unget_length;
 	return 0;
 }
 
@@ -239,11 +244,18 @@ int abstract_file::write(const char *buffer, size_t max_size, size_t *actual_siz
 }
 
 int abstract_file::unget(char c) {
-	if(_ungetStorage) {
-		_ungetStorage = c;
+	if (!__unget_ptr) {
+		// This can happen if the file is unbuffered, but we still need
+		// a space to store ungetc'd data.
+		__ensure(!__buffer_ptr);
+		_ensure_allocation();
+		__ensure(__unget_ptr);
+	}
+
+	if ((size_t)(__buffer_ptr - __unget_ptr) + 1 > ungetBufferSize)
 		return EOF;
-	} else {
-		_ungetStorage = c;
+	else {
+		*(--__unget_ptr) = c;
 		return c;
 	}
 }
@@ -261,7 +273,7 @@ void abstract_file::purge() {
 	__io_offset = 0;
 	__valid_limit = 0;
 	__dirty_end = __dirty_begin;
-	_ungetStorage = {};
+	__unget_ptr = __buffer_ptr;
 }
 
 int abstract_file::flush() {
@@ -402,13 +414,14 @@ int abstract_file::_reset() {
 	return 0;
 }
 
+// This may still be called when buffering is disabled, for ungetc.
 void abstract_file::_ensure_allocation() {
-	__ensure(__buffer_size);
 	if(__buffer_ptr)
 		return;
 
-	auto ptr = getAllocator().allocate(__buffer_size);
-	__buffer_ptr = reinterpret_cast<char *>(ptr);
+	auto ptr = getAllocator().allocate(__buffer_size + ungetBufferSize);
+	__buffer_ptr = reinterpret_cast<char *>(ptr) + ungetBufferSize;
+	__unget_ptr = __buffer_ptr;
 }
 
 // --------------------------------------------------------------------------------------

--- a/options/ansi/include/mlibc/file-io.hpp
+++ b/options/ansi/include/mlibc/file-io.hpp
@@ -5,6 +5,7 @@
 
 #include <mlibc/lock.hpp>
 #include <frg/list.hpp>
+#include <frg/optional.hpp>
 
 namespace mlibc {
 
@@ -37,7 +38,7 @@ public:
 
 	int read(char *buffer, size_t max_size, size_t *actual_size);
 	int write(const char *buffer, size_t max_size, size_t *actual_size);
-	void unget(char c);
+	int unget(char c);
 
 	int update_bufmode(buffer_mode mode);
 
@@ -67,6 +68,7 @@ private:
 	stream_type _type;
 	buffer_mode _bufmode;
 	void (*_do_dispose)(abstract_file *);
+	frg::optional<char> _ungetStorage;
 
 public:
 	// lock for file operations

--- a/options/ansi/include/mlibc/file-io.hpp
+++ b/options/ansi/include/mlibc/file-io.hpp
@@ -5,7 +5,6 @@
 
 #include <mlibc/lock.hpp>
 #include <frg/list.hpp>
-#include <frg/optional.hpp>
 
 namespace mlibc {
 
@@ -68,7 +67,6 @@ private:
 	stream_type _type;
 	buffer_mode _bufmode;
 	void (*_do_dispose)(abstract_file *);
-	frg::optional<char> _ungetStorage;
 
 public:
 	// lock for file operations

--- a/options/ansi/include/stdio.h
+++ b/options/ansi/include/stdio.h
@@ -26,6 +26,8 @@ extern "C" {
 
 struct __mlibc_file_base {
 	// Buffer for I/O operations.
+	// We reserve a few extra bytes for ungetc operations. This means
+	// that __buffer_ptr will point a few bytes *into* the allocation.
 	char *__buffer_ptr;
 
 	// Number of bytes the buffer can hold.
@@ -43,6 +45,11 @@ struct __mlibc_file_base {
 	// Begin and end of the dirty region inside the buffer.
 	size_t __dirty_begin;
 	size_t __dirty_end;
+
+	// This points to the same place as __buffer_ptr, or a few bytes earlier
+	// if there are bytes pushed by ungetc. If buffering is disabled, calls
+	// to ungetc will trigger an allocation.
+	char *__unget_ptr;
 
 	// 0 if we are currently reading from the buffer.
 	// 1 if we are currently writing to the buffer.

--- a/tests/ansi/ungetc.c
+++ b/tests/ansi/ungetc.c
@@ -23,24 +23,43 @@ void test(int buffering) {
 	assert(fgetc(f) == 'x');
 
 	// Test pushing back the same character
-	for(int c = '0'; c <= '9'; c++) {
+	for (int c = '0'; c <= '9'; c++) {
 		assert(fgetc(f) == c);
 		assert(ungetc(c, f) == c);
 		assert(fgetc(f) == c);
 	}
 	assert(fgetc(f) == EOF);
 	assert(ungetc(EOF, f) == EOF);
+
+	// Even though the spec does not guarantee it, we should be able to
+	// ungetc more than one character.
 	assert(ungetc('x', f) == 'x');
+	assert(ungetc('y', f) == 'y');
+	assert(fgetc(f) == 'y');
+	assert(fgetc(f) == 'x');
 
 	// Seeking should discard the effects of ungetc.
+	assert(ungetc('x', f) == 'x');
 	rewind(f);
 
 	// Test pushing back a different character
-	for(int c = '0'; c <= '9'; c++) {
+	for (int c = '0'; c <= '9'; c++) {
 		assert(fgetc(f) == c);
 		assert(ungetc(c - '0' + 'a', f) == c - '0' + 'a');
 		assert(fgetc(f) == c - '0' + 'a');
 	}
+
+#ifndef USE_HOST_LIBC
+	// Too many ungetcs should fail.
+	int eof = 0;
+	for (int i = 0; i < 100; i++) {
+		if (ungetc('x', f) == EOF) {
+			eof = 1;
+			break;
+		}
+	}
+	assert(eof);
+#endif
 
 	fclose(f);
 
@@ -48,6 +67,8 @@ void test(int buffering) {
 }
 
 int main() {
+	fprintf(stderr, "with buffering...\n");
 	test(1);
+	fprintf(stderr, "without buffering...\n");
 	test(0);
 }

--- a/tests/ansi/ungetc.c
+++ b/tests/ansi/ungetc.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <assert.h>
+
+#ifdef USE_HOST_LIBC
+#define TEST_FILE "ungetc-host-libc.tmp"
+#else
+#define TEST_FILE "ungetc.tmp"
+#endif
+
+void test(int buffering) {
+	FILE *f = fopen(TEST_FILE, "w");
+	for(int c = '0'; c <= '9'; c++) {
+		fputc(c, f);
+	}
+	fclose(f);
+
+	f = fopen(TEST_FILE, "r");
+	if (!buffering) {
+		setbuf(f, NULL);
+	}
+
+	assert(ungetc('x', f) == 'x');
+	assert(fgetc(f) == 'x');
+
+	// Test pushing back the same character
+	for(int c = '0'; c <= '9'; c++) {
+		assert(fgetc(f) == c);
+		assert(ungetc(c, f) == c);
+		assert(fgetc(f) == c);
+	}
+	assert(fgetc(f) == EOF);
+	assert(ungetc(EOF, f) == EOF);
+	assert(ungetc('x', f) == 'x');
+
+	// Seeking should discard the effects of ungetc.
+	rewind(f);
+
+	// Test pushing back a different character
+	for(int c = '0'; c <= '9'; c++) {
+		assert(fgetc(f) == c);
+		assert(ungetc(c - '0' + 'a', f) == c - '0' + 'a');
+		assert(fgetc(f) == c - '0' + 'a');
+	}
+
+	fclose(f);
+
+	// TODO: Test with other operations, like fread.
+}
+
+int main() {
+	test(1);
+	test(0);
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,7 @@ ansi_test_cases = [
 	'wcsrtombs',
 	'wmemcmp',
 	'time',
+	'ungetc',
 	'wcsdup',
 	'wcsncasecmp',
 	'fopen'


### PR DESCRIPTION
This, together with a locking patch in gtk+3 (or a change in the way we lock things in file-io.cpp), allows gtk+3 to run again on Managarm. Many thanks to @64 for the test and fixing ungetc even further.