### PR TITLE
options/rtdl: Fix alignment overhead computation for the TLS allocation

### DIFF
--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -885,7 +885,7 @@ Tcb *allocateTcb() {
 
 	// To make sure that both the TCB and TLS data are sufficiently aligned, allocate
 	// slightly more than necessary and adjust alignment afterwards.
-	size_t alignOverhead = frg::min(alignof(Tcb), tlsMaxAlignment);
+	size_t alignOverhead = frg::max(alignof(Tcb), tlsMaxAlignment);
 	size_t allocSize = tlsInitialSize + sizeof(Tcb) + alignOverhead;
 	auto allocation = reinterpret_cast<uintptr_t>(getAllocator().allocate(allocSize));
 	memset(reinterpret_cast<void *>(allocation), 0, allocSize);

--- a/tests/rtdl/meson.build
+++ b/tests/rtdl/meson.build
@@ -10,6 +10,7 @@ rtdl_test_cases = [
 	'scope3',
 	'scope4',
 	'scope5',
+	'tls_align',
 ]
 
 foreach test_name : rtdl_test_cases 

--- a/tests/rtdl/tls_align/libbar.c
+++ b/tests/rtdl/tls_align/libbar.c
@@ -1,0 +1,1 @@
+_Thread_local __attribute__((aligned(8))) char bar_thread_local[8] = "Hello!";

--- a/tests/rtdl/tls_align/libfoo.c
+++ b/tests/rtdl/tls_align/libfoo.c
@@ -1,0 +1,1 @@
+_Thread_local __attribute__((aligned(16))) char foo_thread_local[8] = "Hello!";

--- a/tests/rtdl/tls_align/meson.build
+++ b/tests/rtdl/tls_align/meson.build
@@ -1,0 +1,7 @@
+libfoo = shared_library('foo', 'libfoo.c')
+libbar = shared_library('bar', 'libbar.c')
+test_link_with = [libfoo, libbar]
+
+libfoo_native = shared_library('native-foo', 'libfoo.c', native: true)
+libbar_native = shared_library('native-bar', 'libbar.c', native: true)
+test_native_link_with = [libfoo_native, libbar_native]

--- a/tests/rtdl/tls_align/test.c
+++ b/tests/rtdl/tls_align/test.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdint.h>
+
+extern _Thread_local char foo_thread_local[];
+extern _Thread_local char bar_thread_local[];
+
+int main() {
+	assert(!((uintptr_t)foo_thread_local & (16 - 1)));
+	assert(!((uintptr_t)bar_thread_local & (8 - 1)));
+}


### PR DESCRIPTION
The alignment overhead is used to properly align the TCB, which on x86_64 needs to be aligned to the max TLS block alignment so that accessing blocks before it yields aligned addresses.

Fixes #960.