### PR TITLE
abis/linux: Define LOGIN_NAME_MAX

### DIFF
--- a/abis/linux/limits.h
+++ b/abis/linux/limits.h
@@ -2,5 +2,6 @@
 #define _ABIBITS_LIMITS_H
 
 #define IOV_MAX 1024
+#define LOGIN_NAME_MAX 256
 
 #endif //_ABIBITS_LIMITS_H


### PR DESCRIPTION
Split off from #544

Part of the mlibc LFS project.