### PR TITLE
options/ansi: Fix signgam declaration

### DIFF
--- a/options/ansi/musl-generic-math/weak_alias.h
+++ b/options/ansi/musl-generic-math/weak_alias.h
@@ -1,7 +1,7 @@
 #ifndef _WEAK_ALIAS_H
 #define _WEAK_ALIAS_H
 
-#define weak_alias(name, alias) \
-	extern __typeof (name) alias __attribute__ ((weak, alias (#name)));
+#define weak_alias(name, alias_to) \
+	extern __typeof (name) alias_to __attribute__ ((weak, alias(#name)));
 
 #endif


### PR DESCRIPTION
`libsanitizers` was complaining about `signgam`, and while we did what musl does, this seems to please `libsanitizers`.

Part of the mlibc LFS project.