### PR TITLE
sysdeps/linux: Include unistd.h in sys/syscall.h

### DIFF
--- a/sysdeps/linux/include/sys/syscall.h
+++ b/sysdeps/linux/include/sys/syscall.h
@@ -2,5 +2,8 @@
 #define _SYS_SYSCALL_H
 
 #include <abi-bits/arch-syscall.h>
+#if __has_include(<asm/unistd.h>)
+#include <asm/unistd.h>
+#endif
 
 #endif // _SYS_SYSCALL_H


### PR DESCRIPTION
I got compilation failures if this header is not included, I'm unsure about whether this is correct, so feedback is appreciated.

Part of the mlibc LFS project.