### PR TITLE
options/posix: Support sched_get_priority_max()

### DIFF
--- a/options/posix/generic/sched-stubs.cpp
+++ b/options/posix/generic/sched-stubs.cpp
@@ -17,9 +17,15 @@ int sched_yield(void) {
 	return 0;
 }
 
-int sched_get_priority_max(int) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+int sched_get_priority_max(int policy) {
+	int res = 0;
+
+	auto sysdep = MLIBC_CHECK_OR_ENOSYS(mlibc::sys_get_max_priority, -1);
+	if(int e = sysdep(policy, &res); e) {
+		errno = e;
+		return -1;
+	}
+	return res;
 }
 
 int sched_get_priority_min(int policy) {

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -111,6 +111,7 @@ int sys_close(int fd);
 [[gnu::weak]] int sys_setpriority(int which, id_t who, int prio);
 [[gnu::weak]] int sys_getschedparam(void *tcb, int *policy, struct sched_param *param);
 [[gnu::weak]] int sys_setschedparam(void *tcb, int policy, const struct sched_param *param);
+[[gnu::weak]] int sys_get_max_priority(int policy, int *out);
 [[gnu::weak]] int sys_get_min_priority(int policy, int *out);
 [[gnu::weak]] int sys_getcwd(char *buffer, size_t size);
 [[gnu::weak]] int sys_chdir(const char *path);


### PR DESCRIPTION
This adds support for the `sched_get_priority_max()` function if the appropriate sysdep is available.