### PR TITLE
options/posix: Define TIOCM_DTR and TIOCM_RTS

### DIFF
--- a/options/posix/include/termios.h
+++ b/options/posix/include/termios.h
@@ -123,6 +123,9 @@ extern "C" {
 #define TCOOFF 3
 #define TCOON 4
 
+#define TIOCM_DTR 0x002
+#define TIOCM_RTS 0x004
+
 speed_t cfgetispeed(const struct termios *);
 speed_t cfgetospeed(const struct termios *);
 int cfsetispeed(struct termios *, speed_t);


### PR DESCRIPTION
This should fix `tcl` not building on Managarm ci.