### PR TITLE
options/posix: Semi implement strtof_l

### DIFF
--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -452,9 +452,9 @@ long double strtold_l(const char *__restrict__, char ** __restrict__, locale_t) 
 	__builtin_unreachable();
 }
 
-float strtof_l(const char *__restrict__, char **__restrict__, locale_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+float strtof_l(const char *__restrict__ nptr, char **__restrict__ endptr, locale_t) {
+	mlibc::infoLogger() << "mlibc: strtof_l ignores locales" << frg::endlog;
+	return strtof(nptr, endptr);
 }
 
 int strcoll_l(const char *, const char *, locale_t) {


### PR DESCRIPTION
Weston suddenly started using it, so ignore locale like we always do and call into `strtof()`

Part of the mlibc LFS project.