### PR TITLE
abis/linux: correct the ABI of some integer types

### DIFF
--- a/abis/linux/blkcnt_t.h
+++ b/abis/linux/blkcnt_t.h
@@ -1,7 +1,8 @@
 #ifndef _ABIBITS_BLKCNT_T_H
 #define _ABIBITS_BLKCNT_T_H
 
-// TODO: use int64_t?
-typedef long blkcnt_t;
+#include <bits/types.h>
+
+typedef __mlibc_int64 blkcnt_t;
 
 #endif // _ABIBITS_BLKCNT_T_H

--- a/abis/linux/blksize_t.h
+++ b/abis/linux/blksize_t.h
@@ -2,7 +2,6 @@
 #ifndef _ABIBITS_BLKSIZE_T_H
 #define _ABIBITS_BLKSIZE_T_H
 
-// TODO: use int64_t?
 typedef long blksize_t;
 
 #endif // _ABIBITS_BLKSIZE_T_H

--- a/abis/linux/dev_t.h
+++ b/abis/linux/dev_t.h
@@ -2,7 +2,9 @@
 #ifndef _ABIBITS_DEV_T_H
 #define _ABIBITS_DEV_T_H
 
-typedef unsigned long dev_t;
+#include <bits/types.h>
+
+typedef __mlibc_uint64 dev_t;
 
 #endif // _ABIBITS_DEV_T_H
 

--- a/abis/linux/fsfilcnt_t.h
+++ b/abis/linux/fsfilcnt_t.h
@@ -1,6 +1,8 @@
 #ifndef _ABIBITS_FSFILCNT_T_H
 #define _ABIBITS_FSFILCNT_T_H
 
+#include <bits/types.h>
+
 typedef __mlibc_uint64 fsfilcnt_t;
 
 #endif /* _ABIBITS_FSFILCNT_T_H */

--- a/abis/linux/ino_t.h
+++ b/abis/linux/ino_t.h
@@ -2,8 +2,9 @@
 #ifndef _ABIBITS_INO_T_H
 #define _ABIBITS_INO_T_H
 
-// TODO: use (u)int64_t?
-typedef long ino_t;
+#include <bits/types.h>
+
+typedef __mlibc_uint64 ino_t;
 
 #endif // _ABIBITS_INO_T_H
 


### PR DESCRIPTION
Verified against musl, see https://github.com/bminor/musl/blob/46d1c7801bb509e1097e8fadbaf359367fa4ef0b/include/alltypes.h.in#L27-L35.