### PR TITLE
abis/linux: Define _NSIG

### DIFF
--- a/abis/linux/signal.h
+++ b/abis/linux/signal.h
@@ -162,6 +162,7 @@ typedef struct __stack {
 #define SIGEV_THREAD 2
 
 #define NSIG 65
+#define  _NSIG NSIG
 
 #define SI_ASYNCNL (-60)
 #define SI_TKILL (-6)

--- a/abis/linux/signal.h
+++ b/abis/linux/signal.h
@@ -162,7 +162,6 @@ typedef struct __stack {
 #define SIGEV_THREAD 2
 
 #define NSIG 65
-#define  _NSIG NSIG
 
 #define SI_ASYNCNL (-60)
 #define SI_TKILL (-6)

--- a/options/ansi/include/signal.h
+++ b/options/ansi/include/signal.h
@@ -30,6 +30,8 @@ __sighandler signal(int sig, __sighandler handler);
 
 int raise(int sig);
 
+#define _NSIG NSIG
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Split off from #544 

Part of the mlibc LFS project.