### PR TITLE
rtdl: fix rpaths under 7 characters crashing rtdl

### DIFF
--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -167,7 +167,7 @@ SharedObject *ObjectRepository::requestObjectWithName(frg::string_view name,
 	// preprocessing the rpath only once on parse
 	auto processRpath = [&] (frg::string_view path) {
 		frg::string<MemoryAllocator> sPath { getAllocator() };
-		if (path.sub_string(0, 7) == "$ORIGIN") {
+		if (path.starts_with("$ORIGIN")) {
 			frg::string_view dirname = origin->path;
 			auto lastsl = dirname.find_last('/');
 			if (lastsl != (uint64_t)-1) {


### PR DESCRIPTION
(detected by netbsduser while working on SCAL-UX)

With an rpath of "/", rtdl would fail to substring the rpath, causing an
assertion failure and hence a crash. As the code here implements a
replace functionality, such a substring failure should simply not do a
replace instead.

Depends on https://github.com/managarm/frigg/pull/33 (re-run checks when that gets merged)