### PR TITLE
misc: Do not rely on magic macros to modify freestanding header behaviour

### DIFF
--- a/options/ansi/generic/stdio-stubs.cpp
+++ b/options/ansi/generic/stdio-stubs.cpp
@@ -340,7 +340,7 @@ static void store_int(void *dest, unsigned int size, unsigned long long i) {
 }
 
 template<typename H>
-static int do_scanf(H &handler, const char *fmt, __gnuc_va_list args) {
+static int do_scanf(H &handler, const char *fmt, __builtin_va_list args) {
 	int match_count = 0;
 	for (; *fmt; fmt++) {
 
@@ -712,7 +712,7 @@ int sscanf(const char *__restrict buffer, const char *__restrict format, ...) {
 	return result;
 }
 
-int vfprintf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_list args) {
+int vfprintf(FILE *__restrict stream, const char *__restrict format, __builtin_va_list args) {
 	frg::va_struct vs;
 	frg::arg arg_list[NL_ARGMAX + 1];
 	vs.arg_list = arg_list;
@@ -728,7 +728,7 @@ int vfprintf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_l
 	return p.count;
 }
 
-int vfscanf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_list args) {
+int vfscanf(FILE *__restrict stream, const char *__restrict format, __builtin_va_list args) {
 	auto file = static_cast<mlibc::abstract_file *>(stream);
 	frg::unique_lock lock(file->_lock);
 
@@ -758,17 +758,17 @@ int vfscanf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_li
 	return do_scanf(handler, format, args);
 }
 
-int vprintf(const char *__restrict format, __gnuc_va_list args){
+int vprintf(const char *__restrict format, __builtin_va_list args){
 	return vfprintf(stdout, format, args);
 }
 
-int vscanf(const char *__restrict, __gnuc_va_list) {
+int vscanf(const char *__restrict, __builtin_va_list) {
 	__ensure(!"Not implemented");
 	__builtin_unreachable();
 }
 
 int vsnprintf(char *__restrict buffer, size_t max_size,
-		const char *__restrict format, __gnuc_va_list args) {
+		const char *__restrict format, __builtin_va_list args) {
 	frg::va_struct vs;
 	frg::arg arg_list[NL_ARGMAX + 1];
 	vs.arg_list = arg_list;
@@ -783,7 +783,7 @@ int vsnprintf(char *__restrict buffer, size_t max_size,
 	return p.count;
 }
 
-int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_list args) {
+int vsprintf(char *__restrict buffer, const char *__restrict format, __builtin_va_list args) {
 	frg::va_struct vs;
 	frg::arg arg_list[NL_ARGMAX + 1];
 	vs.arg_list = arg_list;
@@ -797,7 +797,7 @@ int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_l
 	return p.count;
 }
 
-int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc_va_list args) {
+int vsscanf(const char *__restrict buffer, const char *__restrict format, __builtin_va_list args) {
 	struct {
 		char look_ahead() {
 			return *buffer;
@@ -819,18 +819,18 @@ int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc
 
 int fwprintf(FILE *__restrict, const wchar_t *__restrict, ...) MLIBC_STUB_BODY
 int fwscanf(FILE *__restrict, const wchar_t *__restrict, ...) MLIBC_STUB_BODY
-int vfwprintf(FILE *__restrict, const wchar_t *__restrict, __gnuc_va_list) MLIBC_STUB_BODY
-int vfwscanf(FILE *__restrict, const wchar_t *__restrict, __gnuc_va_list) MLIBC_STUB_BODY
+int vfwprintf(FILE *__restrict, const wchar_t *__restrict, __builtin_va_list) MLIBC_STUB_BODY
+int vfwscanf(FILE *__restrict, const wchar_t *__restrict, __builtin_va_list) MLIBC_STUB_BODY
 
 int swprintf(wchar_t *__restrict, size_t, const wchar_t *__restrict, ...) MLIBC_STUB_BODY
 int swscanf(wchar_t *__restrict, size_t, const wchar_t *__restrict, ...) MLIBC_STUB_BODY
-int vswprintf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __gnuc_va_list) MLIBC_STUB_BODY
-int vswscanf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __gnuc_va_list) MLIBC_STUB_BODY
+int vswprintf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __builtin_va_list) MLIBC_STUB_BODY
+int vswscanf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __builtin_va_list) MLIBC_STUB_BODY
 
 int wprintf(const wchar_t *__restrict, ...) MLIBC_STUB_BODY
 int wscanf(const wchar_t *__restrict, ...) MLIBC_STUB_BODY
-int vwprintf(const wchar_t *__restrict, __gnuc_va_list) MLIBC_STUB_BODY
-int vwscanf(const wchar_t *__restrict, __gnuc_va_list) MLIBC_STUB_BODY
+int vwprintf(const wchar_t *__restrict, __builtin_va_list) MLIBC_STUB_BODY
+int vwscanf(const wchar_t *__restrict, __builtin_va_list) MLIBC_STUB_BODY
 
 int fgetc(FILE *stream) {
 	char c;
@@ -1066,7 +1066,7 @@ int asprintf(char **out, const char *format, ...) {
 	return result;
 }
 
-int vasprintf(char **out, const char *format, __gnuc_va_list args) {
+int vasprintf(char **out, const char *format, __builtin_va_list args) {
 	frg::va_struct vs;
 	frg::arg arg_list[NL_ARGMAX + 1];
 	vs.arg_list = arg_list;

--- a/options/ansi/include/stdio.h
+++ b/options/ansi/include/stdio.h
@@ -14,11 +14,6 @@
 extern "C" {
 #endif
 
-// This mechanism provides __gnu_va_list which is equivalent to va_list
-// We have to do this because stdio.h is not supposed to define va_list
-#define __need___va_list
-#include <stdarg.h>
-
 // [C11-7.21.1] I/O related types
 
 #define __MLIBC_EOF_BIT 1
@@ -128,30 +123,30 @@ __attribute__((format(gnu_scanf, 2, 3)))
 int sscanf(const char *__restrict buffer, const char *__restrict format, ...);
 
 __attribute__((format(gnu_printf, 2, 0)))
-int vfprintf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_list args);
+int vfprintf(FILE *__restrict stream, const char *__restrict format, __builtin_va_list args);
 
 __attribute__((format(gnu_scanf, 2, 0)))
-int vfscanf(FILE *__restrict stream, const char *__restrict format, __gnuc_va_list args);
+int vfscanf(FILE *__restrict stream, const char *__restrict format, __builtin_va_list args);
 
 __attribute__((format(gnu_printf, 1, 0)))
-int vprintf(const char *__restrict format, __gnuc_va_list args);
+int vprintf(const char *__restrict format, __builtin_va_list args);
 
 __attribute__((format(gnu_scanf, 1, 0)))
-int vscanf(const char *__restrict format, __gnuc_va_list args);
+int vscanf(const char *__restrict format, __builtin_va_list args);
 
 __attribute__((format(gnu_printf, 3, 0)))
 int vsnprintf(char *__restrict buffer, size_t max_size,
-		const char *__restrict format, __gnuc_va_list args);
+		const char *__restrict format, __builtin_va_list args);
 
 __attribute__((format(gnu_printf, 2, 0)))
-int vsprintf(char *__restrict buffer, const char *__restrict format, __gnuc_va_list args);
+int vsprintf(char *__restrict buffer, const char *__restrict format, __builtin_va_list args);
 
 __attribute__((format(gnu_scanf, 2, 0)))
-int vsscanf(const char *__restrict buffer, const char *__restrict format, __gnuc_va_list args);
+int vsscanf(const char *__restrict buffer, const char *__restrict format, __builtin_va_list args);
 
 // this is a gnu extension
 __attribute__((format(gnu_printf, 2, 0)))
-int vasprintf(char **, const char *, __gnuc_va_list);
+int vasprintf(char **, const char *, __builtin_va_list);
 
 // [C11-7.21.7] Character input/output functions
 

--- a/options/ansi/include/wchar.h
+++ b/options/ansi/include/wchar.h
@@ -1,11 +1,6 @@
 #ifndef _WCHAR_H
 #define _WCHAR_H
 
-// This mechanism provides __gnu_va_list which is equivalent to va_list
-// We have to do this because wchar.h is not supposed to define va_list
-#define __need___va_list
-#include <stdarg.h>
-
 #include <bits/null.h>
 #include <bits/size_t.h>
 #include <bits/wchar_t.h>
@@ -31,18 +26,18 @@ typedef struct __mlibc_mbstate mbstate_t;
 
 int fwprintf(FILE *__restrict, const wchar_t *__restrict, ...);
 int fwscanf(FILE *__restrict, const wchar_t *__restrict, ...);
-int vfwprintf(FILE *__restrict, const wchar_t *__restrict, __gnuc_va_list);
-int vfwscanf(FILE *__restrict, const wchar_t *__restrict, __gnuc_va_list);
+int vfwprintf(FILE *__restrict, const wchar_t *__restrict, __builtin_va_list);
+int vfwscanf(FILE *__restrict, const wchar_t *__restrict, __builtin_va_list);
 
 int swprintf(wchar_t *__restrict, size_t, const wchar_t *__restrict, ...);
 int swscanf(wchar_t *__restrict, size_t, const wchar_t *__restrict, ...);
-int vswprintf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __gnuc_va_list);
-int vswscanf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __gnuc_va_list);
+int vswprintf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __builtin_va_list);
+int vswscanf(wchar_t *__restrict, size_t, const wchar_t *__restrict, __builtin_va_list);
 
 int wprintf(const wchar_t *__restrict, ...);
 int wscanf(const wchar_t *__restrict, ...);
-int vwprintf(const wchar_t *__restrict, __gnuc_va_list);
-int vwscanf(const wchar_t *__restrict, __gnuc_va_list);
+int vwprintf(const wchar_t *__restrict, __builtin_va_list);
+int vwscanf(const wchar_t *__restrict, __builtin_va_list);
 
 // [7.28.3] Wide character I/O functions
 

--- a/options/internal/include/bits/null.h
+++ b/options/internal/include/bits/null.h
@@ -2,8 +2,15 @@
 #ifndef MLIBC_NULL_H
 #define MLIBC_NULL_H
 
-#define __need_NULL
-#include <stddef.h>
+#ifdef NULL
+#undef NULL
+#endif
+
+#ifndef __cplusplus
+#  define NULL ((void *)0)
+#else
+#  define NULL 0
+#endif
 
 #endif // MLIBC_NULL_H
 

--- a/options/internal/include/bits/size_t.h
+++ b/options/internal/include/bits/size_t.h
@@ -1,7 +1,6 @@
 #ifndef MLIBC_SIZE_T_H
 #define MLIBC_SIZE_T_H
 
-#define __need_size_t
-#include <stddef.h>
+typedef __SIZE_TYPE__ size_t;
 
 #endif // MLIBC_SIZE_T_H

--- a/options/internal/include/bits/wchar_t.h
+++ b/options/internal/include/bits/wchar_t.h
@@ -2,8 +2,11 @@
 #ifndef MLIBC_WCHAR_T_H
 #define MLIBC_WCHAR_T_H
 
-#define __need_wchar_t
-#include <stddef.h>
+#ifndef __cplusplus
+
+typedef __WCHAR_TYPE__ wchar_t;
+
+#endif
 
 #endif // MLIBC_WCHAR_T_H
 

--- a/options/internal/include/bits/wint_t.h
+++ b/options/internal/include/bits/wint_t.h
@@ -1,7 +1,6 @@
 #ifndef MLIBC_WINT_T_H
 #define MLIBC_WINT_T_H
 
-#define __need_wint_t
-#include <stddef.h>
+typedef __WINT_TYPE__ wint_t;
 
 #endif // MLIBC_WINT_T_H

--- a/options/posix/generic/posix_stdio.cpp
+++ b/options/posix/generic/posix_stdio.cpp
@@ -184,7 +184,7 @@ int dprintf(int fd, const char *format, ...) {
 	return result;
 }
 
-int vdprintf(int fd, const char *format, __gnuc_va_list args) {
+int vdprintf(int fd, const char *format, __builtin_va_list args) {
 	mlibc::fd_file file{fd};
 	int ret = vfprintf(&file, format, args);
 	file.flush();

--- a/options/posix/include/bits/posix/posix_stdio.h
+++ b/options/posix/include/bits/posix/posix_stdio.h
@@ -28,7 +28,7 @@ int fseeko(FILE *stream, off_t offset, int whence);
 off_t ftello(FILE *stream);
 
 int dprintf(int fd, const char *format, ...);
-int vdprintf(int fd, const char *format, __gnuc_va_list args);
+int vdprintf(int fd, const char *format, __builtin_va_list args);
 
 char *fgetln(FILE *, size_t *);
 


### PR DESCRIPTION
This PR makes it so mlibc does not make assumptions about magic modifier macros to change the behaviour of *non* mlibc-provided freestanding headers.