### PR TITLE
options/posix: Let AF_INET6 in inet_ntop fall through

### DIFF
--- a/options/posix/generic/arpa-inet-stubs.cpp
+++ b/options/posix/generic/arpa-inet-stubs.cpp
@@ -118,9 +118,8 @@ const char *inet_ntop(int af, const void *__restrict src, char *__restrict dst,
 				return dst;
 			break;
 		case AF_INET6:
-			__ensure(!"ipv6 is not implemented!");
-			__builtin_unreachable();
-			break;
+			mlibc::infoLogger() << "inet_pton: ipv6 is not implemented!" << frg::endlog;
+			/* fallthrough */
 		default:
 			errno = EAFNOSUPPORT;
 			return NULL;


### PR DESCRIPTION
This makes more sense than hard crashing, we do this in other places too.

Part of the mlibc LFS project.