### PR TITLE
Fix assert noreturn on clang

### DIFF
--- a/options/ansi/generic/assert-stubs.cpp
+++ b/options/ansi/generic/assert-stubs.cpp
@@ -5,7 +5,7 @@
 
 #include <bits/ensure.h>
 
-[[noreturn]] void __assert_fail(const char *assertion, const char *file, unsigned int line,
+[[gnu::noreturn]] void __assert_fail(const char *assertion, const char *file, unsigned int line,
 		const char *function) {
 	fprintf(stderr, "In function %s, file %s:%d: Assertion '%s' failed!\n",
 			function, file, line, assertion);

--- a/options/glibc/generic/glibc-assert.cpp
+++ b/options/glibc/generic/glibc-assert.cpp
@@ -5,7 +5,7 @@
 
 #include <bits/ensure.h>
 
-[[noreturn]] void __assert_fail_perror(int errno, const char *file, unsigned int line,
+[[gnu::noreturn]] void __assert_fail_perror(int errno, const char *file, unsigned int line,
 		const char *function) {
 	char *errormsg = strerror(errno);
 	fprintf(stderr, "In function %s, file %s:%d: Errno '%s' failed!\n",


### PR DESCRIPTION
Atleast on clang [[noreturn]] is not the same as `__attribute__((__noreturn__))` used in the header and it fails to compile because of that.