### PR TITLE
Sysdep fixes for Vinix and Lyre

### DIFF
--- a/sysdeps/lyre/generic/generic.cpp
+++ b/sysdeps/lyre/generic/generic.cpp
@@ -93,7 +93,7 @@ int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events) {
 	struct timespec ts;
 	ts.tv_sec = timeout / 1000;
 	ts.tv_nsec = (timeout % 1000) * 1000000;
-	return sys_ppoll(fds, count, &ts, NULL, num_events);
+	return sys_ppoll(fds, count, timeout < 0 ? NULL : &ts, NULL, num_events);
 }
 
 int sys_epoll_pwait(int, struct epoll_event *, int,

--- a/sysdeps/vinix/generic/generic.cpp
+++ b/sysdeps/vinix/generic/generic.cpp
@@ -92,7 +92,7 @@ int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events) {
 	struct timespec ts;
 	ts.tv_sec = timeout / 1000;
 	ts.tv_nsec = (timeout % 1000) * 1000000;
-	return sys_ppoll(fds, count, &ts, NULL, num_events);
+	return sys_ppoll(fds, count, timeout < 0 ? NULL : &ts, NULL, num_events);
 }
 
 int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,


### PR DESCRIPTION
This PR fixes an issue on both the Vinix and Lyre sysdeps where sys_poll() never waits indefinitely when a negative integer is passed to it.