### PR TITLE
abis/linux: Make EIEIO conform to the maximum value that Linux reports

### DIFF
--- a/abis/linux/errno.h
+++ b/abis/linux/errno.h
@@ -138,6 +138,6 @@
 
 
 // This is mlibc-specific.
-#define EIEIO           1524152434
+#define EIEIO           4095
 
 #endif // _ABIBITS_ERRNO_H


### PR DESCRIPTION
This fixes a breakage in `elogind`. Technically an ABI break but not used outside the Managarm sysdeps.