### PR TITLE
x86: 64-bit time

### DIFF
--- a/options/ansi/include/bits/ansi/time_t.h
+++ b/options/ansi/include/bits/ansi/time_t.h
@@ -2,7 +2,8 @@
 #ifndef MLIBC_TIME_T
 #define MLIBC_TIME_T
 
-typedef long time_t;
+#include <bits/types.h>
+typedef __mlibc_int64 time_t;
 
 #endif
 

--- a/options/ansi/include/bits/ansi/timespec.h
+++ b/options/ansi/include/bits/ansi/timespec.h
@@ -5,8 +5,13 @@
 #include <bits/ansi/time_t.h>
 #include <bits/field-padding.h>
 
+// Equivalent of timespec64 in glibc.
+// Should be used only with 64-bit syscalls
+// or with appropriate compat syscalls.
 struct timespec {
 	time_t tv_sec;
+	// tv_nspec is required to be long by the C standard.
+	// However linux kernel expects long long. So we add padding.
 	__MLIBC_FIELD_PADDED(long, tv_nsec, long long);
 };
 

--- a/options/ansi/include/bits/ansi/timespec.h
+++ b/options/ansi/include/bits/ansi/timespec.h
@@ -3,10 +3,11 @@
 #define MLIBC_TIMESPEC_H
 
 #include <bits/ansi/time_t.h>
+#include <bits/field-padding.h>
 
 struct timespec {
 	time_t tv_sec;
-	long tv_nsec;
+	__MLIBC_FIELD_PADDED(long, tv_nsec, long long);
 };
 
 #endif // MLIBC_TIMESPEC_H

--- a/options/ansi/include/bits/ansi/timespec.h
+++ b/options/ansi/include/bits/ansi/timespec.h
@@ -12,7 +12,7 @@ struct timespec {
 	time_t tv_sec;
 	// tv_nspec is required to be long by the C standard.
 	// However linux kernel expects long long. So we add padding.
-	__MLIBC_FIELD_PADDED(long, tv_nsec, long long);
+	__MLIBC_FIELD_PADDED(long, long long, tv_nsec);
 };
 
 #endif // MLIBC_TIMESPEC_H

--- a/options/internal/include/bits/field-padding.h
+++ b/options/internal/include/bits/field-padding.h
@@ -1,15 +1,9 @@
 #ifndef MLIBC_FIELD_PADDING_H
 #define MLIBC_FIELD_PADDING_H
 
-#ifdef __GNUC__
-
-#define __MLIBC_FIELD_PADDED(T, F, PT) \
-	PT : (sizeof(PT)-sizeof(T))*8*(BYTE_ORDER == BIG_ENDIAN); \
+#define __MLIBC_FIELD_PADDED(T, AT, F) \
+	AT : (sizeof(AT)-sizeof(T))*8*(__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__); \
 	T F; \
-	PT : (sizeof(PT)-sizeof(T))*8*(BYTE_ORDER == LITTLE_ENDIAN)
-
-#else
-#error "Unsupported compiler"
-#endif
+	AT : (sizeof(AT)-sizeof(T))*8*(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 
 #endif

--- a/options/internal/include/bits/field-padding.h
+++ b/options/internal/include/bits/field-padding.h
@@ -1,0 +1,15 @@
+#ifndef MLIBC_FIELD_PADDING_H
+#define MLIBC_FIELD_PADDING_H
+
+#ifdef __GNUC__
+
+#define __MLIBC_FIELD_PADDED(T, F, PT) \
+	PT : (sizeof(PT)-sizeof(T))*8*(BYTE_ORDER == BIG_ENDIAN); \
+	T F; \
+	PT : (sizeof(PT)-sizeof(T))*8*(BYTE_ORDER == LITTLE_ENDIAN)
+
+#else
+#error "Unsupported compiler"
+#endif
+
+#endif

--- a/tests/ansi/timegm.c
+++ b/tests/ansi/timegm.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <assert.h>
+#include <inttypes.h>
 
 int main() {
 	struct tm soon = {};
@@ -14,7 +15,7 @@ int main() {
 	time_t expected_result = 0;
 	// This should be epoch.
 	result = timegm(&soon);
-	printf("epoch: %ld\n", result);
+	printf("epoch: %" PRId64 "\n", result);
 	assert(result == expected_result);
 
 	soon.tm_sec = 12;
@@ -26,7 +27,7 @@ int main() {
 	expected_result = 1652803692;
 	result = timegm(&soon);
 	// On my host, this returned 1652803692, verify this.
-	printf("epoch: %ld\n", result);
+	printf("epoch: %" PRId64 "\n", result);
 	assert(result == expected_result);
 
 	soon.tm_sec = 45;
@@ -38,7 +39,7 @@ int main() {
 	expected_result = -9181035;
 	result = timegm(&soon);
 	// On my host, this returned -9181035, verify this.
-	printf("epoch: %ld\n", result);
+	printf("epoch: %" PRId64 "\n", result);
 	assert(result == expected_result);
 
 	return 0;


### PR DESCRIPTION
Currently `time_t` is `long`, which is fine 64 bit arches, since `long` is always 8 bytes wide.
However, on x86 `long` is 4 bytes wide.

This PR changes `time_t` to always be 8 bytes wide, by making it `__mlibc_int64`.
