### PR TITLE
options/rtdl: Handle TPOFF64 with reloc->r_addend being not null

### DIFF
--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -1382,7 +1382,6 @@ void Loader::_processRela(SharedObject *object, Elf64_Rela *reloc) {
 						<< p->object()->name << frg::endlog;
 			*((uint64_t *)rel_addr) = p->object()->tlsOffset + p->symbol()->st_value;
 		}else{
-			__ensure(!reloc->r_addend);
 			if(stillSlightlyVerbose)
 				mlibc::infoLogger() << "rtdl: Warning: TPOFF64 with no symbol"
 						" in object " << object->name << frg::endlog;
@@ -1390,7 +1389,7 @@ void Loader::_processRela(SharedObject *object, Elf64_Rela *reloc) {
 				mlibc::panicLogger() << "rtdl: In object " << object->name
 						<< ": Static TLS relocation to dynamically loaded object "
 						<< object->name << frg::endlog;
-			*((uint64_t *)rel_addr) = object->tlsOffset;
+			*((uint64_t *)rel_addr) = object->tlsOffset + reloc->r_addend;
 		}
 	} break;
 #elif defined(__aarch64__)


### PR DESCRIPTION
The sanitizers from `libsanitizers` can produce symbols that trip this ensure, so we should fix it.

Part of the mlibc LFS project.