### PR TITLE
sysdeps: Fix sp assignment in sys_prepare_stack

### DIFF
--- a/options/ansi/include/mlibc/ansi-sysdeps.hpp
+++ b/options/ansi/include/mlibc/ansi-sysdeps.hpp
@@ -20,7 +20,9 @@ namespace [[gnu::visibility("hidden")]] mlibc {
 [[noreturn]] void sys_exit(int status);
 [[noreturn, gnu::weak]] void sys_thread_exit();
 
-[[gnu::weak]] int sys_prepare_stack(void **stack, void *entry, void *user_arg, void* tcb, size_t *stack_size, size_t *guard_size);
+// If *stack is not null, it should point to the lowest addressable byte of the stack.
+// Returns the new stack pointer in *stack and the stack base in *stack_base.
+[[gnu::weak]] int sys_prepare_stack(void **stack, void *entry, void *user_arg, void* tcb, size_t *stack_size, size_t *guard_size, void **stack_base);
 [[gnu::weak]] int sys_clone(void *tcb, pid_t *pid_out, void *stack);
 
 int sys_futex_wait(int *pointer, int expected, const struct timespec *time);

--- a/options/internal/generic/threads.cpp
+++ b/options/internal/generic/threads.cpp
@@ -34,7 +34,7 @@ int thread_create(struct __mlibc_thread_data **__restrict thread, const struct _
 		return ENOSYS;
 	}
 	int ret = mlibc::sys_prepare_stack(&stack, entry,
-			user_arg, new_tcb, &attr.__mlibc_stacksize, &attr.__mlibc_guardsize);
+			user_arg, new_tcb, &attr.__mlibc_stacksize, &attr.__mlibc_guardsize, &new_tcb->stackAddr);
 	if (ret)
 		return ret;
 
@@ -44,9 +44,6 @@ int thread_create(struct __mlibc_thread_data **__restrict thread, const struct _
 	}
 	new_tcb->stackSize = attr.__mlibc_stacksize;
 	new_tcb->guardSize = attr.__mlibc_guardsize;
-	new_tcb->stackAddr = reinterpret_cast<void*>(
-			reinterpret_cast<uintptr_t>(stack)
-			- attr.__mlibc_stacksize - attr.__mlibc_guardsize);
 	new_tcb->returnValueType = (returns_int) ? TcbThreadReturnValue::Integer : TcbThreadReturnValue::Pointer;
 	mlibc::sys_clone(new_tcb, &tid, stack);
 	*thread = reinterpret_cast<struct __mlibc_thread_data *>(new_tcb);

--- a/sysdeps/aero/generic/thread.cpp
+++ b/sysdeps/aero/generic/thread.cpp
@@ -32,21 +32,19 @@ namespace mlibc {
 static constexpr size_t default_stacksize = 0x1000000;
 
 int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb,
-                      size_t *stack_size, size_t *guard_size) {
+                      size_t *stack_size, size_t *guard_size, void **stack_base) {
     if (!*stack_size)
         *stack_size = default_stacksize;
     *guard_size = 0;
 
-    uintptr_t *sp;
     if (*stack) {
-        sp = reinterpret_cast<uintptr_t *>(*stack);
+		*stack_base = *stack;
     } else {
-        sp = reinterpret_cast<uintptr_t *>(
-            reinterpret_cast<uintptr_t>(
-                mmap(nullptr, *stack_size, PROT_READ | PROT_WRITE,
-                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)) +
-            *stack_size);
+        *stack_base = mmap(nullptr, *stack_size, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     }
+	
+	uintptr_t *sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack_base) + *stack_size);
 
     *--sp = reinterpret_cast<uintptr_t>(tcb);
     *--sp = reinterpret_cast<uintptr_t>(user_arg);

--- a/sysdeps/dripos/generic/thread.cpp
+++ b/sysdeps/dripos/generic/thread.cpp
@@ -28,21 +28,20 @@ namespace mlibc {
 
 static constexpr size_t default_stacksize = 0x200000;
 
-int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size) {
-	uintptr_t *sp;
+int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 	if (!*stack_size)
 		*stack_size = default_stacksize;
 	*guard_size = 0;
 
 	if (*stack) {
-		sp = reinterpret_cast<uintptr_t *>(*stack);
+		*stack_base = *stack;
 	} else {
-		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(
-					mmap(nullptr, *stack_size,
+		*stack_base = mmap(nullptr, *stack_size,
 						PROT_READ | PROT_WRITE,
-						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)
-					) + *stack_size);
+						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	}
+	
+	uintptr_t *sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack_base) + *stack_size);
 
 	*--sp = reinterpret_cast<uintptr_t>(tcb);
 	*--sp = reinterpret_cast<uintptr_t>(user_arg);

--- a/sysdeps/keyronex/generic/thread.cpp
+++ b/sysdeps/keyronex/generic/thread.cpp
@@ -40,7 +40,7 @@ extern "C" void __mlibc_thread_entry();
 		return 0;
 	}
 
-	int sys_prepare_stack(void **stack, void *entry, void *arg, void *tcb, size_t *stack_size, size_t *guard_size) {
+	int sys_prepare_stack(void **stack, void *entry, void *arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 		// TODO guard
 
 		mlibc::infoLogger() << "mlibc: sys_prepare_stack() does not setup a guard!" << frg::endlog;
@@ -50,11 +50,15 @@ extern "C" void __mlibc_thread_entry();
 		*stack_size = *stack_size ? *stack_size : DEFAULT_STACK;
 
 		if (!*stack) {
-			*stack = (void *)((char *)mmap(NULL, *stack_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) + *stack_size);
-			if (*stack == MAP_FAILED) {
+			*stack_base = mmap(NULL, *stack_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+			if (*stack_base == MAP_FAILED) {
 				return errno;
 			}
+		} else {
+			*stack_base = *stack;
 		}
+		
+		*stack = (void *)((char *)*stack_base + *stack_size);
 
 		void **stack_it = (void **)*stack;
 

--- a/sysdeps/lemon/generic/thread.cpp
+++ b/sysdeps/lemon/generic/thread.cpp
@@ -28,21 +28,20 @@ namespace mlibc {
 
 static constexpr size_t default_stacksize = 0x200000;
 
-int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size) {
+int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 	if (!*stack_size)
 		*stack_size = default_stacksize;
 	*guard_size = 0;
 
-	uintptr_t *sp;
 	if (*stack) {
-		sp = reinterpret_cast<uintptr_t *>(*stack);
+		*stack_base = *stack;
 	} else {
-		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(
-					mmap(nullptr, *stack_size,
+		*stack_base = mmap(nullptr, *stack_size,
 						PROT_READ | PROT_WRITE,
-						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)
-					) + *stack_size);
+						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	}
+	
+	uintptr_t *sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack_base) + *stack_size);
 
 	*--sp = reinterpret_cast<uintptr_t>(tcb);
 	*--sp = reinterpret_cast<uintptr_t>(user_arg);

--- a/sysdeps/linux/generic/thread.cpp
+++ b/sysdeps/linux/generic/thread.cpp
@@ -27,7 +27,7 @@ namespace mlibc {
 
 static constexpr size_t default_stacksize = 0x200000;
 
-int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size) {
+int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 	(void)tcb;
 	if (!*stack_size)
 		*stack_size = default_stacksize;
@@ -48,10 +48,10 @@ int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size
 				PROT_READ | PROT_WRITE);
 		if(ret)
 			return EAGAIN;
-		map += *stack_size + *guard_size;
 	}
 
-	auto sp = reinterpret_cast<uintptr_t*>(map);
+	*stack_base = reinterpret_cast<void*>(map);
+	auto sp = reinterpret_cast<uintptr_t*>(map + *guard_size + *stack_size);
 	*--sp = reinterpret_cast<uintptr_t>(user_arg);
 	*--sp = reinterpret_cast<uintptr_t>(entry);
 	*stack = reinterpret_cast<void*>(sp);

--- a/sysdeps/lyre/generic/thread.cpp
+++ b/sysdeps/lyre/generic/thread.cpp
@@ -25,7 +25,7 @@ extern "C" void __mlibc_thread_trampoline(void *(*fn)(void *), Tcb *tcb, void *a
 #define DEFAULT_STACK 0x400000
 
 namespace mlibc {
-	int sys_prepare_stack(void **stack, void *entry, void *arg, void *tcb, size_t *stack_size, size_t *guard_size) {
+	int sys_prepare_stack(void **stack, void *entry, void *arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 		// TODO guard
 
 		mlibc::infoLogger() << "mlibc: sys_prepare_stack() does not setup a guard!" << frg::endlog;
@@ -35,11 +35,15 @@ namespace mlibc {
 		*stack_size = *stack_size ? *stack_size : DEFAULT_STACK;
 
 		if (!*stack) {
-			*stack = (void *)((char *)mmap(NULL, *stack_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0) + *stack_size);
-			if (*stack == MAP_FAILED) {
+			*stack_base = mmap(NULL, *stack_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+			if (*stack_base == MAP_FAILED) {
 				return errno;
 			}
+		} else {
+			*stack_base = *stack;
 		}
+		
+		*stack = (void *)((char *)*stack_base + *stack_size);
 
 		void **stack_it = (void **)*stack;
 

--- a/sysdeps/managarm/aarch64/thread.cpp
+++ b/sysdeps/managarm/aarch64/thread.cpp
@@ -35,7 +35,7 @@ int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size
 
 	uintptr_t *sp;
 	if (*stack) {
-		sp = reinterpret_cast<uintptr_t *>(*stack);
+		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack) + *stack_size);
 	} else {
 		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(
 					mmap(nullptr, *stack_size,

--- a/sysdeps/managarm/aarch64/thread.cpp
+++ b/sysdeps/managarm/aarch64/thread.cpp
@@ -3,6 +3,7 @@
 #include <mlibc/tcb.hpp>
 #include <bits/ensure.h>
 #include <sys/mman.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -28,21 +29,22 @@ namespace mlibc {
 
 static constexpr size_t default_stacksize = 0x200000;
 
-int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size) {
+int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 	if (!*stack_size)
 		*stack_size = default_stacksize;
 	*guard_size = 0;
 
-	uintptr_t *sp;
 	if (*stack) {
-		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack) + *stack_size);
+		*stack_base = *stack;
 	} else {
-		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(
-					mmap(nullptr, *stack_size,
-						PROT_READ | PROT_WRITE,
-						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)
-					) + *stack_size);
+		*stack_base = mmap(nullptr, *stack_size, PROT_READ | PROT_WRITE,
+						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if(*stack_base == MAP_FAILED) {
+			return errno;
+		}
 	}
+	
+	uintptr_t *sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack_base) + *stack_size);
 
 	*--sp = reinterpret_cast<uintptr_t>(tcb);
 	*--sp = reinterpret_cast<uintptr_t>(user_arg);

--- a/sysdeps/managarm/x86_64/thread.cpp
+++ b/sysdeps/managarm/x86_64/thread.cpp
@@ -35,7 +35,7 @@ int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size
 
 	uintptr_t *sp;
 	if (*stack) {
-		sp = reinterpret_cast<uintptr_t *>(*stack);
+		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack) + *stack_size);
 	} else {
 		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(
 					mmap(nullptr, *stack_size,

--- a/sysdeps/managarm/x86_64/thread.cpp
+++ b/sysdeps/managarm/x86_64/thread.cpp
@@ -3,6 +3,7 @@
 #include <mlibc/tcb.hpp>
 #include <bits/ensure.h>
 #include <sys/mman.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -28,21 +29,22 @@ namespace mlibc {
 
 static constexpr size_t default_stacksize = 0x200000;
 
-int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size) {
+int sys_prepare_stack(void **stack, void *entry, void *user_arg, void *tcb, size_t *stack_size, size_t *guard_size, void **stack_base) {
 	if (!*stack_size)
 		*stack_size = default_stacksize;
 	*guard_size = 0;
 
-	uintptr_t *sp;
 	if (*stack) {
-		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack) + *stack_size);
+		*stack_base = *stack;
 	} else {
-		sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(
-					mmap(nullptr, *stack_size,
-						PROT_READ | PROT_WRITE,
-						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)
-					) + *stack_size);
+		*stack_base = mmap(nullptr, *stack_size, PROT_READ | PROT_WRITE,
+						MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if(*stack_base == MAP_FAILED) {
+			return errno;
+		}
 	}
+	
+	uintptr_t *sp = reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(*stack_base) + *stack_size);
 
 	*--sp = reinterpret_cast<uintptr_t>(tcb);
 	*--sp = reinterpret_cast<uintptr_t>(user_arg);

--- a/tests/posix/pthread_attr.c
+++ b/tests/posix/pthread_attr.c
@@ -99,7 +99,7 @@ static void *stackaddr_worker(void *arg) {
 #endif
 
 	// Check if our stack pointer is in a sane range.
-	assert(addr >= sp);
+	assert(sp > addr);
 	return NULL;
 }
 #pragma GCC diagnostic push
@@ -110,12 +110,14 @@ static void test_stackaddr() {
 	size_t size;
 	assert(!pthread_attr_getstacksize(&attr, &size));
 	void *addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
-				MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) + size;
-	assert(!pthread_attr_setstackaddr(&attr, addr));
+				MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	assert(!pthread_attr_setstack(&attr, addr, size));
 	assert(!pthread_attr_setguardsize(&attr, 0));
 	void *new_addr;
-	assert(!pthread_attr_getstackaddr(&attr, &new_addr));
+	size_t new_size;
+	assert(!pthread_attr_getstack(&attr, &new_addr, &new_size));
 	assert(new_addr == addr);
+	assert(new_size == size);
 
 	pthread_t thread;
 	assert(!pthread_create(&thread, &attr, stackaddr_worker, &addr));


### PR DESCRIPTION
Change sp assignment in sys_prepare_stack in case `*stack` is not null to `*stack + *stack_size`, because *stack points to the bottom of the stack and not top. As it is currently the writes later down in this function would be out of bounds in that case.