### PR TITLE
define _GNU_SOURCE in posix_string.cpp

### DIFF
--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -1,3 +1,7 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <bits/ensure.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
...otherwise `memrchr` will be mangled as a C++ function (_Z7memrchrPKvim)