### PR TITLE
abis/linux: Add some missing defines

### DIFF
--- a/abis/linux/limits.h
+++ b/abis/linux/limits.h
@@ -4,5 +4,6 @@
 #define IOV_MAX 1024
 #define LOGIN_NAME_MAX 256
 #define NAME_MAX 255
+#define OPEN_MAX 256
 
 #endif //_ABIBITS_LIMITS_H

--- a/abis/mlibc/limits.h
+++ b/abis/mlibc/limits.h
@@ -9,4 +9,6 @@
 // Maximum hostname length, posix defines it as 255
 #define HOST_NAME_MAX 255
 
+#define OPEN_MAX 256
+
 #endif //_ABIBITS_LIMITS_H


### PR DESCRIPTION
Xorg libraries really liked `OPEN_MAX`, so I defined it. `libsanitizers` was complaining about `struct termio`, but it seems obsolete. I added it to the linux abi as to not pollute the global headers.

Part of the mlibc LFS project.