### PR TITLE
options/linux: Include certain linux specific headers in sys/syscall.h if we're linux

### DIFF
--- a/options/linux/include/sys/syscall.h
+++ b/options/linux/include/sys/syscall.h
@@ -2,5 +2,9 @@
 #define _SYS_SYSCALL_H
 
 // OpenSSL wants this header to exist
+#ifdef __linux__
+#include <abi-bits/arch-syscall.h>
+#include <asm/unistd.h>
+#endif
 
 #endif // _SYS_SYSCALL_H


### PR DESCRIPTION
After #525 was merged, programs still refused to use the syscall macro, claiming it couldn't be found. This fixes that problem.

Part of mlibc LFS project.