### PR TITLE
options/ansi: Move complex-stubs.cpp to complex-stubs.c

### DIFF
--- a/options/ansi/generic/complex-stubs.c
+++ b/options/ansi/generic/complex-stubs.c
@@ -1,14 +1,9 @@
 #include <complex.h>
 
-extern "C" {
-
 long double cimagl(long double complex z) {
     return __imag__(z);
 }
 
 long double creall(long double complex z) {
     return __real__(z);
-}
-
-
 }

--- a/options/ansi/meson.build
+++ b/options/ansi/meson.build
@@ -6,7 +6,7 @@ endif
 ansi_sources = files(
 	'generic/stdlib-stubs.cpp',
 	'generic/assert-stubs.cpp',
-	'generic/complex-stubs.cpp',
+	'generic/complex-stubs.c',
 
 	'generic/complex/csqrt.c',
 	'generic/complex/csinhf.c',


### PR DESCRIPTION
This fixes an issue where the 'complex' type is not defined for C++ sources