### PR TITLE
abis/linux: Define SCM_CREDENTIALS

### DIFF
--- a/abis/linux/socket.h
+++ b/abis/linux/socket.h
@@ -35,6 +35,7 @@ struct mmsghdr {
 #endif
 
 #define SCM_RIGHTS 1
+#define SCM_CREDENTIALS 2
 
 #define SHUT_RD 0
 #define SHUT_WR 1


### PR DESCRIPTION
Split off from #541 

Part of the mlibc LFS project.