### PR TITLE
options/posix: Make strtod_l call strtod

### DIFF
--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -449,9 +449,9 @@ int grantpt(int) {
 	return 0;
 }
 
-double strtod_l(const char *__restrict__, char ** __restrict__, locale_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+double strtod_l(const char *__restrict__ nptr, char ** __restrict__ endptr, locale_t) {
+	mlibc::infoLogger() << "mlibc: strtod_l ignores locale!" << frg::endlog;
+	return strtod(nptr, endptr);
 }
 
 long double strtold_l(const char *__restrict__, char ** __restrict__, locale_t) {


### PR DESCRIPTION
The new glib update seems to like strtod_l, so let's make it a call to strtod as to not break 75% of Managarm userspace.