### PR TITLE
abis/linux: Define additional AT_ values

### DIFF
--- a/abis/linux/auxv.h
+++ b/abis/linux/auxv.h
@@ -2,11 +2,23 @@
 #define _ABIBITS_AUXV_H
 
 #define AT_NULL 0
+#define AT_IGNORE 1
 #define AT_PHDR 3
 #define AT_PHENT 4
 #define AT_PHNUM 5
+#define AT_PAGESZ 6
 #define AT_BASE 7
+#define AT_FLAGS 8
 #define AT_ENTRY 9
+#define AT_NOTELF 10
+#define AT_UID 11
+#define AT_EUID 12
+#define AT_GID 13
+#define AT_EGID 14
+#define AT_PLATFORM 15
+#define AT_HWCAP 16
+#define AT_CLKTCK 17
+#define AT_FPUCW 18
 #define AT_SECURE 23
 #define AT_RANDOM 25
 #define AT_EXECFN 31


### PR DESCRIPTION
Some additional values for auxv.

Part of the mlibc LFS project.