### PR TITLE
riscv: use far jump to init/fini

### DIFF
--- a/options/internal/riscv64/mlibc_crtend.S
+++ b/options/internal/riscv64/mlibc_crtend.S
@@ -2,10 +2,10 @@
 .hidden __mlibc_do_dtors
 
 .section .init
-	j __mlibc_do_ctors
+	tail __mlibc_do_ctors
 
 .section .fini
-	j __mlibc_do_dtors
+	tail __mlibc_do_dtors
 
 .section .ctors
 .hidden __CTOR_END__


### PR DESCRIPTION
This should fix the 'relocation truncated to fit' errors we see on the `abi-break` branch.
