### PR TITLE
options/posix: Stub the rest of the timer_* family

### DIFF
--- a/options/posix/generic/sys-time-stubs.cpp
+++ b/options/posix/generic/sys-time-stubs.cpp
@@ -83,3 +83,8 @@ int timer_gettime(timer_t, struct itimerspec *) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+int timer_delete(timer_t) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/generic/sys-time-stubs.cpp
+++ b/options/posix/generic/sys-time-stubs.cpp
@@ -73,3 +73,13 @@ int timer_create(clockid_t, struct sigevent *__restrict, timer_t *__restrict) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
+
+int timer_settime(timer_t, int, const struct itimerspec *__restrict, struct itimerspec *__restrict) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
+int timer_gettime(timer_t, struct itimerspec *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}

--- a/options/posix/include/sys/time.h
+++ b/options/posix/include/sys/time.h
@@ -40,6 +40,7 @@ int timer_create(clockid_t clockid, struct sigevent *__restrict sevp, timer_t *_
 int timer_settime(timer_t timerid, int flags, const struct itimerspec *__restrict new_value,
 	struct itimerspec *__restrict old_value);
 int timer_gettime(timer_t timerid, struct itimerspec *curr_value);
+int timer_delete(timer_t timerid);
 
 // The following 2 macros are taken from musl
 #define TIMEVAL_TO_TIMESPEC(tv, ts) ( \

--- a/options/posix/include/sys/time.h
+++ b/options/posix/include/sys/time.h
@@ -37,6 +37,9 @@ int setitimer(int which, const struct itimerval *new_value,
 	struct itimerval *old_value);
 
 int timer_create(clockid_t clockid, struct sigevent *__restrict sevp, timer_t *__restrict timerid);
+int timer_settime(timer_t timerid, int flags, const struct itimerspec *__restrict new_value,
+	struct itimerspec *__restrict old_value);
+int timer_gettime(timer_t timerid, struct itimerspec *curr_value);
 
 // The following 2 macros are taken from musl
 #define TIMEVAL_TO_TIMESPEC(tv, ts) ( \


### PR DESCRIPTION
This should unbreak the Managarm ci.

Part of the mlibc LFS project.