### PR TITLE
options/rtdl: Ignore the first item in __dlapi_iterate_phdr

### DIFF
--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -570,6 +570,12 @@ int __dlapi_iterate_phdr(int (*callback)(struct dl_phdr_info *, size_t, void*), 
 		struct dl_phdr_info info;
 		info.dlpi_addr = object->baseAddress;
 		info.dlpi_name = object->name.data();
+
+		if(object->isMainObject) {
+			info.dlpi_name = "";
+		} else {
+			info.dlpi_name = object->name.data();
+		}
 		info.dlpi_phdr = static_cast<ElfW(Phdr)*>(object->phdrPointer);
 		info.dlpi_phnum = object->phdrCount;
 		info.dlpi_adds = rtsCounter;
@@ -581,6 +587,8 @@ int __dlapi_iterate_phdr(int (*callback)(struct dl_phdr_info *, size_t, void*), 
 		info.dlpi_tls_data = tryAccessDtv(object);
 
 		last_return = callback(&info, sizeof(struct dl_phdr_info), data);
+		if(last_return)
+			return last_return;
 	}
 
 	return last_return;

--- a/tests/rtdl/dl_iterate_phdr/test.c
+++ b/tests/rtdl/dl_iterate_phdr/test.c
@@ -50,10 +50,8 @@ static int callback(struct dl_phdr_info *info, size_t size, void *data) {
 	if (contains(LDSO_PATTERN, info->dlpi_name))
 		found->found_ldso++;
 
-	// Temporarily disable this to work around issue #579.
-	// if (!strcmp("", info->dlpi_name))
-	// 	found->found_self++;
-	found->found_self = 1;
+	if (!strcmp("", info->dlpi_name))
+		found->found_self++;
 
 	assert(info->dlpi_phdr);
 	return 0;
@@ -85,8 +83,7 @@ int main() {
 	assert(!dl_iterate_phdr(callback, &found));
 	assert(found.found_ldso == 1);
 	assert(found.found_self == 1);
-	// Temporary workaround for issue #585.
-	// assert(found.found_foo == 1);
+	assert(found.found_foo == 1);
 	assert(found.found_foo > 0);
 	assert(found.found_bar == 1);
 

--- a/tests/rtdl/dl_iterate_phdr/test.c
+++ b/tests/rtdl/dl_iterate_phdr/test.c
@@ -33,7 +33,7 @@ static int ends_with(const char *suffix, const char *s) {
 }
 
 static int contains(const char *pattern, const char *s) {
-	return !!strstr(pattern, s);
+	return !!strstr(s, pattern);
 }
 
 static int callback(struct dl_phdr_info *info, size_t size, void *data) {


### PR DESCRIPTION
This matches the behavior of glibc and pleases ASan.

Part of the mlibc LFS project.

Fixes #579 