### PR TITLE
Various fixes for mlibc LFS part 3

### DIFF
--- a/options/posix/include/dirent.h
+++ b/options/posix/include/dirent.h
@@ -28,6 +28,8 @@ struct dirent {
 	char d_name[1024];
 };
 
+#define d_fileno d_ino
+
 struct __mlibc_dir_struct {
 	int __handle;
 	__mlibc_size __ent_next;

--- a/options/posix/include/sys/syslog.h
+++ b/options/posix/include/sys/syslog.h
@@ -1,0 +1,1 @@
+#include <syslog.h>

--- a/options/posix/meson.build
+++ b/options/posix/meson.build
@@ -128,6 +128,7 @@ if not no_headers
 		'include/sys/utsname.h',
 		'include/sys/vfs.h',
 		'include/sys/wait.h',
+		'include/sys/syslog.h',
 		subdir: 'sys'
 	)
 	install_headers(


### PR DESCRIPTION
Round 3, mostly defines again, a few structs, two missing headers and several compatibility defines.

Part of the mlibc LFS project.