### PR TITLE
sysdeps/managarm: rework ioctls to allow using dedicated messages

### DIFF
--- a/sysdeps/managarm/generic/drm.cpp
+++ b/sysdeps/managarm/generic/drm.cpp
@@ -12,25 +12,28 @@
 namespace mlibc {
 
 int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle handle) {
+	managarm::fs::IoctlRequest<MemoryAllocator> ioctl_req(getSysdepsAllocator());
+
 	switch(request) {
 	case DRM_IOCTL_VERSION: {
 		auto param = reinterpret_cast<drm_version*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -58,22 +61,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_GET_CAP: {
 		auto param = reinterpret_cast<drm_get_cap*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_capability(param->capability);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if(resp.error() == managarm::fs::Errors::ILLEGAL_ARGUMENT) {
@@ -90,22 +94,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		auto param = reinterpret_cast<drm_set_client_cap *>(arg);
 		mlibc::infoLogger() << "\e[35mmlibc: DRM_IOCTL_SET_CLIENT_CAP(" << param->capability << ") ignores its value\e[39m" << frg::endlog;
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_capability(param->capability);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if(resp.error() == managarm::fs::Errors::ILLEGAL_ARGUMENT) {
@@ -147,17 +152,18 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETRESOURCES: {
 		auto param = reinterpret_cast<drm_mode_card_res *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
@@ -165,7 +171,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 			return EINVAL;
 		}
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
@@ -213,15 +219,15 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETCONNECTOR: {
 		auto param = reinterpret_cast<drm_mode_get_connector*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_connector_id(param->connector_id);
 		req.set_drm_max_modes(param->count_modes);
 
-		auto [offer, send_req, recv_resp, recv_list] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp, recv_list] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline(),
 				helix_ng::recvBuffer(reinterpret_cast<void *>(param->modes_ptr), param->count_modes * sizeof(drm_mode_modeinfo))
@@ -229,6 +235,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		);
 
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		if(recv_resp.error() == kHelErrDismissed)
 			return EINVAL;
@@ -236,7 +243,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		HEL_CHECK(recv_resp.error());
 		HEL_CHECK(recv_list.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -275,22 +282,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETPROPERTY: {
 		auto param = reinterpret_cast<drm_mode_get_property*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_property_id(param->prop_id);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if(resp.error() != managarm::fs::Errors::SUCCESS) {
@@ -325,24 +333,25 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_SETPROPERTY: {
 		auto param = reinterpret_cast<drm_mode_connector_set_property *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_property_id(param->prop_id);
 		req.set_drm_property_value(param->value);
 		req.set_drm_obj_id(param->connector_id);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if(resp.error() != managarm::fs::Errors::SUCCESS) {
@@ -358,22 +367,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETPROPBLOB: {
 		auto param = reinterpret_cast<drm_mode_get_blob *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_blob_id(param->blob_id);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if(resp.error() != managarm::fs::Errors::SUCCESS) {
@@ -400,22 +410,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETPLANE: {
 		auto param = reinterpret_cast<drm_mode_get_plane*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_plane_id(param->plane_id);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -441,24 +452,25 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETPLANERESOURCES: {
 		auto param = reinterpret_cast<drm_mode_get_plane_res *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		frg::string<MemoryAllocator> ser(getSysdepsAllocator());
 		req.SerializeToString(&ser);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBuffer(ser.data(), ser.size()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -480,22 +492,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETENCODER: {
 		auto param = reinterpret_cast<drm_mode_get_encoder*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_encoder_id(param->encoder_id);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -510,8 +523,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_CREATE_DUMB: {
 		auto param = reinterpret_cast<drm_mode_create_dumb*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_width(param->width);
@@ -519,17 +531,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		req.set_drm_bpp(param->bpp);
 		req.set_drm_flags(param->flags);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -543,8 +557,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_ADDFB: {
 		auto param = reinterpret_cast<drm_mode_fb_cmd *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_width(param->width);
@@ -554,17 +567,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		req.set_drm_depth(param->depth);
 		req.set_drm_handle(param->handle);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -585,8 +600,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		__ensure(!param->modifier[0] || param->modifier[0] == DRM_FORMAT_MOD_INVALID);
 		__ensure(!param->offsets[0]);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(DRM_IOCTL_MODE_ADDFB);
 
 		req.set_drm_width(param->width);
@@ -596,17 +610,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		req.set_drm_depth(24);
 		req.set_drm_handle(param->handles[0]);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -618,23 +634,24 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_RMFB: {
 		auto param = reinterpret_cast<int *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_fb_id(*param);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -644,23 +661,24 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_MAP_DUMB: {
 		auto param = reinterpret_cast<drm_mode_map_dumb*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_handle(param->handle);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -672,25 +690,26 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_GETCRTC: {
 		auto param = reinterpret_cast<drm_mode_crtc*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_crtc_id(param->crtc_id);
 
-		auto [offer, send_req, recv_resp, recv_data] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp, recv_data] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline(),
 				helix_ng::recvBuffer(&param->mode, sizeof(drm_mode_modeinfo)))
 		);
 
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 		HEL_CHECK(recv_data.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -706,8 +725,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_SETCRTC: {
 		auto param = reinterpret_cast<drm_mode_crtc*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		for(size_t i = 0; i < param->count_connectors; i++) {
@@ -720,20 +738,22 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		req.set_drm_fb_id(param->fb_id);
 		req.set_drm_mode_valid(param->mode_valid);
 
-		auto [offer, send_req, send_mode, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, send_mode, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::sendBuffer(&param->mode, sizeof(drm_mode_modeinfo)),
 				helix_ng::recvInline())
 		);
 
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(send_mode.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -743,25 +763,26 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_OBJ_GETPROPERTIES: {
 		auto param = reinterpret_cast<drm_mode_obj_get_properties *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_count_props(param->count_props);
 		req.set_drm_obj_id(param->obj_id);
 		req.set_drm_obj_type(param->obj_type);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -784,8 +805,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_PAGE_FLIP: {
 		auto param = reinterpret_cast<drm_mode_crtc_page_flip *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		__ensure(!(param->flags & ~DRM_MODE_PAGE_FLIP_EVENT));
@@ -793,17 +813,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 		req.set_drm_fb_id(param->fb_id);
 		req.set_drm_cookie(param->user_data);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -813,8 +835,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_DIRTYFB: {
 		auto param = reinterpret_cast<drm_mode_fb_dirty_cmd*>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_fb_id(param->fb_id);
@@ -830,17 +851,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 			req.add_drm_clips(std::move(clip));
 		}
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if(resp.error() == managarm::fs::Errors::ILLEGAL_ARGUMENT) {
@@ -854,8 +877,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_CURSOR: {
 		auto param = reinterpret_cast<drm_mode_cursor *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_flags(param->flags);
@@ -873,17 +895,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 			return EINVAL;
 		}
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		if (resp.error() == managarm::fs::Errors::NO_BACKING_DEVICE) {
@@ -898,23 +922,24 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_DESTROY_DUMB: {
 		auto param = reinterpret_cast<drm_mode_destroy_dumb *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 
 		req.set_drm_handle(param->handle);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		*result = resp.result();
@@ -923,24 +948,25 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_CREATEPROPBLOB: {
 		auto param = reinterpret_cast<drm_mode_create_blob *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_blob_size(param->length);
 
-		auto [offer, send_req, blob_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, blob_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::sendBuffer(reinterpret_cast<void *>(param->data), param->length),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(blob_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -952,22 +978,23 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_DESTROYPROPBLOB: {
 		auto param = reinterpret_cast<drm_mode_destroy_blob *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_blob_id(param->blob_id);
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -977,8 +1004,7 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_MODE_ATOMIC: {
 		auto param = reinterpret_cast<drm_mode_atomic *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_flags(param->flags);
 		req.set_drm_cookie(param->user_data);
@@ -1003,17 +1029,19 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 			req.add_drm_prop_values(prop_values_ptr[i]);
 		}
 
-		auto [offer, send_req, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 
 		*result = resp.result();
@@ -1047,25 +1075,26 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_PRIME_HANDLE_TO_FD: {
 		auto param = reinterpret_cast<drm_prime_handle *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_prime_handle(param->handle);
 		req.set_drm_flags(param->flags);
 
-		auto [offer, send_req, send_creds, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, send_creds, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::imbueCredentials(),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(send_creds.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		__ensure(resp.error() == managarm::fs::Errors::SUCCESS);
 
@@ -1076,24 +1105,25 @@ int ioctl_drm(int fd, unsigned long request, void *arg, int *result, HelHandle h
 	case DRM_IOCTL_PRIME_FD_TO_HANDLE: {
 		auto param = reinterpret_cast<drm_prime_handle *>(arg);
 
-		managarm::fs::CntRequest<MemoryAllocator> req(getSysdepsAllocator());
-		req.set_req_type(managarm::fs::CntReqType::PT_IOCTL);
+		managarm::fs::GenericIoctlRequest<MemoryAllocator> req(getSysdepsAllocator());
 		req.set_command(request);
 		req.set_drm_flags(param->flags);
 
-		auto [offer, send_req, send_creds, recv_resp] = exchangeMsgsSync(
+		auto [offer, send_ioctl_req, send_req, send_creds, recv_resp] = exchangeMsgsSync(
 			handle,
 			helix_ng::offer(
+				helix_ng::sendBragiHeadOnly(ioctl_req, getSysdepsAllocator()),
 				helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 				helix_ng::imbueCredentials(getHandleForFd(param->fd)),
 				helix_ng::recvInline())
 		);
 		HEL_CHECK(offer.error());
+		HEL_CHECK(send_ioctl_req.error());
 		HEL_CHECK(send_req.error());
 		HEL_CHECK(send_creds.error());
 		HEL_CHECK(recv_resp.error());
 
-		managarm::fs::SvrResponse<MemoryAllocator> resp(getSysdepsAllocator());
+		managarm::fs::GenericIoctlReply<MemoryAllocator> resp(getSysdepsAllocator());
 		resp.ParseFromArray(recv_resp.data(), recv_resp.length());
 		if(resp.error() == managarm::fs::Errors::FILE_NOT_FOUND) {
 			return EBADF;


### PR DESCRIPTION
Split off from #812. This is the mlibc part of managarm/managarm#519.