### PR TITLE
options/posix: Add dlvsym

### DIFF
--- a/options/posix/generic/dlfcn-stubs.cpp
+++ b/options/posix/generic/dlfcn-stubs.cpp
@@ -37,6 +37,13 @@ void *dlsym(void *__restrict handle, const char *__restrict string) {
 	return __dlapi_resolve(handle, string, ra);
 }
 
+[[gnu::noinline]]
+void *dlvsym(void *__restrict handle, const char *__restrict string, const char *__restrict version) {
+	mlibc::infoLogger() << "mlibc: dlvsym ignores version " << version << frg::endlog;
+	auto ra = __builtin_extract_return_addr(__builtin_return_address(0));
+	return __dlapi_resolve(handle, string, ra);
+}
+
 //gnu extensions
 int dladdr(const void *ptr, Dl_info *out) {
 	__dlapi_symbol info;

--- a/options/posix/include/dlfcn.h
+++ b/options/posix/include/dlfcn.h
@@ -23,6 +23,7 @@ int dlclose(void *);
 char *dlerror(void);
 void *dlopen(const char *, int);
 void *dlsym(void *__restrict, const char *__restrict);
+void *dlvsym(void *__restrict, const char *__restrict, const char *__restrict);
 
 //gnu extension
 typedef struct {


### PR DESCRIPTION
The implementation is only partial, as the version argument is ignored. Thus, `dlvsym` behaves just like `dlsym`.

Part of the mlibc LFS project.