### PR TITLE
sysdeps/managarm: Handle ENOTCONN for FIONREAD ioctl

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2049,6 +2049,8 @@ int sys_write(int fd, const void *data, size_t size, ssize_t *bytes_written) {
 		return ENOSPC;
 	}else if(resp.error() == managarm::fs::Errors::WOULD_BLOCK) {
 		return EAGAIN;
+	}else if(resp.error() == managarm::fs::Errors::NOT_CONNECTED) {
+		return ENOTCONN;
 	}else{
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 		*bytes_written = resp.size();

--- a/sysdeps/managarm/generic/ioctl.cpp
+++ b/sysdeps/managarm/generic/ioctl.cpp
@@ -75,11 +75,15 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result) {
 
 		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
-		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
+		if(resp.error() == managarm::fs::Errors::NOT_CONNECTED) {
+			return ENOTCONN;
+		} else {
+			__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
-		*argp = resp.fionread_count();
+			*argp = resp.fionread_count();
 
-		return 0;
+			return 0;
+		}
 	}
 	case FIOCLEX: {
 		managarm::posix::IoctlFioclexRequest<MemoryAllocator> req(getSysdepsAllocator());


### PR DESCRIPTION
A small fix that eliminates `glxgears` crashing when closing the program.