### PR TITLE
abis/linux: correct type of sigset_t

### DIFF
--- a/abis/linux/signal.h
+++ b/abis/linux/signal.h
@@ -113,8 +113,7 @@ typedef void (*__sighandler) (int);
 #define SIGRTMIN 35
 #define SIGRTMAX 64
 
-// TODO: replace this by uint64_t
-typedef long sigset_t;
+typedef uint64_t sigset_t;
 
 // constants for sigprocmask()
 #define SIG_BLOCK 0


### PR DESCRIPTION
Should be merged before [bootstrap-managarm#284](https://github.com/managarm/bootstrap-managarm/pull/284)