### PR TITLE
rtdl: zero .tbss and correctly align TCB

### DIFF
--- a/options/internal/riscv64-include/mlibc/thread.hpp
+++ b/options/internal/riscv64-include/mlibc/thread.hpp
@@ -2,15 +2,16 @@
 
 #include <stdint.h>
 #include <mlibc/tcb.hpp>
+#include <bits/ensure.h>
 
 namespace mlibc {
 
 inline Tcb *get_current_tcb() {
-	uintptr_t ptr = (uintptr_t)__builtin_thread_pointer();
-
 	// On RISC-V, the TCB is below the thread pointer.
-	// TODO: This may be wrong if the TLS section has stricter alignment requirements.
-	return reinterpret_cast<Tcb *>(ptr - sizeof(Tcb));
+	uintptr_t tp = (uintptr_t)__builtin_thread_pointer();
+	auto tcb = reinterpret_cast<Tcb *>(tp - sizeof(Tcb));
+	__ensure(tcb == tcb->selfPointer);
+	return tcb;
 }
 
 } // namespace mlibc

--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -754,6 +754,7 @@ void initTlsObjects(Tcb *tcb, const frg::vector<SharedObject *, MemoryAllocator>
 
 			char *tcb_ptr = reinterpret_cast<char *>(tcb);
 			auto tls_ptr = tcb_ptr + object->tlsOffset;
+			memset(tls_ptr, 0, object->tlsSegmentSize);
 			memcpy(tls_ptr, object->tlsImagePtr, object->tlsImageSize);
 
 			if (checkInitialized)

--- a/tests/posix/pthread_thread_local.c
+++ b/tests/posix/pthread_thread_local.c
@@ -2,46 +2,52 @@
 #include <pthread.h>
 #include <assert.h>
  
-_Thread_local unsigned int rage = 9999; 
+_Thread_local unsigned int counter = 9999; 
 _Thread_local unsigned int uninitialized;
  
-void *check_rage(void *arg)
+void *check_counter(void *arg)
 {
 	(void)arg;
-    fprintf(stderr, "Rage counter for thread a: %d, at %p\n", rage, &rage);
+	fprintf(stderr, "counter for worker thread: %d, at %p\n", counter, &counter);
 	fflush(stderr);
-	assert(rage == 9999);
+	assert(counter == 9999);
+
+	fprintf(stderr, "uninitialized data for worker thread: %d, at %p\n", uninitialized, &uninitialized);
+	fflush(stderr);
 	assert(uninitialized == 0);
 
-	++rage;
+	++counter;
 	++uninitialized;
-    fprintf(stderr, "Rage counter for thread a: %d\n", rage);
+	fprintf(stderr, "counter for worker thread: %d\n", counter);
 	fflush(stderr);
-	assert(rage == 10000);
+	assert(counter == 10000);
 	assert(uninitialized == 1);
 	return NULL;
 }
  
 int main()
 {
-    fprintf(stderr, "Rage counter for main: %d, at %p\n", rage, &rage);
+	fprintf(stderr, "counter for main thread: %d, at %p\n", counter, &counter);
 	fflush(stderr);
-	assert(rage == 9999);
+	assert(counter == 9999);
+
+	fprintf(stderr, "uninitialized data for main thread: %d, at %p\n", uninitialized, &uninitialized);
+	fflush(stderr);
 	assert(uninitialized == 0);
 
-	++rage;
+	++counter;
 	++uninitialized;
-    fprintf(stderr, "Rage counter for main: %d\n", rage);
+	fprintf(stderr, "counter for main: %d\n", counter);
 	fflush(stderr);
-	assert(rage == 10000);
+	assert(counter == 10000);
 	assert(uninitialized == 1);
 
 	pthread_t thd;
-	pthread_create(&thd, NULL, check_rage, NULL);
+	pthread_create(&thd, NULL, check_counter, NULL);
 	pthread_join(thd, NULL);
 
-    fprintf(stderr, "Rage counter for main: %d\n", rage);
+	fprintf(stderr, "counter for main: %d\n", counter);
 	fflush(stderr);
-	assert(rage == 10000);
+	assert(counter == 10000);
 	assert(uninitialized == 1);
 }


### PR DESCRIPTION
Previously, the TCB was not correctly aligned:
* On AArch64 and RISC-V, the assumption `tp + sizeoc(Tcb) == tlsData` would break if sizeof(Tcb) was not a multiple of `tlsMaxAlignment`. This meant that adding members to `Tcb` would cause a breakage.
* On x86_64, we relied on the default alignment of the memory allocator to provide sufficient alignment for the TCB and TLS data (though this caused no breakage in practice).

This also fixes a bug whereby the `.tbss` was not being zeroed on the main thread.