### PR TITLE
options/rtdl: Load scope fix

### DIFF
--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -460,6 +460,13 @@ void *__dlapi_open(const char *file, int flags, void *returnAddress) {
 			return nullptr;
 		}
 
+		// If the local scope is requested, but the local scope is a nullptr, use the global scope anyway.
+		if(!(flags & RTLD_GLOBAL)) {
+			if(object->localScope == nullptr) {
+				object->localScope = globalScope.get();
+			}
+		}
+
 		Loader linker{(flags & RTLD_GLOBAL) ? globalScope.get() : object->localScope, nullptr, false, rts};
 		linker.linkObjects(object);
 		linker.initObjects();


### PR DESCRIPTION
If the local load scope is requested at object load, but said local scope is null, we happily pass a nullptr down which later blows up in our face. To avoid this, I introduced a simple check to see if the local scope is requested, and if so, if the local scope to be used is set to something that's not a nullptr. This fixes `hexchat` on Managarm once more.