### PR TITLE
sysdeps/managarm: Add missing call to __dlapi_enter

### DIFF
--- a/sysdeps/managarm/generic/entry.cpp
+++ b/sysdeps/managarm/generic/entry.cpp
@@ -18,6 +18,7 @@
 void __mlibc_initLocale();
 
 extern "C" uintptr_t *__dlapi_entrystack();
+extern "C" void __dlapi_enter(uintptr_t *);
 
 // declared in posix-pipe.hpp
 thread_local Queue globalQueue;
@@ -124,8 +125,8 @@ LibraryGuard::LibraryGuard() {
 			__mlibc_stack_data.envp);
 }
 
-extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
-	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
+extern "C" void __mlibc_entry(uintptr_t *entry_stack, int (*main_fn)(int argc, char *argv[], char *env[])) {
+	__dlapi_enter(entry_stack);
 	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
 	exit(result);
 }

--- a/sysdeps/managarm/x86_64/crt-src/Scrt1.S
+++ b/sysdeps/managarm/x86_64/crt-src/Scrt1.S
@@ -1,7 +1,8 @@
 .section .text
 .global _start
 _start:
-	lea main(%rip), %rdi
+	mov %rsp, %rdi
+	lea main(%rip), %rsi
 	call __mlibc_entry
 .section .note.GNU-stack,"",%progbits
 

--- a/sysdeps/managarm/x86_64/crt-src/crt0.S
+++ b/sysdeps/managarm/x86_64/crt-src/crt0.S
@@ -2,7 +2,8 @@
 .section .text
 .global _start
 _start:
-	mov $main, %rdi
+	mov %rsp, %rdi
+	mov $main, %rsi
 	call __mlibc_entry
 
 .section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
This causes an ABI break, needed for upcoming gobject-introspection stuff