### PR TITLE
options/internal: implement ubsan hooks for libc.so and ld.so internal usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,5 @@ jobs:
             uses: actions/checkout@v2
           - name: Compile sysdeps
             run: |
-                meson "-Dc_args=['-fno-stack-protector']" "-Dcpp_args=['-fno-stack-protector']" "-Dbuild_tests=true" --cross-file ci/${{matrix.sysdeps}}.cross-file compile-${{matrix.sysdeps}}
+                meson "-Dc_args=['-fno-stack-protector']" "-Dcpp_args=['-fno-stack-protector']" "-Dbuild_tests=true" "-Db_sanitize=undefined" --cross-file ci/${{matrix.sysdeps}}.cross-file compile-${{matrix.sysdeps}}
                 ninja -C compile-${{matrix.sysdeps}}

--- a/ci/bootstrap.yml
+++ b/ci/bootstrap.yml
@@ -69,6 +69,7 @@ packages:
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
         - "-Dbuild_tests=true"
+        - "-Db_sanitize=undefined"
         - "-Dwerror=true"
         - '@THIS_SOURCE_DIR@'
         environ:
@@ -90,6 +91,7 @@ packages:
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
         - "-Dbuild_tests=true"
+        - "-Db_sanitize=undefined"
         - "-Dstatic=true"
         - "-Dwerror=true"
         - '@THIS_SOURCE_DIR@'
@@ -111,6 +113,7 @@ packages:
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
         - "-Dbuild_tests=true"
+        - "-Db_sanitize=undefined"
         - "-Dwerror=true"
         - "-Ddisable_posix_option=true"
         - "-Ddisable_linux_option=true"

--- a/meson.build
+++ b/meson.build
@@ -223,6 +223,7 @@ internal_sources = [
 	'options/internal/generic/essential.cpp',
 	'options/internal/generic/frigg.cpp',
 	'options/internal/generic/sigset.cpp',
+	'options/internal/generic/ubsan.cpp',
 	'options/internal/gcc/stack_protector.cpp',
 	'options/internal/gcc/guard-abi.cpp',
 	'options/internal/gcc/initfini.cpp',
@@ -266,6 +267,7 @@ rtdl_sources += [
 	'options/internal/generic/ensure.cpp',
 	'options/internal/generic/essential.cpp',
 	'options/internal/generic/frigg.cpp',
+	'options/internal/generic/ubsan.cpp',
 	'options/rtdl/generic/main.cpp',
 	'options/rtdl/generic/linker.cpp',
 	'options/rtdl' / host_machine.cpu_family() / 'runtime.S'

--- a/options/internal/generic/essential.cpp
+++ b/options/internal/generic/essential.cpp
@@ -5,7 +5,8 @@ namespace {
 	// Needed since we cannot declare a templated enum.
 	template<typename T>
 	struct word_helper {
-		enum class [[gnu::may_alias, gnu::aligned(1)]] word_enum : T { };
+		using underlying [[gnu::aligned(1)]] = T;
+		enum class [[gnu::may_alias]] word_enum : underlying { };
 	};
 
 	template<typename T>

--- a/options/internal/generic/ubsan.cpp
+++ b/options/internal/generic/ubsan.cpp
@@ -1,0 +1,233 @@
+#include <limits.h>
+#include <mlibc/debug.hpp>
+
+#define FMT(obj) format_object((obj), opts, formatter)
+
+#define LOG_NAME_LOC(name, loc) "ubsan: " name " at " << loc << "\n  "
+#define LOG_LHS_RHS(lhs, rhs) "LHS = " << (lhs) << ", RHS = " << (rhs)
+
+struct SourceLocation {
+	const char *filename;
+	uint32_t line;
+	uint32_t column;
+};
+
+template<class F>
+void format_object(const SourceLocation &loc, frg::format_options opts, F &formatter) {
+	FMT(loc.filename);
+	FMT(":");
+	FMT(loc.line);
+	FMT(":");
+	FMT(loc.column);
+}
+
+using ValueHandle = uintptr_t;
+
+struct TypeDescriptor {
+	enum class Kind : uint16_t {
+		Integer = 0x0000,
+		Float = 0x0001,
+		Unknown = 0xffff
+	} kind;
+
+	uint16_t info;
+	char name[];
+
+	unsigned bitWidthInt() const {
+		return 1 << (info >> 1);
+	}
+
+	bool isInlineInt() const {
+		if (kind != Kind::Integer)
+			return false;
+
+		auto inlineBits = sizeof(ValueHandle) * CHAR_BIT;
+		auto valueBits = bitWidthInt();
+		return inlineBits <= valueBits;
+	}
+
+	bool isSigned() const {
+		return info & 1;
+	}
+};
+
+template<class F>
+void format_object(const TypeDescriptor &type, frg::format_options opts, F &formatter) {
+	FMT(type.name);
+}
+
+struct Value {
+	const TypeDescriptor &type;
+	ValueHandle val;
+
+	Value(const TypeDescriptor &type, ValueHandle val) : type(type), val(val) {}
+};
+
+template<class F>
+void format_object(const Value &val, frg::format_options opts, F &formatter) {
+	if (val.type.isInlineInt() && val.type.isSigned()) {
+		auto signedValue = static_cast<int64_t>(val.val);
+		FMT(signedValue);
+	} else if (val.type.isInlineInt() && !val.type.isSigned()) {
+		auto unsignedValue = static_cast<uint64_t>(val.val);
+		FMT(unsignedValue);
+	}
+
+	FMT(" (");
+	FMT(val.type);
+	FMT(")");
+}
+
+
+// --- Hook implementations ---
+
+struct TypeMismatch {
+	SourceLocation loc;
+	const TypeDescriptor &type;
+	unsigned char logAlignment;
+	unsigned char kind;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_type_mismatch_v1(TypeMismatch *tm, ValueHandle pointer) {
+	// TODO: Make this print more information.
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("type mismatch", tm->loc)
+		<< "accessed address " << (void *)pointer << " but type "
+		<< tm->type << " requires alignment " << (1 << tm->logAlignment)
+		<< frg::endlog;
+}
+
+struct PointerOverflowData {
+	SourceLocation loc;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_pointer_overflow(PointerOverflowData *pod, ValueHandle base, ValueHandle result) {
+	(void)base;
+	(void)result;
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("pointer overflow", pod->loc)
+		<< frg::endlog;
+}
+
+struct InvalidValueData {
+	SourceLocation loc;
+	const TypeDescriptor &type;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_load_invalid_value(InvalidValueData *ivd, ValueHandle value) {
+	(void)value;
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("load of invalid value", ivd->loc)
+		<< frg::endlog;
+}
+
+struct OverflowData {
+	SourceLocation loc;
+	const TypeDescriptor &type;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_add_overflow(OverflowData *od, ValueHandle lhs, ValueHandle rhs) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("add overflowed ", od->loc)
+		<< LOG_LHS_RHS(Value(od->type, lhs), Value(od->type, rhs))
+		<< frg::endlog;
+}
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_sub_overflow(OverflowData *od, ValueHandle lhs, ValueHandle rhs) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("sub overflowed", od->loc)
+		<< LOG_LHS_RHS(Value(od->type, lhs), Value(od->type, rhs))
+		<< frg::endlog;
+}
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_mul_overflow(OverflowData *od, ValueHandle lhs, ValueHandle rhs) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("mul overflowed", od->loc)
+		<< LOG_LHS_RHS(Value(od->type, lhs), Value(od->type, rhs))
+		<< frg::endlog;
+}
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_divrem_overflow(OverflowData *od, ValueHandle lhs, ValueHandle rhs) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("divrem overflowed", od->loc)
+		<< LOG_LHS_RHS(Value(od->type, lhs), Value(od->type, rhs))
+		<< frg::endlog;
+}
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_negate_overflow(OverflowData *od, ValueHandle lhs, ValueHandle rhs) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("negate overflowed", od->loc)
+		<< LOG_LHS_RHS(Value(od->type, lhs), Value(od->type, rhs))
+		<< frg::endlog;
+}
+
+struct ShiftOutOfBoundsData {
+	SourceLocation loc;
+	const TypeDescriptor &lhsType;
+	const TypeDescriptor &rhsType;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_shift_out_of_bounds(ShiftOutOfBoundsData *soob, ValueHandle lhs, ValueHandle rhs) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("shift out of bounds", soob->loc)
+		<< LOG_LHS_RHS(Value(soob->lhsType, lhs), Value(soob->rhsType, rhs))
+		<< frg::endlog;
+}
+
+struct OutOfBoundsData {
+	SourceLocation loc;
+	const TypeDescriptor &arrayType;
+	const TypeDescriptor &indexType;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_out_of_bounds(OutOfBoundsData *oobd, ValueHandle data) {
+	(void)data;
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("out of bounds access", oobd->loc)
+		<< frg::endlog;
+}
+
+struct UnreachableData {
+	SourceLocation loc;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_builtin_unreachable(UnreachableData *ubd) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("reached __builtin_unreachable()", ubd->loc)
+		<< frg::endlog;
+}
+
+struct InvalidBuiltinData {
+	SourceLocation loc;
+	unsigned char kind;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_invalid_builtin(InvalidBuiltinData *ibd) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("reached invalid builtin", ibd->loc)
+		<< frg::endlog;
+}
+
+struct VLABoundData {
+	SourceLocation loc;
+	const TypeDescriptor &type;
+};
+
+extern "C" [[gnu::visibility("hidden")]]
+void __ubsan_handle_vla_bound_not_positive(VLABoundData *vlabd) {
+	mlibc::panicLogger()
+		<< LOG_NAME_LOC("VLA bound not positive", vlabd->loc)
+		<< frg::endlog;
+}

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -170,6 +170,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 		case DT_RELASZ:
 		case DT_RELAENT:
 		case DT_RELACOUNT:
+		case DT_DEBUG:
 			continue;
 		default:
 			__ensure(!"Unexpected dynamic entry in program interpreter");

--- a/tests/glibc/ffsl-ffsll.c
+++ b/tests/glibc/ffsl-ffsll.c
@@ -1,20 +1,31 @@
 #include <assert.h>
 #include <string.h>
+#include <limits.h>
 
 int main(void){
-    long test1 = 1L << (sizeof(long) * 8 - 1);
-    long long test2 = 1LL << (sizeof(long long) * 8 - 1);
+	// ffsl
+	assert(ffsl(0x8000) == 16);
+	assert(ffsl(0) == 0);
+	assert(ffsl(LLONG_MAX - 1) ==  2);
+	assert(ffsl(LLONG_MAX) == 1);
+	assert(ffsl(LONG_MIN) == (long)(sizeof(long) * CHAR_BIT));
+	assert(ffsl(LONG_MIN + 1) == 1);
 
-    assert(ffsl(test1) == sizeof(long) * 8);
-    assert(ffsll(test2) == sizeof(long long) * 8);
-    assert(ffsl(0) == 0);
-    assert(ffsll(0) == 0);
-    assert(ffsl(test1) == ffsll(test1));
-    if(sizeof(long) < sizeof(long long)){
-        assert(ffsl(test1) < ffsll(test2));
-    } else {
-        assert(ffsl(test2) == ffsll(test2));
-    }
+	for (int i = 1; i < 0x1000; i++) {
+		assert(ffsl(i) - 1 == __builtin_ctz(i));
+	}
 
-    return 0;
+	// ffsll
+	assert(ffsll(0x8000) == 16);
+	assert(ffsll(0) == 0);
+	assert(ffsll(LLONG_MAX - 1) ==  2);
+	assert(ffsll(LLONG_MAX) == 1);
+	assert(ffsll(LLONG_MIN) == (long long)(sizeof(long long) * CHAR_BIT));
+	assert(ffsll(LLONG_MIN + 1) == 1);
+
+	for (int i = 1; i < 0x1000; i++) {
+		assert(ffsll(i) - 1 == __builtin_ctz(i));
+	}
+
+	return 0;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -90,6 +90,10 @@ test_sources = [
 	crt
 ]
 
+# Our ubsan implementation can't be used by the tests themselves,
+# since it is internal to libc.so and ld.so.
+test_override_options = ['b_sanitize=none']
+
 if static
 	test_sources += '../options/internal/gcc-extra/mlibc_crtbegin.S'
 	test_sources += '../options/internal' / host_machine.cpu_family() / 'mlibc_crtend.S'
@@ -100,6 +104,7 @@ if not disable_ansi_option
 		exec = executable('ansi-' + f, ['ansi/' + f + '.c', test_sources],
 			link_with: libc, include_directories: libc_include_dirs,
 			build_rpath: meson.build_root(),
+			override_options: test_override_options,
 			c_args: '-no-pie',
 			link_args: ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so',
 				'-no-pie'])
@@ -112,6 +117,7 @@ if not disable_bsd_option
 		exec = executable('ansi-' + f, ['bsd/' + f + '.c', test_sources],
 			link_with: libc, include_directories: libc_include_dirs,
 			build_rpath: meson.build_root(),
+			override_options: test_override_options,
 			c_args: '-no-pie',
 			link_args: ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so',
 				'-no-pie'])
@@ -124,6 +130,7 @@ if not disable_posix_option
 		exec = executable('posix-' + f, ['posix/' + f + '.c', test_sources],
 			link_with: libc, include_directories: libc_include_dirs,
 			build_rpath: meson.build_root(),
+			override_options: test_override_options,
 			c_args: '-no-pie',
 			link_args: ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so',
 				'-no-pie'])
@@ -134,6 +141,7 @@ if not disable_posix_option
 		exec = executable('posix-' + f, ['posix/' + f + '.c', test_sources],
 			link_with: libc, include_directories: libc_include_dirs,
 			build_rpath: meson.build_root(),
+			override_options: test_override_options,
 			c_args: '-no-pie',
 			link_args: ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so',
 				'-no-pie'])
@@ -147,6 +155,7 @@ if not disable_posix_option
 		exec = executable('glibc-' + f, ['glibc/' + f + '.c', test_sources],
 			link_with: libc, include_directories: libc_include_dirs,
 			build_rpath: meson.build_root(),
+			override_options: test_override_options,
 			c_args: '-no-pie',
 			link_args: ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so',
 				'-no-pie'])
@@ -158,6 +167,7 @@ foreach f : rtdl_test_cases
     exec = executable('rtdl-' + f, ['rtdl/' + f + '.c', test_sources],
 	    link_with: libc, include_directories: libc_include_dirs,
 	    build_rpath: meson.build_root(),
+		override_options: test_override_options,
 	    c_args: '-no-pie',
 	    link_args: ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so',
 		    '-no-pie'])


### PR DESCRIPTION
The `ffsl-ffsll` test had to also be fixed because it was crashing with UBSan enabled. We refactor it along the lines of #445.