### PR TITLE
sysdeps/managarm: Fill in more uname information

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2477,9 +2477,9 @@ int sys_uname(struct utsname *buf) {
 	__ensure(buf);
 	mlibc::infoLogger() << "\e[31mmlibc: uname() returns static information\e[39m" << frg::endlog;
 	strcpy(buf->sysname, "Managarm");
-	strcpy(buf->nodename, "?");
-	strcpy(buf->release, "?");
-	strcpy(buf->version, "?");
+	strcpy(buf->nodename, "managarm");
+	strcpy(buf->release, "0.0.1-rolling");
+	strcpy(buf->version, "Managarm is not Managram");
 #if defined(__x86_64__)
 	strcpy(buf->machine, "x86_64");
 #elif defined (__aarch64__)


### PR DESCRIPTION
It's all static data for now, but it's better than the `???` everywhere.