### PR TITLE
meta: add ABI_BREAKS.md

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -1,0 +1,8 @@
+# ABI Breaks
+
+This document lists the ABI breaks that were made in each mlibc major version.
+
+## Version 3
+
+- [#452](https://github.com/managarm/mlibc/pull/452): The functions `FD_{CLR,ISSET,SET,ZERO}` were renamed to `__FD_{CLR,ISSET,SET,ZERO}` and replaced by macros to match Wine's assumptions.
+


### PR DESCRIPTION
Future PRs against the `abi-break` branch should add a note here explaining the change to downstream users.