### PR TITLE
[WIP] sysdeps/managarm: implement sys_sysconf

### DIFF
--- a/options/linux/generic/sys-sysinfo.cpp
+++ b/options/linux/generic/sys-sysinfo.cpp
@@ -6,6 +6,7 @@
 #include <mlibc/linux-sysdeps.hpp>
 
 int sysinfo(struct sysinfo *info) {
+	mlibc::infoLogger() << "mlibc: sysinfo top" << frg::endlog;
 	MLIBC_CHECK_OR_ENOSYS(mlibc::sys_sysinfo, -1);
 	if(int e = mlibc::sys_sysinfo(info); e) {
 		errno = e;

--- a/sysdeps/managarm/generic/sched.cpp
+++ b/sysdeps/managarm/generic/sched.cpp
@@ -1,10 +1,12 @@
 #include <bits/ensure.h>
 #include <unistd.h>
+#include <pwd.h>
 
 #include <hel.h>
 #include <hel-syscalls.h>
 #include <mlibc/debug.hpp>
 #include <mlibc/allocator.hpp>
+// #include <mlibc/arch-defs.hpp>
 #include <mlibc/posix-pipe.hpp>
 #include <mlibc/posix-sysdeps.hpp>
 
@@ -93,6 +95,5 @@ int sys_setthreadaffinity(pid_t tid, size_t cpusetsize, const cpu_set_t *mask) {
 
 	return 0;
 }
-
 
 }

--- a/sysdeps/managarm/generic/sysinfo.cpp
+++ b/sysdeps/managarm/generic/sysinfo.cpp
@@ -1,0 +1,33 @@
+#include <unistd.h>
+
+#include <hel.h>
+#include <hel-syscalls.h>
+#include <mlibc/debug.hpp>
+#include <mlibc/allocator.hpp>
+#include <mlibc/linux-sysdeps.hpp>
+#include <mlibc/posix-sysdeps.hpp>
+
+int sys_sysinfo(struct sysinfo *info) {
+	mlibc::infoLogger() << "mlibc: sys_sysinfo top" << frg::endlog;
+	// TODO: fill in missing fields
+	uint64_t uptimeNanos;
+	HEL_CHECK(helGetSystemInformation(&uptimeNanos));
+
+	info->uptime = uptimeNanos / 1'000'000'000;
+	return 0;
+}
+
+int sys_sysconf(int num, long *ret) {
+	mlibc::infoLogger() << "mlibc: sys_sysconf top" << frg::endlog;
+	switch(num) {
+		case _SC_NPROCESSORS_ONLN:
+		case _SC_NPROCESSORS_CONF:
+			*ret = 0;
+			mlibc::infoLogger() << "mlibc: ret = " << ret << ", *ret = " << *ret << frg::endlog;
+			HEL_CHECK(helGetCpuInformation((uint32_t*)ret));
+			mlibc::infoLogger() << "mlibc: ret = " << ret << ", *ret = " << *ret << frg::endlog;
+			return 0;
+		default:
+			return EINVAL;
+	}
+}

--- a/sysdeps/managarm/meson.build
+++ b/sysdeps/managarm/meson.build
@@ -44,6 +44,7 @@ libc_sources += files(
 	'generic/sched.cpp',
 	'generic/signals.cpp',
 	'generic/socket.cpp',
+	'generic/sysinfo.cpp',
 	'generic/time.cpp'
 )
 libc_sources += [


### PR DESCRIPTION
Dependent on [managarm#575](https://github.com/managarm/managarm/pull/575).

Main reason this (and the managarm PR) are drafts is because the helGetCpuInformation syscall will probably change, since at the moment it only returns the amount of CPU cores.