### PR TITLE
options/posix: implement stpncpy and move stpcpy to posix

### DIFF
--- a/options/ansi/generic/string-stubs.cpp
+++ b/options/ansi/generic/string-stubs.cpp
@@ -437,12 +437,6 @@ void *mempcpy(void *dest, const void *src, size_t len) {
 	return (char *)memcpy(dest, src, len) + len;
 }
 
-char *stpcpy(char *__restrict dest, const char *__restrict src) {
-	auto n = strlen(src);
-	memcpy(dest, src, n + 1);
-	return dest + n;
-}
-
 // GNU extensions.
 // Taken from musl.
 int strverscmp(const char *l0, const char *r0) {

--- a/options/ansi/include/string.h
+++ b/options/ansi/include/string.h
@@ -53,7 +53,6 @@ size_t strlen(const char *s);
 
 int strerror_r(int, char *, size_t);
 void *mempcpy(void *, const void *, size_t);
-char *stpcpy(char *__restrict, const char *__restrict);
 
 // GNU extensions.
 int strverscmp(const char *l0, const char *r0);

--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -29,6 +29,27 @@ char *strndup(const char *string, size_t max_size) {
 	return new_string;
 }
 
+char *stpcpy(char *__restrict dest, const char *__restrict src) {
+	auto n = strlen(src);
+	memcpy(dest, src, n + 1);
+	return dest + n;
+}
+
+char *stpncpy(char *__restrict dest, const char *__restrict src, size_t n) {
+	size_t nulls, copied, srcLen = strlen(src);
+	if (n >= srcLen) {
+		nulls = n - srcLen;
+		copied = srcLen;
+	} else {
+		nulls = 0;
+		copied = n;
+	}
+
+	memcpy(dest, src, copied);
+	memset(dest + srcLen, 0, nulls);
+	return dest + n - nulls;
+}
+
 size_t strnlen(const char *s, size_t n) {
 	size_t len = 0;
 	while(len < n && s[len])

--- a/options/posix/include/bits/posix/posix_string.h
+++ b/options/posix/include/bits/posix/posix_string.h
@@ -14,6 +14,8 @@ size_t strnlen(const char *, size_t);
 char *strtok_r(char *__restrict, const char *__restrict, char **__restrict);
 char *strsep(char **stringp, const char *delim);
 char *strsignal(int sig);
+char *stpcpy(char *__restrict, const char *__restrict);
+char *stpncpy(char *__restrict, const char *__restrict, size_t n);
 
 int strcoll_l(const char *s1, const char *s2, locale_t locale);
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -56,6 +56,7 @@ posix_test_cases = [
 	'system', # This test should be in the ANSI tests, but it depends on sys/wait.h
 	'sigsuspend',
 	'sigaltstack',
+	'string',
 	'realpath',
 	'ffs',
 	'getcwd',

--- a/tests/posix/string.c
+++ b/tests/posix/string.c
@@ -1,0 +1,29 @@
+#include <string.h>
+#include <assert.h>
+
+int main() {
+	char buf[4];
+
+	// stpncpy
+	assert(stpncpy(buf, "", 4) == buf);
+	assert(!strcmp(buf, ""));
+	
+	assert(stpncpy(buf, "123", 4) == buf + 3);
+	assert(!strcmp(buf, "123"));
+	
+	assert(stpncpy(buf, "12", 4) == buf + 2);
+	assert(buf[0] == '1' && buf[1] == '2' && buf[2] == '\0' && buf[3] == '\0');
+
+	assert(stpncpy(buf, "123456", 4) == buf + 4);
+	assert(buf[0] == '1' && buf[1] == '2' && buf[2] == '3' && buf[3] == '4');
+
+	// stpcpy
+	assert(stpcpy(buf, "") == buf);
+	assert(!strcmp(buf, ""));
+	
+	assert(stpcpy(buf, "12") == buf + 2);
+	assert(!strcmp(buf, "12"));
+	
+	assert(stpcpy(buf, "123") == buf + 3);
+	assert(!strcmp(buf, "123"));
+}


### PR DESCRIPTION
`stpcpy` previously lived in `options/ansi`.
