### PR TITLE
Add mlock sysdeps + sys_symlinkat error code fixes

### DIFF
--- a/options/posix/generic/sys-mman-stubs.cpp
+++ b/options/posix/generic/sys-mman-stubs.cpp
@@ -18,9 +18,13 @@ int mprotect(void *pointer, size_t size, int prot) {
 	return 0;
 }
 
-int mlock(const void *, size_t) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int mlock(const void *addr, size_t len) {
+	MLIBC_CHECK_OR_ENOSYS(mlibc::sys_mlock, -1);
+	if(int e = mlibc::sys_mlock(addr, len); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
 }
 
 int mlockall(int flags) {

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -130,6 +130,7 @@ int sys_close(int fd);
 [[gnu::weak]] int sys_fchmodat(int fd, const char *pathname, mode_t mode, int flags);
 [[gnu::weak]] int sys_utimensat(int dirfd, const char *pathname, const struct timespec times[2], int flags);
 [[gnu::weak]] int sys_mlockall(int flags);
+[[gnu::weak]] int sys_mlock(const void *addr, size_t len);
 
 // mlibc assumes that anonymous memory returned by sys_vm_map() is zeroed by the kernel / whatever is behind the sysdeps
 int sys_vm_map(void *hint, size_t size, int prot, int flags, int fd, off_t offset, void **window);

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -168,8 +168,18 @@ int sys_symlinkat(const char *target_path, int dirfd, const char *link_path) {
 
 	managarm::posix::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
 	resp.ParseFromArray(recv_resp.data(), recv_resp.length());
-	__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
-	return 0;
+	if(resp.error() == managarm::posix::Errors::FILE_NOT_FOUND) {
+		return ENOENT;
+	}else if(resp.error() == managarm::posix::Errors::ILLEGAL_ARGUMENTS) {
+		return EINVAL;
+	}else if(resp.error() == managarm::posix::Errors::BAD_FD) {
+		return EBADF;
+	}else if(resp.error() == managarm::posix::Errors::NOT_A_DIRECTORY) {
+		return ENOTDIR;
+	}else{
+		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
+		return 0;
+	}
 }
 
 int sys_link(const char *old_path, const char *new_path) {


### PR DESCRIPTION
While working on more webkit memes, we found that webkit likes mlock to not crash, so I made that a sysdep. I've also improved the error handling for `sys_symlinkat` in the Managarm sysdeps.