### PR TITLE
*: replace instances of () with (void) in C headers

### DIFF
--- a/options/posix/include/sched.h
+++ b/options/posix/include/sched.h
@@ -53,7 +53,7 @@ struct sched_param {
 	int sched_priority;
 };
 
-int sched_yield();
+int sched_yield(void);
 
 struct __mlibc_cpu_set {
 	unsigned long __bits[128/sizeof(long)];

--- a/options/posix/include/ucontext.h
+++ b/options/posix/include/ucontext.h
@@ -9,7 +9,7 @@ extern "C" {
 
 int getcontext(ucontext_t *);
 int setcontext(const ucontext_t *);
-void makecontext(ucontext_t *, void (*)(), int, ...);
+void makecontext(ucontext_t *, void (*)(void), int, ...);
 int swapcontext(ucontext_t *, const ucontext_t *);
 
 #ifdef __cplusplus


### PR DESCRIPTION
These are currently wrong, and their meaning changes in the near future, which prompted me to search for them