### PR TITLE
options/{internal,rtdl}: add GlobalConfig and RtdlConfig

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -219,6 +219,7 @@ internal_sources = [
 	'options/internal/generic/ensure.cpp',
 	'options/internal/generic/essential.cpp',
 	'options/internal/generic/frigg.cpp',
+	'options/internal/generic/global-config.cpp',
 	'options/internal/generic/inline-emitter.cpp',
 	'options/internal/generic/locale.cpp',
 	'options/internal/generic/sigset.cpp',

--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -20,6 +20,7 @@
 #include <mlibc/ansi-sysdeps.hpp>
 #include <mlibc/strtofp.hpp>
 #include <mlibc/strtol.hpp>
+#include <mlibc/global-config.hpp>
 
 #ifdef __MLIBC_POSIX_OPTION
 #include <pthread.h>
@@ -436,19 +437,9 @@ size_t wcstombs(char *mb_string, const wchar_t *wc_string, size_t max_size) {
 	return wcsrtombs(mb_string, &wc_string, max_size, 0);
 }
 
-static bool debugMalloc() {
-	static bool debug = [] () -> bool {
-		// TODO: We should use a locking variant of getenv here to guard
-		// against concurrent modifications of the environment.
-		auto value = getenv("MLIBC_DEBUG_MALLOC");
-		return value && !strcmp(value, "1");
-	}(); // Immediately invoked.
-	return debug;
-}
-
 void free(void *ptr) {
 	// TODO: Print PID only if POSIX option is enabled.
-	if(debugMalloc()) {
+	if (mlibc::globalConfig().debugMalloc) {
 		mlibc::infoLogger() << "mlibc (PID ?): free() on "
 				<< ptr << frg::endlog;
 		if((uintptr_t)ptr & 1)
@@ -460,7 +451,7 @@ void free(void *ptr) {
 void *malloc(size_t size) {
 	auto nptr = getAllocator().allocate(size);
 	// TODO: Print PID only if POSIX option is enabled.
-	if(debugMalloc())
+	if (mlibc::globalConfig().debugMalloc)
 		mlibc::infoLogger() << "mlibc (PID ?): malloc() returns "
 				<< nptr << frg::endlog;
 	return nptr;
@@ -469,7 +460,7 @@ void *malloc(size_t size) {
 void *realloc(void *ptr, size_t size) {
 	auto nptr = getAllocator().reallocate(ptr, size);
 	// TODO: Print PID only if POSIX option is enabled.
-	if(debugMalloc())
+	if (mlibc::globalConfig().debugMalloc)
 		mlibc::infoLogger() << "mlibc (PID ?): realloc() on "
 				<< ptr << " returns " << nptr << frg::endlog;
 	return nptr;

--- a/options/internal/generic/global-config.cpp
+++ b/options/internal/generic/global-config.cpp
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+#include <string.h>
+#include <mlibc/global-config.hpp>
+
+namespace mlibc {
+
+struct GlobalConfigGuard {
+	GlobalConfigGuard();
+};
+
+GlobalConfigGuard guard;
+
+GlobalConfigGuard::GlobalConfigGuard() {
+	// Force the config to be created during initialization of libc.so.
+	mlibc::globalConfig();
+}
+
+static bool envEnabled(const char *env) {
+	auto value = getenv(env);
+	return value && *value && *value != '0';
+}
+
+GlobalConfig::GlobalConfig() {
+	debugMalloc = envEnabled("MLIBC_DEBUG_MALLOC");
+}
+
+}

--- a/options/internal/include/mlibc/global-config.hpp
+++ b/options/internal/include/mlibc/global-config.hpp
@@ -1,0 +1,19 @@
+#ifndef MLIBC_GLOBAL_CONFIG
+#define MLIBC_GLOBAL_CONFIG
+
+namespace mlibc {
+
+struct GlobalConfig {
+	GlobalConfig();
+	
+	bool debugMalloc;
+};
+
+inline const GlobalConfig &globalConfig() {
+	static GlobalConfig cached;
+	return cached;
+}
+
+}
+
+#endif // MLIBC_GLOBAL_CONFIG

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -16,6 +16,7 @@
 #include <mlibc/allocator.hpp>
 #include <mlibc/debug.hpp>
 #include <mlibc/posix-sysdeps.hpp>
+#include <mlibc/rtdl-config.hpp>
 
 namespace {
 	constexpr bool debugPathResolution = false;
@@ -466,10 +467,8 @@ int getloadavg(double *, int) {
 	__builtin_unreachable();
 }
 
-extern "C" int __dlapi_secure_required(void);
-
 char *secure_getenv(const char *name) {
-	if (__dlapi_secure_required())
+	if (mlibc::rtdlConfig().secureRequired)
 		return NULL;
 	else
 		return getenv(name);

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -7,6 +7,7 @@
 #include <abi-bits/auxv.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/rtdl-sysdeps.hpp>
+#include <mlibc/rtdl-config.hpp>
 #include <mlibc/rtdl-abi.hpp>
 #include <mlibc/stack_protector.hpp>
 #include <internal-config.h>
@@ -28,7 +29,8 @@ extern HIDDEN void *_GLOBAL_OFFSET_TABLE_[];
 extern HIDDEN Elf64_Dyn _DYNAMIC[];
 #endif
 
-bool secureRequired;
+mlibc::RtdlConfig rtdlConfig;
+
 uintptr_t *entryStack;
 frg::manual_box<ObjectRepository> initialRepository;
 frg::manual_box<Scope> globalScope;
@@ -222,7 +224,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 			case AT_ENTRY: entry_pointer = reinterpret_cast<void *>(*value); break;
 			case AT_EXECFN: execfn = reinterpret_cast<const char *>(*value); break;
 			case AT_RANDOM: stack_entropy = reinterpret_cast<void*>(*value); break;
-			case AT_SECURE: secureRequired = reinterpret_cast<uintptr_t>(*value); break;
+			case AT_SECURE: rtdlConfig.secureRequired = reinterpret_cast<uintptr_t>(*value); break;
 		}
 
 		aux += 2;
@@ -316,10 +318,6 @@ extern "C" [[ gnu::visibility("default") ]] uintptr_t *__dlapi_entrystack() {
 	return entryStack;
 }
 
-extern "C" [[ gnu::visibility("default") ]] int __dlapi_secure_required() {
-	return secureRequired;
-}
-
 extern "C" [[ gnu::visibility("default") ]]
 const char *__dlapi_error() {
 	auto error = lastError;
@@ -330,6 +328,11 @@ const char *__dlapi_error() {
 extern "C" [[ gnu::visibility("default") ]]
 void *__dlapi_get_tls(struct __abi_tls_entry *entry) {
 	return reinterpret_cast<char *>(accessDtv(entry->object)) + entry->offset;
+}
+
+extern "C" [[ gnu::visibility("default") ]]
+const mlibc::RtdlConfig &__dlapi_get_config() {
+	return rtdlConfig;
 }
 
 #ifdef __MLIBC_POSIX_OPTION

--- a/options/rtdl/include/mlibc/rtdl-config.hpp
+++ b/options/rtdl/include/mlibc/rtdl-config.hpp
@@ -1,0 +1,24 @@
+#ifndef MLIBC_RTDL_CONFIG
+#define MLIBC_RTDL_CONFIG
+
+namespace mlibc {
+
+struct RtdlConfig {
+	bool secureRequired;
+};
+
+}
+
+extern "C" const mlibc::RtdlConfig &__dlapi_get_config();
+
+#ifndef MLIBC_BUILDING_RTDL
+namespace mlibc {
+
+inline const RtdlConfig &rtdlConfig() {
+	return __dlapi_get_config();
+}
+
+}
+#endif
+
+#endif // MLIBC_RTDL_CONFIG


### PR DESCRIPTION
This PR adds a mechanism to pass global program configuration data between `ld.so` and `libc.so`, laying the groundwork for #614.