### PR TITLE
managarm: send mode in openat to posix

### DIFF
--- a/abis/linux/errno.h
+++ b/abis/linux/errno.h
@@ -136,4 +136,8 @@
 #define ERFKILL         132
 #define EHWPOISON       133
 
+
+// This is mlibc-specific.
+#define EIEIO           1524152434
+
 #endif // _ABIBITS_ERRNO_H

--- a/abis/mlibc/errno.h
+++ b/abis/mlibc/errno.h
@@ -120,4 +120,7 @@
 #define EBADE 1114
 #define EHWPOISON 1115
 #define EBADRQC 1116
+
+#define EIEIO 1524152434
+
 #endif // _ABIBITS_ERRNO_H

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1524,6 +1524,8 @@ int sys_mkfifoat(int dirfd, const char *path, mode_t mode) {
 		return EBADF;
 	}else if(resp.error() == managarm::posix::Errors::ILLEGAL_ARGUMENTS) {
 		return EINVAL;
+	}else if(resp.error() == managarm::posix::Errors::INTERNAL_ERROR) {
+		return EIEIO;
 	}else{
 		__ensure(resp.error() == managarm::posix::Errors::SUCCESS);
 		return 0;

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1423,6 +1423,9 @@ int sys_openat(int dirfd, const char *path, int flags, mode_t, int *fd) {
 
 	mlibc::infoLogger() << "\e[35mmlibc: sys_openat() ignores mode\e[39m"
 				<< frg::endlog;
+	// We do not support O_TMPFILE.
+	if(flags & O_TMPFILE)
+		return EOPNOTSUPP;
 
 	uint32_t proto_flags = 0;
 	if(flags & O_CREAT)

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1418,11 +1418,9 @@ int sys_open(const char *path, int flags, mode_t mode, int *fd) {
 	return sys_openat(AT_FDCWD, path, flags, mode, fd);
 }
 
-int sys_openat(int dirfd, const char *path, int flags, mode_t, int *fd) {
+int sys_openat(int dirfd, const char *path, int flags, mode_t mode, int *fd) {
 	SignalGuard sguard;
 
-	mlibc::infoLogger() << "\e[35mmlibc: sys_openat() ignores mode\e[39m"
-				<< frg::endlog;
 	// We do not support O_TMPFILE.
 	if(flags & O_TMPFILE)
 		return EOPNOTSUPP;
@@ -1455,6 +1453,7 @@ int sys_openat(int dirfd, const char *path, int flags, mode_t, int *fd) {
 	req.set_fd(dirfd);
 	req.set_path(frg::string<MemoryAllocator>(getSysdepsAllocator(), path));
 	req.set_flags(proto_flags);
+	req.set_mode(mode);
 
 	auto [offer, sendHead, sendTail, recvResp] = exchangeMsgsSync(
 		getPosixLane(),


### PR DESCRIPTION
Fix a bug where if a file is crated with open or openat, it will not have any permission modes.

More importantly, this removes about 50% of log spam.

Managarm PR: [managarm#568](https://github.com/managarm/managarm/pull/568l)