### PR TITLE
options/ansi: cache value of env var MLIBC_DEBUG_MALLOC

### DIFF
--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -421,10 +421,19 @@ size_t wcstombs(char *mb_string, const wchar_t *wc_string, size_t max_size) {
 	return wcsrtombs(mb_string, &wc_string, max_size, 0);
 }
 
+static bool debugMalloc() {
+	static bool debug = [] () -> bool {
+		// TODO: We should use a locking variant of getenv here to guard
+		// against concurrent modifications of the environment.
+		auto value = getenv("MLIBC_DEBUG_MALLOC");
+		return value && !strcmp(value, "1");
+	}(); // Immediately invoked.
+	return debug;
+}
 
 void free(void *ptr) {
 	// TODO: Print PID only if POSIX option is enabled.
-	if(getenv("MLIBC_DEBUG_MALLOC")) {
+	if(debugMalloc()) {
 		mlibc::infoLogger() << "mlibc (PID ?): free() on "
 				<< ptr << frg::endlog;
 		if((uintptr_t)ptr & 1)
@@ -436,7 +445,7 @@ void free(void *ptr) {
 void *malloc(size_t size) {
 	auto nptr = getAllocator().allocate(size);
 	// TODO: Print PID only if POSIX option is enabled.
-	if(getenv("MLIBC_DEBUG_MALLOC"))
+	if(debugMalloc())
 		mlibc::infoLogger() << "mlibc (PID ?): malloc() returns "
 				<< nptr << frg::endlog;
 	return nptr;
@@ -445,7 +454,7 @@ void *malloc(size_t size) {
 void *realloc(void *ptr, size_t size) {
 	auto nptr = getAllocator().reallocate(ptr, size);
 	// TODO: Print PID only if POSIX option is enabled.
-	if(getenv("MLIBC_DEBUG_MALLOC"))
+	if(debugMalloc())
 		mlibc::infoLogger() << "mlibc (PID ?): realloc() on "
 				<< ptr << " returns " << nptr << frg::endlog;
 	return nptr;


### PR DESCRIPTION
Fixes #597.
