### PR TITLE
options/ansi: threads.h should define thread_local for C

### DIFF
--- a/options/ansi/include/threads.h
+++ b/options/ansi/include/threads.h
@@ -24,6 +24,9 @@ enum {
 typedef struct __mlibc_thread_data *thrd_t;
 typedef struct __mlibc_mutex mtx_t;
 typedef struct __mlibc_cond cnd_t;
+#ifndef __cplusplus
+#define thread_local _Thread_local
+#endif
 
 typedef int (*thrd_start_t)(void*);
 


### PR DESCRIPTION
C++ defines `thread_local` as a keyword but in ISO C it isn't and must be a preprocessor definition. (See [ISO C11 draft spec](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf), section 6.2.4 - `_Thread_local` is listed as a storage-class specifier; section 7.26.1 - `thread_local` is listed as a macro defined by `<threads.h>` which expands to `_Thread_local`).

The lack of this breaks the build of e.g. [ObjFW](https://github.com/ObjFW/ObjFW).
