### PR TITLE
meson: install bits/inline-definitions.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -247,6 +247,7 @@ if not no_headers
 		'options/internal/include/bits/off_t.h',
 		'options/internal/include/bits/ssize_t.h',
 		'options/internal/include/bits/sigset_t.h',
+		'options/internal/include/bits/inline-definition.h',
 		subdir: 'bits'
 	)
 endif


### PR DESCRIPTION
Forgot this in #507. I guess nothing in the CI includes this header :^)