### PR TITLE
abis/linux: Add various missing ip related structs and defines

### DIFF
--- a/abis/linux/in.h
+++ b/abis/linux/in.h
@@ -49,6 +49,17 @@ struct ipv6_mreq {
 	unsigned        ipv6mr_interface;
 };
 
+struct in_pktinfo {
+	unsigned int ipi_ifindex;
+	struct in_addr ipi_spec_dst;
+	struct in_addr ipi_addr;
+};
+
+struct group_req {
+	uint32_t gr_interface;
+	struct sockaddr_storage gr_group;
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/abis/linux/in.h
+++ b/abis/linux/in.h
@@ -39,6 +39,11 @@ struct sockaddr_in6 {
 	uint32_t        sin6_scope_id;
 };
 
+struct ip_mreq {
+	struct in_addr imr_multiaddr;
+	struct in_addr imr_interface;
+};
+
 struct ipv6_mreq {
 	struct in6_addr ipv6mr_multiaddr;
 	unsigned        ipv6mr_interface;

--- a/abis/linux/in.h
+++ b/abis/linux/in.h
@@ -55,6 +55,11 @@ struct in_pktinfo {
 	struct in_addr ipi_addr;
 };
 
+struct in6_pktinfo {
+	struct in6_addr ipi6_addr;
+	uint32_t ipi6_ifindex;
+};
+
 struct group_req {
 	uint32_t gr_interface;
 	struct sockaddr_storage gr_group;
@@ -116,5 +121,42 @@ struct group_req {
 #define IPPROTO_MPLS     137
 #define IPPROTO_RAW      255
 #define IPPROTO_MAX      256
+
+#define IP_TOS 1
+#define IP_TTL 2
+#define IP_PKTINFO 8
+#define IP_MULTICAST_IF 32
+#define IP_MULTICAST_TTL 33
+#define IP_MULTICAST_LOOP 34
+#define IP_ADD_MEMBERSHIP 35
+#define IP_DROP_MEMBERSHIP 36
+
+#define IPV6_UNICAST_HOPS 16
+#define IPV6_MULTICAST_IF 17
+#define IPV6_MULTICAST_HOPS 18
+#define IPV6_MULTICAST_LOOP 19
+#define IPV6_JOIN_GROUP 20
+#define IPV6_LEAVE_GROUP 21
+#define IPV6_V6ONLY 26
+#define IPV6_RECVPKTINFO 49
+#define IPV6_PKTINFO 50
+#define IPV6_RECVHOPLIMIT 51
+#define IPV6_HOPLIMIT 52
+
+/* These defines are needed for compatibility with Linux kernel headers. */
+#define __UAPI_DEF_IN_ADDR      0
+#define __UAPI_DEF_IN_IPPROTO   0
+#define __UAPI_DEF_IN_PKTINFO   0
+#define __UAPI_DEF_IP_MREQ      0
+#define __UAPI_DEF_SOCKADDR_IN  0
+#define __UAPI_DEF_IN_CLASS     0
+#define __UAPI_DEF_IN6_ADDR     0
+#define __UAPI_DEF_IN6_ADDR_ALT 0
+#define __UAPI_DEF_SOCKADDR_IN6 0
+#define __UAPI_DEF_IPV6_MREQ    0
+#define __UAPI_DEF_IPPROTO_V6   0
+#define __UAPI_DEF_IPV6_OPTIONS 0
+#define __UAPI_DEF_IN6_PKTINFO  0
+#define __UAPI_DEF_IP6_MTUINFO  0
 
 #endif // _ABITBITS_IN_H


### PR DESCRIPTION
Split off from #541 

Part of the mlibc LFS projec