### PR TITLE
termios-stub.cpp: make sure _GNU_SOURCE is defined

### DIFF
--- a/options/posix/generic/termios-stubs.cpp
+++ b/options/posix/generic/termios-stubs.cpp
@@ -1,3 +1,6 @@
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 
 #include <errno.h>
 #include <termios.h>


### PR DESCRIPTION
need to get CBAUD, etc.