### PR TITLE
options/posix: Define _SC_TTY_NAME_MAX

### DIFF
--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -119,6 +119,7 @@ extern "C" {
 #define _SC_XOPEN_CRYPT 16
 #define _SC_NPROCESSORS_CONF 17
 #define _SC_SYMLOOP_MAX 18
+#define _SC_TTY_NAME_MAX 19
 
 #define STDERR_FILENO 2
 #define STDIN_FILENO 0


### PR DESCRIPTION
Split off from #544

Part of the mlibc LFS project.