### PR TITLE
Fix inline-emitter not including mlibc-config.h

### DIFF
--- a/options/internal/generic/inline-emitter.cpp
+++ b/options/internal/generic/inline-emitter.cpp
@@ -3,6 +3,8 @@
 
 #define __MLIBC_EMIT_INLINE_DEFINITIONS
 
+#include <mlibc-config.h>
+
 #include <elf.h>
 
 #ifdef __MLIBC_LINUX_OPTION

--- a/options/linux/include/sys/sysmacros.h
+++ b/options/linux/include/sys/sysmacros.h
@@ -1,6 +1,10 @@
 #ifndef _SYS_SYSMACROS_H
 #define _SYS_SYSMACROS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <bits/inline-definition.h>
 
 __MLIBC_INLINE_DEFINITION unsigned int __mlibc_dev_major(
@@ -23,5 +27,9 @@ __MLIBC_INLINE_DEFINITION unsigned long long int __mlibc_dev_makedev(
 #define major(dev) __mlibc_dev_major(dev)
 #define minor(dev) __mlibc_dev_minor(dev)
 #define makedev(major, minor) __mlibc_dev_makedev(major, minor)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _SYS_SYSMACROS_H


### PR DESCRIPTION
Also add `extern "C"` to the macros in `sys/sysmacros.h`