### PR TITLE
sysdeps/managarm: Fix AArch64 crt

### DIFF
--- a/sysdeps/managarm/aarch64/crt-src/Scrt1.S
+++ b/sysdeps/managarm/aarch64/crt-src/Scrt1.S
@@ -1,7 +1,8 @@
 .section .text
 .global _start
 _start:
-	adr x0, main
+	mov x0, sp
+	adr x1, main
 
 	bl __mlibc_entry
 	brk #0

--- a/sysdeps/managarm/aarch64/crt-src/crt0.S
+++ b/sysdeps/managarm/aarch64/crt-src/crt0.S
@@ -2,8 +2,9 @@
 .section .text
 .global _start
 _start:
-	adrp x0, main
-	add x0, x0, :lo12:main
+	mov x0, sp
+	adrp x1, main
+	add x1, x1, :lo12:main
 	bl __mlibc_entry
 
 .section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
The entry point was changed to include the sp parameter but the AArch64 crts weren't updated.