### PR TITLE
options/ansi: prevent multiplication overflows in calloc

### DIFF
--- a/options/ansi/generic/stdlib-stubs.cpp
+++ b/options/ansi/generic/stdlib-stubs.cpp
@@ -138,6 +138,13 @@ void *aligned_alloc(size_t alignment, size_t size) {
 
 }
 void *calloc(size_t count, size_t size) {
+	// we want to ensure that count*size > SIZE_MAX doesn't happen
+	// to prevent overflowing, we divide both sides of the inequality by size and check with that
+	if(size && count > (SIZE_MAX / size)) {
+		errno = EINVAL;
+		return NULL;
+	}
+
 	// TODO: this could be done more efficient if the OS gives us already zero'd pages
 	void *ptr = malloc(count * size);
 	if(!ptr)

--- a/tests/ansi/calloc.c
+++ b/tests/ansi/calloc.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int main() {
+	errno = 0;
+	void *ptr = calloc((SIZE_MAX / 2) + 2, 2);
+	assert(!ptr);
+	assert(errno);
+
+	errno = 0;
+	ptr = calloc(sizeof(size_t), 10);
+	assert(ptr);
+	for(size_t i = 0; i < 10; i++) {
+		size_t *p = ptr;
+		assert(!p[i]);
+	}
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,6 +25,7 @@ all_test_cases = [
 	'ansi/qsort',
 	'ansi/freopen',
 	'ansi/strxfrm',
+	'ansi/calloc',
 	'bsd/ns_get_put',
 	'bsd/reallocarray',
 	'bsd/strl',
@@ -125,7 +126,12 @@ host_libc_noasan_test_cases = [
 	'posix/pthread_attr', # does some stack overflowing to check stack size
 	'posix/posix_memalign',
 	'posix/search', # requires tdelete (#351)
+	'ansi/calloc', # does some overflowing
 ]
+
+extra_cflags_test_cases = {
+	'ansi/calloc': ['-Wno-alloc-size-larger-than'],
+}
 
 test_sources = []
 test_link_args = []
@@ -221,10 +227,17 @@ foreach test_name : all_test_cases
 		else
 			host_libc_sanitize_options = 'b_sanitize=address,undefined'
 		endif
+
+		if test_name in extra_cflags_test_cases
+			extra_cflags = extra_cflags_test_cases[test_name]
+		else
+			extra_cflags = []
+		endif
+
 		exec = executable('host-libc-' + test_exec_name, test_name + '.c',
 			build_rpath: meson.build_root(),
 			override_options: host_libc_sanitize_options,
-			c_args: ['-D_GNU_SOURCE', '-DUSE_HOST_LIBC', '-pthread'],
+			c_args: ['-D_GNU_SOURCE', '-DUSE_HOST_LIBC', '-pthread', extra_cflags],
 			link_args: ['-lresolv', '-ldl', '-pthread', '-lm', '-lrt'],
 			native: true,
 		)


### PR DESCRIPTION
This fixes #790.