### PR TITLE
dummy-libs: fix a typo in the comment

### DIFF
--- a/dummy-libs/libpthread/src/dummy.cpp
+++ b/dummy-libs/libpthread/src/dummy.cpp
@@ -1,5 +1,5 @@
 
-// We build an empty libpthread because g++ always links with -lm
+// We build an empty libpthread because g++ always links with -lpthread
 // The actual functions reside inside libc
 
 extern "C" void __mlibc_libpthread_dummy(void) { }


### PR DESCRIPTION
it's not `-lm` but `-lpthread` instead.