### PR TITLE
abis: Define PACKET_HOST

### DIFF
--- a/abis/linux/packet.h
+++ b/abis/linux/packet.h
@@ -1,0 +1,6 @@
+#ifndef _ABIBITS_PACKET_H
+#define _ABIBITS_PACKET_H
+
+#define PACKET_HOST 0
+
+#endif // _ABIBITS_PACKET_H

--- a/abis/mlibc/packet.h
+++ b/abis/mlibc/packet.h
@@ -1,0 +1,6 @@
+#ifndef _ABIBITS_PACKET_H
+#define _ABIBITS_PACKET_H
+
+#define PACKET_HOST 0
+
+#endif // _ABIBITS_PACKET_H

--- a/options/linux/include/netpacket/packet.h
+++ b/options/linux/include/netpacket/packet.h
@@ -1,6 +1,8 @@
 #ifndef _NETPACKET_PACKET_H
 #define _NETPACKET_PACKET_H
 
+#include <abi-bits/packet.h>
+
 struct sockaddr_ll {
 	unsigned short int sll_family;
 	unsigned short int sll_protocol;

--- a/sysdeps/aero/include/abi-bits/packet.h
+++ b/sysdeps/aero/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/packet.h

--- a/sysdeps/aero/meson.build
+++ b/sysdeps/aero/meson.build
@@ -44,6 +44,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		subdir: 'abi-bits'
 	)
 	install_headers(

--- a/sysdeps/dripos/include/abi-bits/packet.h
+++ b/sysdeps/dripos/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/packet.h

--- a/sysdeps/dripos/meson.build
+++ b/sysdeps/dripos/meson.build
@@ -40,6 +40,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		subdir: 'abi-bits'
 	)
 endif

--- a/sysdeps/ironclad/include/abi-bits/packet.h
+++ b/sysdeps/ironclad/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/packet.h

--- a/sysdeps/ironclad/meson.build
+++ b/sysdeps/ironclad/meson.build
@@ -40,6 +40,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		subdir: 'abi-bits'
 	)
 	install_headers(

--- a/sysdeps/lemon/include/abi-bits/packet.h
+++ b/sysdeps/lemon/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/packet.h

--- a/sysdeps/lemon/meson.build
+++ b/sysdeps/lemon/meson.build
@@ -45,6 +45,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		subdir: 'abi-bits'
 	)
 	install_headers(

--- a/sysdeps/linux/include/abi-bits/packet.h
+++ b/sysdeps/linux/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/packet.h

--- a/sysdeps/linux/meson.build
+++ b/sysdeps/linux/meson.build
@@ -54,6 +54,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		host_machine.cpu_family() / 'abi-bits/arch-syscall.h',
 		subdir: 'abi-bits'
 	)

--- a/sysdeps/managarm/include/abi-bits/packet.h
+++ b/sysdeps/managarm/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/packet.h

--- a/sysdeps/managarm/meson.build
+++ b/sysdeps/managarm/meson.build
@@ -95,6 +95,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		subdir: 'abi-bits'
 	)
 endif

--- a/sysdeps/qword/include/abi-bits/packet.h
+++ b/sysdeps/qword/include/abi-bits/packet.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/packet.h

--- a/sysdeps/qword/meson.build
+++ b/sysdeps/qword/meson.build
@@ -40,6 +40,7 @@ if not no_headers
 		'include/abi-bits/ptrace.h',
 		'include/abi-bits/poll.h',
 		'include/abi-bits/epoll.h',
+		'include/abi-bits/packet.h',
 		subdir: 'abi-bits'
 	)
 	install_headers(


### PR DESCRIPTION
This PR adds a bunch of missing constants into the Linux ABI. It also stubs 2 functions and adds 2 new sysdeps.

Part of the mlibc LFS project.