### PR TITLE
options/glibc: Don't overwrite posix icmp6.h

### DIFF
--- a/options/glibc/include/bits/glibc/glibc_icmp6.h
+++ b/options/glibc/include/bits/glibc/glibc_icmp6.h
@@ -1,6 +1,5 @@
-
-#ifndef _NETINET_ICMP6_H
-#define _NETINET_ICMP6_H
+#ifndef _GLIBC_NETINET_ICMP6_H
+#define _GLIBC_NETINET_ICMP6_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,5 +17,5 @@ extern "C" {
 }
 #endif
 
-#endif /* _NETINET_ICMP6_H */
+#endif /* _GLIBC_NETINET_ICMP6_H */
 

--- a/options/glibc/meson.build
+++ b/options/glibc/meson.build
@@ -77,13 +77,13 @@ if not no_headers
 	)
 	install_headers(
 		'include/netinet/in_systm.h',
-		'include/netinet/icmp6.h',
 		subdir: 'netinet'
 	)
 	install_headers(
 		'include/bits/glibc/glibc_signal.h',
 		'include/bits/glibc/glibc_assert.h',
 		'include/bits/glibc/glibc_malloc.h',
+		'include/bits/glibc/glibc_icmp6.h',
 		subdir: 'bits/glibc'
 	)
 endif

--- a/options/posix/include/netinet/icmp6.h
+++ b/options/posix/include/netinet/icmp6.h
@@ -7,6 +7,11 @@ extern "C" {
 
 #include <stdint.h>
 #include <abi-bits/in.h>
+#include <mlibc-config.h>
+
+#if __MLIBC_GLIBC_OPTION
+#include <bits/glibc/glibc_icmp6.h>
+#endif // __MLIBC_GLIBC_OPTION
 
 #define ICMP6_FILTER 1
 


### PR DESCRIPTION
Currently if the glibc option is enabled it overwrites the posix icmp6.h header with the extension header.