### PR TITLE
misc: Remove include-fixed include path

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,11 +85,6 @@ if not headers_only
 		error('could not find compiler-specific header directory')
 	endif
 
-	if c_compiler.get_id() == 'gcc' and fs.exists(ccdir / 'include-fixed')
-		rtdl_include_dirs += include_directories(ccdir / 'include-fixed')
-		libc_include_dirs += include_directories(ccdir / 'include-fixed')
-	endif
-
 	rtdl_include_dirs += include_directories(ccdir / 'include')
 	libc_include_dirs += include_directories(ccdir / 'include')
 endif


### PR DESCRIPTION
Adding the include-fixed include directory breaks the build if the directory actually has some system headers. For an example on Gentoo there is pthread.h there and when building mlibc it gets included instead of the mlibc pthread.h causing the build to fail.