### PR TITLE
options/elf: Define _DYNAMIC

### DIFF
--- a/options/elf/include/link.h
+++ b/options/elf/include/link.h
@@ -45,6 +45,8 @@ struct r_debug {
 
 int dl_iterate_phdr(int (*callback)(struct dl_phdr_info*, size_t, void*), void* data);
 
+extern ElfW(Dyn) _DYNAMIC[];
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is needed for `libsanitizers`.

Part of the mlibc LFS project.