### PR TITLE
options/ansi: add __MLIBC_TRACE macro to aid debugging

### DIFF
--- a/options/ansi/include/stdio.h
+++ b/options/ansi/include/stdio.h
@@ -226,5 +226,12 @@ int fputs_unlocked(const char *, FILE *);
 #	include <bits/posix/posix_stdio.h>
 #endif
 
+/* Macro to aid printf debugging. See tests/ansi/trace.c */
+#define __MLIBC_TRACE(format, ...) ({ \
+			fprintf(stderr, "__MLIBC_TRACE(): %s at " __FILE__ ":%d " format "\n", \
+					__PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__); \
+			fflush(stderr); \
+		})
+
 #endif // _STDIO_H
 

--- a/tests/ansi/trace.c
+++ b/tests/ansi/trace.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+	__MLIBC_TRACE();
+	__MLIBC_TRACE("foo");
+	__MLIBC_TRACE("bar %d", 1);
+	__MLIBC_TRACE("baz %d %s", 1, "quux");
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,6 +19,7 @@ all_test_cases = [
 	'ansi/wcsncasecmp',
 	'ansi/fopen',
 	'ansi/memmem',
+	'ansi/trace',
 	'bsd/ns_get_put',
 	'bsd/reallocarray',
 	'bsd/strl',
@@ -82,6 +83,7 @@ fail_test_cases = [
 ]
 
 host_libc_excluded_test_cases = [
+	'ansi/trace', # This tests a macro which is only defined in mlibc.
 	'bsd/strl', # These functions do not exist on Linux.
 ]
 host_libc_noasan_test_cases = [


### PR DESCRIPTION
Since we find ourselves printf debugging ports a lot (especially when gdb can't be used), this macro will be nice to have.

I *think* this should work under all `-std=` values, since we're in a system header.