### PR TITLE
options/rtdl: Fix a memory deallocation bug in accessDtv

### DIFF
--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -874,7 +874,7 @@ void *accessDtv(SharedObject *object) {
 		auto ndtv = frg::construct_n<void *>(getAllocator(), runtimeTlsMap->indices.size());
 		memset(ndtv, 0, sizeof(void *) * runtimeTlsMap->indices.size());
 		memcpy(ndtv, tcb_ptr->dtvPointers, sizeof(void *) * tcb_ptr->dtvSize);
-		frg::destruct(getAllocator(), tcb_ptr->dtvPointers);
+		frg::destruct_n(getAllocator(), tcb_ptr->dtvPointers, tcb_ptr->dtvSize);
 		tcb_ptr->dtvSize = runtimeTlsMap->indices.size();
 		tcb_ptr->dtvPointers = ndtv;
 	}


### PR DESCRIPTION
A memory deallocation bug was found and fixed in rtdl.

Part of the mlibc LFS project.
Found with the assistance of https://github.com/managarm/mlibc/pull/682 (thanks qookie).