### PR TITLE
sysdeps/managarm: managarm should be Managarm in sys_uname

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -4881,7 +4881,7 @@ int sys_memfd_create(const char *name, int flags, int *fd) {
 int sys_uname(struct utsname *buf) {
 	__ensure(buf);
 	mlibc::infoLogger() << "\e[31mmlibc: uname() returns static information\e[39m" << frg::endlog;
-	strcpy(buf->sysname, MLIBC_SYSTEM_NAME);
+	strcpy(buf->sysname, "Managarm");
 	strcpy(buf->nodename, "?");
 	strcpy(buf->release, "?");
 	strcpy(buf->version, "?");


### PR DESCRIPTION
As discussed on Discord, this change is to make `uname -s` print `Managarm` instead of `managarm`.