### PR TITLE
abis: deprecate some headers in the mlibc ABI

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -6,6 +6,6 @@ This document lists the ABI breaks that were made in each mlibc major version.
 
 - [#452](https://github.com/managarm/mlibc/pull/452): The functions `FD_{CLR,ISSET,SET,ZERO}` were renamed to `__FD_{CLR,ISSET,SET,ZERO}` and replaced by macros to match Wine's assumptions.
 - [#511](https://github.com/managarm/mlibc/pull/511): Musl's regex engine was added, implementing `regcomp` and `regexec`. This required some changes to the `regex_t` struct.
-- [#504](https://github.com/managarm/mlibc/pull/504), [#580](https://github.com/managarm/mlibc/pull/580): In both the mlibc and Linux ABIs, a `domainname` member was added to `struct utsname`, which is a glibc extension.
+- [#504](https://github.com/managarm/mlibc/pull/504): A `domainname` member was added to `struct utsname`, which is a glibc extension.
 - [#311](https://github.com/managarm/mlibc/pull/311): Added all necessary fields in `pthread_attr_t` required for implementing all `pthread_attr` functions.
 - [#652](https://github.com/managarm/mlibc/pull/652): The ABI of `struct statfs` and `struct statvfs` was changed to match Linux. `socklen_t` was also changed from `unsigned long` to `unsigned int`.

--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -6,6 +6,7 @@ This document lists the ABI breaks that were made in each mlibc major version.
 
 - [#452](https://github.com/managarm/mlibc/pull/452): The functions `FD_{CLR,ISSET,SET,ZERO}` were renamed to `__FD_{CLR,ISSET,SET,ZERO}` and replaced by macros to match Wine's assumptions.
 - [#511](https://github.com/managarm/mlibc/pull/511): Musl's regex engine was added, implementing `regcomp` and `regexec`. This required some changes to the `regex_t` struct.
-- [#504](https://github.com/managarm/mlibc/pull/504): A `domainname` member was added to `struct utsname`, which is a glibc extension.
+- [#504](https://github.com/managarm/mlibc/pull/504): In the Linux ABI, a `domainname` member was added to `struct utsname`, which is a glibc extension.
 - [#311](https://github.com/managarm/mlibc/pull/311): Added all necessary fields in `pthread_attr_t` required for implementing all `pthread_attr` functions.
 - [#652](https://github.com/managarm/mlibc/pull/652): The ABI of `struct statfs` and `struct statvfs` was changed to match Linux. `socklen_t` was also changed from `unsigned long` to `unsigned int`.
+- [#658](https://github.com/managarm/mlibc/pull/648): In the Linux ABI, `cc_t` was changed from an `unsigned int` to an `unsigned char`.

--- a/abis/linux/termios.h
+++ b/abis/linux/termios.h
@@ -1,7 +1,7 @@
 #ifndef _ABIBITS_TERMIOS_H
 #define _ABIBITS_TERMIOS_H
 
-typedef unsigned int cc_t;
+typedef unsigned char cc_t;
 typedef unsigned int speed_t;
 typedef unsigned int tcflag_t;
 

--- a/abis/linux/wait.h
+++ b/abis/linux/wait.h
@@ -22,4 +22,7 @@
 #define WIFCONTINUED(x) ((x) == 0xffff)
 #define WCOREDUMP(x) ((x) & WCOREFLAG)
 
+/* glibc extension, but also useful for kernels */
+#define W_EXITCODE(ret, sig) (((ret) << 8) | (sig))
+
 #endif //_ABIBITS_WAIT_H

--- a/abis/mlibc/signal.h
+++ b/abis/mlibc/signal.h
@@ -1,6 +1,11 @@
 #ifndef _ABIBITS_SIGNAL_H
 #define _ABIBITS_SIGNAL_H
 
+#if __MLIBC_BUILDING_MLIBC
+#warning abis/mlibc/signal.h is deprecated. We suggest to use abis/linux/signal.h instead. \
+	Note that this will potentially require kernel changes.
+#endif
+
 #include <abi-bits/pid_t.h>
 #include <abi-bits/uid_t.h>
 #include <bits/size_t.h>

--- a/abis/mlibc/termios.h
+++ b/abis/mlibc/termios.h
@@ -1,6 +1,11 @@
 #ifndef _ABIBITS_TERMIOS_H
 #define _ABIBITS_TERMIOS_H
 
+#if __MLIBC_BUILDING_MLIBC
+#warning abis/mlibc/termios.h is deprecated. We suggest to use abis/linux/termios.h instead. \
+	Note that this will potentially require kernel changes.
+#endif
+
 typedef unsigned int cc_t;
 typedef unsigned int speed_t;
 typedef unsigned int tcflag_t;

--- a/abis/mlibc/utsname.h
+++ b/abis/mlibc/utsname.h
@@ -7,7 +7,6 @@ struct utsname {
 	char release[65];
 	char version[65];
 	char machine[65];
-	char domainname[65];
 };
 
 #endif // _ABIBITS_UTSNAME_T_H

--- a/abis/mlibc/utsname.h
+++ b/abis/mlibc/utsname.h
@@ -1,6 +1,11 @@
 #ifndef _ABIBITS_UTSNAME_T_H
 #define _ABIBITS_UTSNAME_T_H
 
+#if __MLIBC_BUILDING_MLIBC
+#warning abis/mlibc/wait.h is deprecated. We suggest to use abis/linux/wait.h instead. \
+	Note that this will potentially require kernel changes.
+#endif
+
 struct utsname {
 	char sysname[65];
 	char nodename[65];

--- a/abis/mlibc/wait.h
+++ b/abis/mlibc/wait.h
@@ -1,6 +1,11 @@
 #ifndef _ABIBITS_WAIT_H
 #define _ABIBITS_WAIT_H
 
+#if __MLIBC_BUILDING_MLIBC
+#warning abis/mlibc/wait.h is deprecated. We suggest to use abis/linux/wait.h instead. \
+	Note that this will potentially require kernel changes.
+#endif
+
 #define WCONTINUED 1
 #define WNOHANG 2
 #define WUNTRACED 4

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ if not headers_only
 	add_languages('c', 'cpp')
 	c_compiler = meson.get_compiler('c')
 
-	add_project_arguments('-Wno-unused-function', language: ['c', 'cpp'])
+	add_project_arguments('-Wno-unused-function', '-D__MLIBC_BUILDING_MLIBC', language: ['c', 'cpp'])
 	add_project_arguments('-nostdinc', '-fno-builtin', language: ['c', 'cpp'])
 	add_project_arguments('-fno-rtti', '-fno-exceptions', language: 'cpp')
 	add_project_link_arguments('-nostdlib', language: ['c', 'cpp'])

--- a/sysdeps/aero/include/abi-bits/signal.h
+++ b/sysdeps/aero/include/abi-bits/signal.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/signal.h
+../../../../abis/linux/signal.h

--- a/sysdeps/aero/include/abi-bits/termios.h
+++ b/sysdeps/aero/include/abi-bits/termios.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/termios.h
+../../../../abis/linux/termios.h

--- a/sysdeps/aero/include/abi-bits/utsname.h
+++ b/sysdeps/aero/include/abi-bits/utsname.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/utsname.h
+../../../../abis/linux/utsname.h

--- a/sysdeps/aero/include/abi-bits/wait.h
+++ b/sysdeps/aero/include/abi-bits/wait.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/wait.h
+../../../../abis/linux/wait.h

--- a/sysdeps/managarm/include/abi-bits/signal.h
+++ b/sysdeps/managarm/include/abi-bits/signal.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/signal.h
+../../../../abis/linux/signal.h

--- a/sysdeps/managarm/include/abi-bits/utsname.h
+++ b/sysdeps/managarm/include/abi-bits/utsname.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/utsname.h
+../../../../abis/linux/utsname.h

--- a/sysdeps/managarm/include/abi-bits/wait.h
+++ b/sysdeps/managarm/include/abi-bits/wait.h
@@ -1,1 +1,1 @@
-../../../../abis/mlibc/wait.h
+../../../../abis/linux/wait.h


### PR DESCRIPTION
As discussed on Discord. This deprecates some headers in the `mlibc` ABI in favour of the Linux ABI. This partially reverts #580 (a deprecation notice is added instead).

Once we are happy with this PR, we should ping all the sysdep owners to see if they are happy to have their sysdeps moved over to the Linux ABI too, because these changes will require some modifications to their kernels.

Fixes #430, fixes #257, fixes #466.