### PR TITLE
sysdeps/managarm: Fix the type_mask and the flags_mask

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -744,8 +744,8 @@ int sys_tcdrain(int) {
 }
 
 int sys_socket(int domain, int type_and_flags, int proto, int *fd) {
-	constexpr int type_mask = int(0xFFFF);
-	constexpr int flags_mask = ~int(0xFFFF);
+	constexpr int type_mask = int(0xF);
+	constexpr int flags_mask = ~int(0xF);
 	__ensure(!((type_and_flags & flags_mask) & ~(SOCK_CLOEXEC | SOCK_NONBLOCK)));
 
 	SignalGuard sguard;
@@ -807,8 +807,8 @@ int sys_pipe(int *fds, int flags) {
 }
 
 int sys_socketpair(int domain, int type_and_flags, int proto, int *fds) {
-	constexpr int type_mask = int(0xFFFF);
-	constexpr int flags_mask = ~int(0xFFFF);
+	constexpr int type_mask = int(0xF);
+	constexpr int flags_mask = ~int(0xF);
 	__ensure(!((type_and_flags & flags_mask) & ~(SOCK_CLOEXEC | SOCK_NONBLOCK)));
 
 	SignalGuard sguard;


### PR DESCRIPTION
Forgot to include this in the abi switch, my bad.