### PR TITLE
options/ansi: fix wrong pointer subtract in fread

### DIFF
--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -102,7 +102,7 @@ int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 
 	size_t unget_length = 0;
 	if (__unget_ptr != __buffer_ptr) {
-		unget_length = frg::min(max_size, (size_t)(__unget_ptr - __buffer_ptr));
+		unget_length = frg::min(max_size, (size_t)(__buffer_ptr - __unget_ptr));
 		memcpy(buffer, __unget_ptr, unget_length);
 
 		__unget_ptr += unget_length;


### PR DESCRIPTION
This is the wrong way around since `__buffer_ptr >= __unget_ptr` holds as an invariant.
