### PR TITLE
rtdl: Fix debug mode build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -413,6 +413,7 @@ if not headers_only
 
 	ld_cpp_args = [
 		'-fvisibility=hidden',
+		'-fvisibility-inlines-hidden',
 		'-fno-stack-protector',
 		'-DMLIBC_BUILDING_RTDL'
 	]


### PR DESCRIPTION
In some cases the rtdl can contain unwanted relocations to symbols from c++ stdlib when built in debug mode, this can be fixed by using `-fvisibility-inlines-hidden` in addition to `-fvisibility=hidden`.