### PR TITLE
abis/linux: Define S_IEXEC

### DIFF
--- a/abis/linux/stat.h
+++ b/abis/linux/stat.h
@@ -26,6 +26,7 @@
 #define S_IRUSR 0400
 #define S_IWUSR 0200
 #define S_IXUSR 0100
+#define S_IEXEC S_IXUSR
 #define S_IRWXG 070
 #define S_IRGRP 040
 #define S_IWGRP 020


### PR DESCRIPTION
Part of the mlibc LFS project.