### PR TITLE
abis/mlibc: make struct sigaction and siginfo_t match linux ABI

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -7,3 +7,4 @@ This document lists the ABI breaks that were made in each mlibc major version.
 - [#452](https://github.com/managarm/mlibc/pull/452): The functions `FD_{CLR,ISSET,SET,ZERO}` were renamed to `__FD_{CLR,ISSET,SET,ZERO}` and replaced by macros to match Wine's assumptions.
 - [#511](https://github.com/managarm/mlibc/pull/511): Musl's regex engine was added, implementing `regcomp` and `regexec`. This required some changes to the `regex_t` struct.
 - [#504](https://github.com/managarm/mlibc/pull/504), [#580](https://github.com/managarm/mlibc/pull/580): In both the mlibc and Linux ABIs, a `domainname` member was added to `struct utsname`, which is a glibc extension.
+- [#594](https://github.com/managarm/mlibc/pull/594): The signal ABI was changed so that `sa_handler` and `sa_sigaction` are a union, and `siginfo_t` uses a union internally (matching the Linux ABI and providing additional members).

--- a/abis/linux/clock_t.h
+++ b/abis/linux/clock_t.h
@@ -1,0 +1,6 @@
+#ifndef _ABIBITS_CLOCK_T_H
+#define _ABIBITS_CLOCK_T_H
+
+typedef long clock_t;
+
+#endif // _ABIBITS_CLOCK_T_H

--- a/abis/linux/signal.h
+++ b/abis/linux/signal.h
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <abi-bits/pid_t.h>
 #include <abi-bits/uid_t.h>
+#include <abi-bits/clock_t.h>
 #include <bits/size_t.h>
 
 union sigval {

--- a/abis/mlibc/signal.h
+++ b/abis/mlibc/signal.h
@@ -1,6 +1,7 @@
 #ifndef _ABIBITS_SIGNAL_H
 #define _ABIBITS_SIGNAL_H
 
+#include <abi-bits/clock_t.h>
 #include <abi-bits/pid_t.h>
 #include <abi-bits/uid_t.h>
 #include <bits/size_t.h>

--- a/options/ansi/include/time.h
+++ b/options/ansi/include/time.h
@@ -1,6 +1,7 @@
 #ifndef _TIME_H
 #define _TIME_H
 
+#include <abi-bits/clock_t.h>
 #include <bits/null.h>
 #include <bits/size_t.h>
 #include <bits/ansi/time_t.h>
@@ -29,8 +30,6 @@ extern "C" {
 #endif
 
 // [7.27.1] Components of time
-
-typedef long clock_t; // Matches Linux' ABI.
 
 struct tm {
 	int tm_sec;

--- a/options/posix/include/sys/time.h
+++ b/options/posix/include/sys/time.h
@@ -2,6 +2,7 @@
 #define _SYS_TIME_H
 
 #include <abi-bits/time.h>
+#include <abi-bits/clock_t.h>
 #include <bits/ansi/time_t.h>
 #include <bits/posix/suseconds_t.h>
 #include <bits/posix/timeval.h>

--- a/sysdeps/aero/include/abi-bits/clock_t.h
+++ b/sysdeps/aero/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/dripos/include/abi-bits/clock_t.h
+++ b/sysdeps/dripos/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/ironclad/include/abi-bits/clock_t.h
+++ b/sysdeps/ironclad/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/lemon/include/abi-bits/clock_t.h
+++ b/sysdeps/lemon/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/linux/include/abi-bits/clock_t.h
+++ b/sysdeps/linux/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/managarm/include/abi-bits/clock_t.h
+++ b/sysdeps/managarm/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/qword/include/abi-bits/clock_t.h
+++ b/sysdeps/qword/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h

--- a/sysdeps/vinix/include/abi-bits/clock_t.h
+++ b/sysdeps/vinix/include/abi-bits/clock_t.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/clock_t.h


### PR DESCRIPTION
Fixes #257. Fixes #590. Obsoletes #463.
