### PR TITLE
Add .note.GNU-stack to crt files of linux x86 sysdep

### DIFF
--- a/sysdeps/linux/x86/crt-src/crti.S
+++ b/sysdeps/linux/x86/crt-src/crti.S
@@ -7,3 +7,5 @@ _init:
 .global _fini
 _fini:
 	pushl %eax
+
+.section .note.GNU-stack,"",%progbits

--- a/sysdeps/linux/x86/crt-src/crtn.S
+++ b/sysdeps/linux/x86/crt-src/crtn.S
@@ -5,3 +5,5 @@
 .section .fini
 	popl %eax
 	ret
+
+.section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
Mark stack in crti and crtn of linux sysdep non-executable.
This also makes the behavior consistent with other crt files.
