### PR TITLE
options/posix: Limit the logging of newlocale and uselocale

### DIFF
--- a/options/posix/generic/posix_locale.cpp
+++ b/options/posix/generic/posix_locale.cpp
@@ -2,9 +2,19 @@
 #include <bits/ensure.h>
 #include <mlibc/debug.hpp>
 
+namespace {
+
+bool newlocale_seen = false;
+bool uselocale_seen = false;
+
+}
+
 locale_t newlocale(int, const char *, locale_t) {
 	// Due to all of the locale functions being stubs, the locale will not be used
-	mlibc::infoLogger() << "mlibc: newlocale() is a no-op" << frg::endlog;
+	if(!newlocale_seen) {
+		mlibc::infoLogger() << "mlibc: newlocale() is a no-op" << frg::endlog;
+		newlocale_seen = true;
+	}
 	return nullptr;
 }
 
@@ -14,7 +24,10 @@ void freelocale(locale_t) {
 }
 
 locale_t uselocale(locale_t) {
-	mlibc::infoLogger() << "mlibc: uselocale() is a no-op" << frg::endlog;
+	if(!uselocale_seen) {
+		mlibc::infoLogger() << "mlibc: uselocale() is a no-op" << frg::endlog;
+		uselocale_seen = true;
+	}
 	return nullptr;
 }
 


### PR DESCRIPTION
This spams a lot during `WebKitGTK` operations, and that eats performance in QEMU. This _should_ only log it once now.