### PR TITLE
sys/socket.h: fix some CMSG_ macros not aligning

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -4,6 +4,11 @@ This document lists the ABI breaks that were made in each mlibc major version.
 
 ## Version 3
 
+- [#728](https://github.com/managarm/mlibc/pull/728):
+  The macros `CMSG_{LEN,SPACE,DATA}` were not accounting for padding between
+  `struct cmsghdr` and it's respective data. This manifested itself as some
+  parts of control data being skipped on platforms where `struct cmsghdr` is
+  not divisible by `alignof(size_t)`.
 - [#452](https://github.com/managarm/mlibc/pull/452): The functions `FD_{CLR,ISSET,SET,ZERO}` were renamed to `__FD_{CLR,ISSET,SET,ZERO}` and replaced by macros to match Wine's assumptions.
 - [#511](https://github.com/managarm/mlibc/pull/511): Musl's regex engine was added, implementing `regcomp` and `regexec`. This required some changes to the `regex_t` struct.
 - [#504](https://github.com/managarm/mlibc/pull/504): In the Linux ABI, a `domainname` member was added to `struct utsname`, which is a glibc extension.

--- a/options/posix/include/sys/socket.h
+++ b/options/posix/include/sys/socket.h
@@ -38,11 +38,11 @@ struct sockaddr {
 		~(__alignof__(size_t) - 1))
 
 // Basic macros to return content and padding size of a control message.
-#define CMSG_LEN(s) (sizeof(struct cmsghdr) + (s))
-#define CMSG_SPACE(s) (sizeof(struct cmsghdr) + CMSG_ALIGN(s))
+#define CMSG_LEN(s) (CMSG_ALIGN(sizeof(struct cmsghdr)) + (s))
+#define CMSG_SPACE(s) (CMSG_ALIGN(sizeof(struct cmsghdr)) + CMSG_ALIGN(s))
 
 // Provides access to the data of a control message.
-#define CMSG_DATA(c) ((char *)(c) + sizeof(struct cmsghdr))
+#define CMSG_DATA(c) ((char *)(c) + CMSG_ALIGN(sizeof(struct cmsghdr)))
 
 #define __MLIBC_CMSG_NEXT(c) ((char *)(c) + CMSG_ALIGN((c)->cmsg_len))
 #define __MLIBC_MHDR_LIMIT(m) ((char *)(m)->msg_control + (m)->msg_controllen)


### PR DESCRIPTION
```
Excerpt from sys/socket.h:
	// Control message format:
	// The offsets marked with ^ are aligned to alignof(size_t).
	//
	// |---HEADER---|---DATA---|---PADDING---|---HEADER---|...
	// ^            ^                        ^
	// |---------CMSG_LEN------|
	// |---------------CMSG_SPACE------------|

By this definition, control message header and data should both be
aligned to (at least) alignof(size_t), however, previously, the
implementation of these macros in options/posix relied on
sizeof(struct cmsghdr) % sizeof(size_t) being zero. After the recent
change to socklen_t, this no longer held true, and DATA would be aligned
to a 12 byte boundary (on x86_64), and hence would move all data back a
bit. Code that relied on CMSG_ALIGN() to compute sizes of cmsg data
(notably, sysdeps/managarm) hence broke as a result.

The change in this commit fixes that misalignment.
```

It would be desirable for this change to land into 3.0.0-rc2