### PR TITLE
options/posix: move local pthread keys into TCB

### DIFF
--- a/options/ansi/include/limits.h
+++ b/options/ansi/include/limits.h
@@ -51,6 +51,7 @@
 #define _POSIX_HOST_NAME_MAX 255
 
 #define PTHREAD_STACK_MIN 16384
+#define PTHREAD_KEYS_MAX 1024
 
 #include <abi-bits/limits.h>
 

--- a/options/internal/include/mlibc/tcb.hpp
+++ b/options/internal/include/mlibc/tcb.hpp
@@ -71,15 +71,6 @@ namespace mlibc {
 	}
 }
 
-// There are a few parts of the mlibc code which assume the layout of
-// this struct:
-//
-// options/linker/aarch64/runtime.S uses the offset of dtvPointers.
-// sysdeps/linux/{riscv64,x86_64}/cp_syscall.S uses the offset of cancelBits.
-//
-// Gcc also expects the stack canary to be at fs:0x28,
-// at least on x86_64, so this struct has fixed
-// ABI until stackCanary.
 struct Tcb {
 	Tcb *selfPointer;
 	size_t dtvSize;
@@ -120,3 +111,21 @@ struct Tcb {
 	frg::array<LocalKey, PTHREAD_KEYS_MAX> *localKeys;
 };
 
+// There are a few places where we assume the layout of the TCB:
+#if defined(__x86_64__)
+// sysdeps/linux/x86_64/cp_syscall.S uses the offset of cancelBits.
+// GCC also expects the stack canary to be at fs:0x28.
+static_assert(offsetof(Tcb, stackCanary) == 0x28);
+static_assert(offsetof(Tcb, cancelBits) == 0x30);
+#elif defined(__aarch64__)
+// options/linker/aarch64/runtime.S uses the offset of dtvPointers.
+static_assert(offsetof(Tcb, dtvPointers) == 16);
+#elif defined(__riscv) && __riscv_xlen == 64
+// The thread pointer on RISC-V points to *after* the TCB, and since
+// we need to access specific fields that means that the value in
+// sysdeps/linux/riscv64/cp_syscall.S needs to be updated whenever
+// the struct is expanded.
+static_assert(sizeof(Tcb) - offsetof(Tcb, cancelBits) == 56);
+#else
+#error "Missing architecture specific code."
+#endif

--- a/options/internal/include/mlibc/tcb.hpp
+++ b/options/internal/include/mlibc/tcb.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <stdint.h>
+#include <limits.h>
 #include <bits/size_t.h>
+#include <frg/array.hpp>
 
 /*
  * Explanation of cancellation bits:
@@ -110,5 +112,11 @@ struct Tcb {
 	CleanupHandler *cleanupBegin;
 	CleanupHandler *cleanupEnd;
 	int isJoinable;
+
+	struct LocalKey {
+		void *value;
+		uint64_t generation;
+	};
+	frg::array<LocalKey, PTHREAD_KEYS_MAX> *localKeys;
 };
 

--- a/options/posix/include/pthread.h
+++ b/options/posix/include/pthread.h
@@ -60,7 +60,6 @@ extern "C" {
 #define PTHREAD_CANCELED ((void*) -1)
 
 // values for pthread_key
-#define PTHREAD_KEYS_MAX 1024
 #define PTHREAD_DESTRUCTOR_ITERATIONS 8
 
 #define PTHREAD_INHERIT_SCHED 0

--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -844,6 +844,7 @@ Tcb *allocateTcb() {
 	tcb_ptr->didExit = 0;
 	tcb_ptr->isJoinable = 1;
 	tcb_ptr->returnValue = nullptr;
+	tcb_ptr->localKeys = frg::construct<frg::array<Tcb::LocalKey, PTHREAD_KEYS_MAX>>(getAllocator());
 	tcb_ptr->dtvSize = runtimeTlsMap->indices.size();
 	tcb_ptr->dtvPointers = frg::construct_n<void *>(getAllocator(), runtimeTlsMap->indices.size());
 	memset(tcb_ptr->dtvPointers, 0, sizeof(void *) * runtimeTlsMap->indices.size());

--- a/sysdeps/linux/riscv64/cp_syscall.S
+++ b/sysdeps/linux/riscv64/cp_syscall.S
@@ -13,7 +13,7 @@ __mlibc_do_asm_cp_syscall:
 	mv a4, a5
 	mv a5, a6
 	ld a6, -8(sp) // a7
-	lw t0, -56(tp) // Tcb::cancelBits
+	lw t0, -56(tp) // Tcb::cancelBits. See asserts in tcb.hpp.
 __mlibc_syscall_begin:
 	// tcbCancelEnableBit && tcbCancelTriggerBit
 	li t1, (1 << 0) | (1 << 2)

--- a/sysdeps/linux/riscv64/cp_syscall.S
+++ b/sysdeps/linux/riscv64/cp_syscall.S
@@ -13,7 +13,7 @@ __mlibc_do_asm_cp_syscall:
 	mv a4, a5
 	mv a5, a6
 	ld a6, -8(sp) // a7
-	lw t0, -48(tp) // Tcb::cancelBits
+	lw t0, -56(tp) // Tcb::cancelBits
 __mlibc_syscall_begin:
 	// tcbCancelEnableBit && tcbCancelTriggerBit
 	li t1, (1 << 0) | (1 << 2)


### PR DESCRIPTION
Followed on from #618. This avoids a call to `__tls_get_addr` inside `pthread_getspecific` / `pthread_setspecific`, which should allow ASan to function. We also add some locking that was missed before.

~~Blocked on #622.~~