### PR TITLE
tests/ansi: check that fclose(stdout) doesn't crash on exit

### DIFF
--- a/tests/ansi/fopen.c
+++ b/tests/ansi/fopen.c
@@ -50,5 +50,10 @@ int main() {
 	assert(!strcmp(buffer2, completestr));
 	fclose(file);
 
+	// Check that stdout, stdin and stderr can be closed by the application (issue #12).
+	fclose(stdout);
+	fclose(stdin);
+	fclose(stderr);
+
 	return 0;
 }


### PR DESCRIPTION
This was fixed earlier, but it doesn't hurt to add a test for this case. See #12.