### PR TITLE
options/glibc: simplify basename ABI and implementation

### DIFF
--- a/options/ansi/include/string.h
+++ b/options/ansi/include/string.h
@@ -62,27 +62,10 @@ void *memmem(const void *, size_t, const void *, size_t);
 
 /* Handling the basename mess:
  * If <libgen.h> is included *at all*, we use the XPG-defined basename
- * implementation, otherwise, we use the GNU one. Since our ABI previously
- * provided the XPG one under basename, we'll have to diverge from GNU here and
- * provide __mlibc_gnu_basename instead.
+ * implementation, otherwise, we use the GNU one.
  */
 #if defined(__MLIBC_GLIBC_OPTION) && defined(_GNU_SOURCE) && !defined(basename)
-char *__mlibc_gnu_basename_c(const char *path);
-
-# ifdef __cplusplus
-extern "C++" {
-static inline const char *__mlibc_gnu_basename(const char *path) {
-	return __mlibc_gnu_basename_c(path);
-}
-static inline char *__mlibc_gnu_basename(char *path) {
-	return __mlibc_gnu_basename_c(path);
-}
-}
-# else
-#  define __mlibc_gnu_basename __mlibc_gnu_basename_c
-# endif
-
-#define basename __mlibc_gnu_basename
+char *basename(const char *path);
 #endif
 
 #ifdef __cplusplus

--- a/options/glibc/generic/string.cpp
+++ b/options/glibc/generic/string.cpp
@@ -4,29 +4,13 @@
 #include <type_traits>
 #include <string.h>
 
-/* This is a bit of a weird detail of the GNU implementation and C's lack of
- * overloading and strictness: GNU takes const char * and returns a char * so
- * that it autocasts to your desired constness, this function never actually
- * modifies the string.
+/* As with other string functions in C, this takes a const char * and returns a
+ * char * so that it autocasts to your desired constness. This function never
+ * actually modifies the string.
  */
-char *__mlibc_gnu_basename_c(const char *path) {
+char *basename(const char *path) {
 	char *basename_component = strrchr(path, '/');
-	if (!basename_component) {
+	if (!basename_component)
 		return const_cast<char *>(path);
-	}
 	return basename_component + 1;
 }
-
-
-/* GNU exposes these overloads, and as a result, we should probably have them
- * checked, to make sure we actually match expectations.
- */
-static_assert(
-	std::is_same_v<decltype(basename((const char *)nullptr)), const char*>,
-	"C++ overloads broken"
-);
-
-static_assert(
-	std::is_same_v<decltype(basename((char *)nullptr)), char*>,
-	"C++ overloads broken"
-);

--- a/options/posix/generic/libgen-stubs.cpp
+++ b/options/posix/generic/libgen-stubs.cpp
@@ -5,7 +5,9 @@
 
 #include <mlibc/debug.hpp>
 
-// Adopted from musl's code.
+// The functions in this file are adapted from musl.
+
+// Note that 'basename' here is defined to be __mlibc_xpg_basename by libgen.h.
 char *basename(char *s) {
 	// This empty string behavior is specified by POSIX.
 	if (!s || !*s)

--- a/options/posix/include/libgen.h
+++ b/options/posix/include/libgen.h
@@ -6,13 +6,8 @@
 extern "C" {
 #endif
 
-#if defined(basename) && defined(_GNU_SOURCE)
-/* see: ./options/ansi/include/string.h, search for __mlibc_gnu_basename */
-# undef basename
-#endif
-
-char *basename(char *);
-#define basename basename
+char *__mlibc_xpg_basename(char *);
+#define basename __mlibc_xpg_basename
 char *dirname(char *);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This will need to be backported to the release branch, since it's an ABI break.
