### PR TITLE
sysdeps: add reminder to call __dlapi_enter for static builds to work properly

### DIFF
--- a/sysdeps/aero/generic/entry.cpp
+++ b/sysdeps/aero/generic/entry.cpp
@@ -28,6 +28,7 @@ LibraryGuard::LibraryGuard() {
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[],
                                              char *env[])) {
+    // TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
     auto result =
         main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
     exit(result);

--- a/sysdeps/dripos/generic/entry.cpp
+++ b/sysdeps/dripos/generic/entry.cpp
@@ -28,6 +28,7 @@ LibraryGuard::LibraryGuard() {
 }
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
+	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
 	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
 	exit(result);
 }

--- a/sysdeps/ironclad/generic/entry.cpp
+++ b/sysdeps/ironclad/generic/entry.cpp
@@ -28,6 +28,7 @@ LibraryGuard::LibraryGuard() {
 }
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
+	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
 	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
 	exit(result);
 }

--- a/sysdeps/lemon/generic/entry.cpp
+++ b/sysdeps/lemon/generic/entry.cpp
@@ -27,6 +27,7 @@ LibraryGuard::LibraryGuard() {
 }
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
+	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
 	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
 	exit(result);
 }

--- a/sysdeps/managarm/generic/entry.cpp
+++ b/sysdeps/managarm/generic/entry.cpp
@@ -124,6 +124,7 @@ LibraryGuard::LibraryGuard() {
 }
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
+	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
 	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
 	exit(result);
 }

--- a/sysdeps/qword/generic/entry.cpp
+++ b/sysdeps/qword/generic/entry.cpp
@@ -28,6 +28,7 @@ LibraryGuard::LibraryGuard() {
 }
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
+	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
 	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
 	exit(result);
 }


### PR DESCRIPTION
This should reduce some confusion for new ports.