### PR TITLE
Some small things for Chromium

### DIFF
--- a/abis/linux/signal.h
+++ b/abis/linux/signal.h
@@ -165,10 +165,20 @@ typedef struct __stack {
 #define SEGV_ACCERR 2
 
 #define BUS_ADRALN 1
+#define BUS_ADRERR 2
+#define BUS_OBJERR 3
+#define BUS_MCEERR_AR 4
+#define BUS_MCEERR_AO 5
 
 #define ILL_ILLOPC 1
+#define ILL_ILLOPN 2
+#define ILL_ILLADR 3
 #define ILL_ILLTRP 4
 #define ILL_PRVOPC 5
+#define ILL_PRVREG 6
+#define ILL_COPROC 7
+#define ILL_BADSTK 8
+#define ILL_BADIADDR 9
 
 #define NSIG 65
 

--- a/options/glibc/include/resolv.h
+++ b/options/glibc/include/resolv.h
@@ -29,11 +29,15 @@ int res_init(void);
 /* From musl: Unused; purely for broken apps
  * To avoid an massive struct, only add the items requested. */
 typedef struct __res_state {
+	int retrans;
+	int retry;
 	unsigned long options;
 	int nscount;
 	struct sockaddr_in nsaddr_list[MAXNS];
 	char *dnsrch[MAXDNSRCH + 1];
 	char defdname[256];
+	unsigned ndots:4;
+	unsigned nsort:4;
 	union {
 		char pad[52];
 		struct {


### PR DESCRIPTION
We found some missing items for Chromium while @czapek1337 was building chromium under cbuildrt. This includes some missing signal constants in the Linux ABI. This PR fixes them.

Part of the Chromium on Managarm project.
Part of the systemd on Managarm project.