### PR TITLE
options/ansi: Fix out of bounds read in wcswidth

### DIFF
--- a/options/ansi/generic/wchar-stubs.cpp
+++ b/options/ansi/generic/wchar-stubs.cpp
@@ -744,8 +744,8 @@ int wcwidth(wchar_t ucs) {
 
 int wcswidth(const wchar_t *wcs, size_t n) {
 	int ret = 0;
-	for(size_t i = 0; i < n && wcs[n]; i++) {
-		int cols = wcwidth(wcs[n]);
+	for(size_t i = 0; i < n && wcs[i]; i++) {
+		int cols = wcwidth(wcs[i]);
 		if (cols < 0)
 			return -1;
 		ret += cols;


### PR DESCRIPTION
An out of bounds read was found and fixed while running with the debug allocator.

Part of the mlibc LFS project.
Found with the assistance of #682 (thanks qookie).