### PR TITLE
rtdl: don't load the same SONAME twice

### DIFF
--- a/options/rtdl/generic/linker.hpp
+++ b/options/rtdl/generic/linker.hpp
@@ -53,6 +53,8 @@ struct ObjectRepository {
 
 	SharedObject *findCaller(void *address);
 
+	SharedObject *findLoadedObject(frg::string_view name);
+
 private:
 	void _fetchFromPhdrs(SharedObject *object, void *phdr_pointer,
 			size_t phdr_entry_size, size_t num_phdrs, void *entry_pointer);
@@ -110,6 +112,7 @@ struct SharedObject {
 	frg::string<MemoryAllocator> name;
 	frg::string<MemoryAllocator> path;
 	frg::string<MemoryAllocator> interpreterPath;
+	const char *soName;
 	bool isMainObject;
 	uint64_t objectRts;
 

--- a/tests/rtdl/dl_iterate_phdr/test.c
+++ b/tests/rtdl/dl_iterate_phdr/test.c
@@ -11,9 +11,8 @@
 #define LIBBAR "libnative-bar.so"
 #else
 #define LDSO_PATTERN "ld.so"
-// Temporarily hardcode the paths to work around issue #584.
-#define LIBFOO "tests/rtdl/dl_iterate_phdr/libfoo.so"
-#define LIBBAR "tests/rtdl/dl_iterate_phdr/libbar.so"
+#define LIBFOO "libfoo.so"
+#define LIBBAR "libbar.so"
 #endif
 
 struct result {

--- a/tests/rtdl/meson.build
+++ b/tests/rtdl/meson.build
@@ -1,6 +1,7 @@
 rtdl_test_cases = [
 	'dl_iterate_phdr',
 	'rtld_next',
+	'soname',
 ]
 
 foreach test_name : rtdl_test_cases 

--- a/tests/rtdl/soname/libbar.c
+++ b/tests/rtdl/soname/libbar.c
@@ -1,0 +1,1 @@
+char *name() { return "bar"; }

--- a/tests/rtdl/soname/libfoo.c
+++ b/tests/rtdl/soname/libfoo.c
@@ -1,0 +1,1 @@
+char *name() { return "foo"; }

--- a/tests/rtdl/soname/meson.build
+++ b/tests/rtdl/soname/meson.build
@@ -1,0 +1,17 @@
+# Create two libraries with the same SONAME.
+bar_soname = '-Wl,-soname=libbar.so'
+
+libfoo = shared_library('foo', 'libfoo.c', link_args: '-Wl,-soname=libbar.so')
+libbar = shared_library('bar', 'libbar.c', link_args: '-Wl,-soname=libbar.so')
+test_depends = [libfoo, libbar]
+
+libfoo_native = shared_library('native-foo', 'libfoo.c',
+	link_args: ['-ldl', '-Wl,-soname=libnative-bar.so'],
+	native: true
+)
+libbar_native = shared_library('native-bar', 'libbar.c',
+	link_args: ['-ldl', '-Wl,-soname=libnative-bar.so'],
+	native: true
+)
+test_native_depends = [libfoo_native, libbar_native]
+

--- a/tests/rtdl/soname/test.c
+++ b/tests/rtdl/soname/test.c
@@ -1,0 +1,33 @@
+#include <dlfcn.h>
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+#ifdef USE_HOST_LIBC
+#define LIBFOO "libnative-foo.so"
+#define LIBBAR "libnative-bar.so"
+#else
+#define LIBFOO "libfoo.so"
+#define LIBBAR "libbar.so"
+#endif
+
+int main() {
+	void *foo = dlopen(LIBFOO, RTLD_NOW);
+	void *bar = dlopen(LIBBAR, RTLD_NOW);
+	assert(foo);
+	assert(bar);
+
+	// Since these libraries have the same SONAME, they should return the same thing.
+	assert(foo == bar);
+
+	char *(*fooSym)(void) = dlsym(foo, "name");
+	char *(*barSym)(void) = dlsym(bar, "name");
+	assert(fooSym && barSym);
+	assert(fooSym() && barSym());
+	printf("foo: name() = \"%s\"\n", fooSym());
+	printf("bar: name() = \"%s\"\n", barSym());
+	assert(!strcmp(fooSym(), barSym()));
+
+	dlclose(foo);
+	dlclose(bar);
+}


### PR DESCRIPTION
Fixes #585. Also fixes some hardcoding of paths in the `dl_iterate_phdr` test.