### PR TITLE
Add some missing members to glob.h

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -10,3 +10,4 @@ This document lists the ABI breaks that were made in each mlibc major version.
 - [#311](https://github.com/managarm/mlibc/pull/311): Added all necessary fields in `pthread_attr_t` required for implementing all `pthread_attr` functions.
 - [#652](https://github.com/managarm/mlibc/pull/652): The ABI of `struct statfs` and `struct statvfs` was changed to match Linux. `socklen_t` was also changed from `unsigned long` to `unsigned int`.
 - [#658](https://github.com/managarm/mlibc/pull/648): In the Linux ABI, `cc_t` was changed from an `unsigned int` to an `unsigned char`.
+- [#679](https://github.com/managarm/mlibc/pull/679): The `struct glob_t` received some additional members to bring it up to par with glibc.

--- a/options/posix/include/glob.h
+++ b/options/posix/include/glob.h
@@ -15,19 +15,31 @@ extern "C" {
 #define GLOB_NOCHECK 0x10
 #define GLOB_NOESCAPE 0x20
 #define GLOB_NOSORT 0x40
-
 #define GLOB_PERIOD 0x80
 #define GLOB_TILDE 0x100
 #define GLOB_TILDE_CHECK 0x200
+#define GLOB_BRACE 0x400
+#define GLOB_NOMAGIC 0x800
+#define GLOB_ALTDIRFUNC 0x1000
+#define GLOB_ONLYDIR 0x2000
+#define GLOB_MAGCHAR 0x4000
 
 #define GLOB_ABORTED 1
 #define GLOB_NOMATCH 2
 #define GLOB_NOSPACE 3
+#define GLOB_NOSYS 4
 
+struct stat;
 typedef struct glob_t {
 	size_t gl_pathc;
 	char **gl_pathv;
 	size_t gl_offs;
+	int gl_flags;
+	void (*gl_closedir) (void *);
+	struct dirent *(*gl_readdir) (void *);
+	void *(*gl_opendir) (const char *);
+	int (*gl_lstat) (const char *__restrict, struct stat *__restrict);
+	int (*gl_stat) (const char *__restrict, struct stat *__restrict);
 } glob_t;
 
 int glob(const char *__restirct, int, int(*)(const char *, int), struct glob_t *__restrict);


### PR DESCRIPTION
This PR supercedes #634, but is the same in content. It adds additional members and defines to glob.h, while preserving the mlibc values.

Part of the mlibc LFS project.