### PR TITLE
sysdeps/managarm: remove CLOCK_MONOTONIC_RAW warning

### DIFF
--- a/sysdeps/managarm/generic/time.cpp
+++ b/sysdeps/managarm/generic/time.cpp
@@ -25,7 +25,7 @@ namespace mlibc {
 
 int sys_clock_get(int clock, time_t *secs, long *nanos) {
 	// This implementation is inherently signal-safe.
-	if(clock == CLOCK_MONOTONIC || clock == CLOCK_MONOTONIC_COARSE) {
+	if(clock == CLOCK_MONOTONIC || clock == CLOCK_MONOTONIC_RAW || clock == CLOCK_MONOTONIC_COARSE) {
 		uint64_t tick;
 		HEL_CHECK(helGetClock(&tick));
 		*secs = tick / 1000000000;
@@ -58,13 +58,6 @@ int sys_clock_get(int clock, time_t *secs, long *nanos) {
 				"\e[39m" << frg::endlog;
 		*secs = 0;
 		*nanos = 0;
-	}else if(clock == CLOCK_MONOTONIC_RAW) {
-		mlibc::infoLogger() << "\e[31mmlibc: clock_gettime implements CLOCK_MONOTONIC_RAW as CLOCK_MONOTONIC"
-				"\e[39m" << frg::endlog;
-		uint64_t tick;
-		HEL_CHECK(helGetClock(&tick));
-		*secs = tick / 1000000000;
-		*nanos = tick % 1000000000;
 	}else if(clock == CLOCK_BOOTTIME) {
 		mlibc::infoLogger() << "\e[31mmlibc: clock_gettime does not support CLOCK_BOOTTIME"
 				"\e[39m" << frg::endlog;


### PR DESCRIPTION
helGetClock is a raw counter, so warning here makes no sense.