### PR TITLE
tests: Fix include paths when using cshim

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -149,7 +149,11 @@ test_link_args = []
 test_override_options = ['b_sanitize=none']
 
 if library_type == 'static'
-	libc = libc_static
+	libc_dep = declare_dependency(
+		include_directories: libc_include_dirs,
+		link_with: libc_static,
+		dependencies: [libc_deps, rtlib_deps]
+	)
 	use_pie = false
 	test_c_args += '-no-pie'
 	test_link_args += ['-no-pie', '-static']
@@ -159,7 +163,11 @@ if library_type == 'static'
 		crt,
 	]
 else
-	libc = libc_shared
+	libc_dep = declare_dependency(
+		include_directories: libc_include_dirs,
+		link_with: libc_shared,
+		dependencies: [libc_deps, rtlib_deps]
+	)
 	test_link_args += ['-Wl,--dynamic-linker=' + meson.build_root() + '/ld.so']
 
 	if host_machine.system() in ['linux', 'managarm']
@@ -201,8 +209,7 @@ foreach test_name : all_test_cases
 
 	should_fail = fail_test_cases.contains(test_name)
 	exec = executable(test_exec_name, [test_name + '.c', test_sources],
-		link_with: libc, include_directories: libc_include_dirs,
-		dependencies: rtdl_deps + rtlib_deps,
+		dependencies: libc_dep,
 		build_rpath: meson.build_root(),
 		override_options: test_override_options,
 		c_args: test_c_args,

--- a/tests/rtdl/ld_library_path/meson.build
+++ b/tests/rtdl/ld_library_path/meson.build
@@ -9,7 +9,7 @@ test_env += ['LD_LIBRARY_PATH=' + test_ld_path]
 test_native_env += ['LD_LIBRARY_PATH=' + test_ld_path]
 
 libfoo = shared_library('foo', 'libfoo.c',
-	link_with: libc, include_directories: libc_include_dirs,
+	dependencies: libc_dep,
 	link_args: test_additional_link_args,
 )
 

--- a/tests/rtdl/meson.build
+++ b/tests/rtdl/meson.build
@@ -30,8 +30,8 @@ foreach test_name : rtdl_test_cases
 	subdir(test_name)
 
 	exec = executable('rtdl-' + test_name, [test_name / 'test.c', test_sources],
-		link_with: test_link_with + libc, include_directories: libc_include_dirs,
-		dependencies: rtdl_deps + rtlib_deps,
+		link_with: test_link_with,
+		dependencies: libc_dep,
 		build_rpath: test_rpath,
 		override_options: test_override_options,
 		c_args: test_c_args,

--- a/tests/rtdl/preinit/meson.build
+++ b/tests/rtdl/preinit/meson.build
@@ -5,7 +5,7 @@ if host_machine.cpu_family() == 'riscv64'
 endif
 
 libfoo = shared_library('foo', 'libfoo.c',
-	link_with: libc, include_directories: libc_include_dirs,
+	dependencies: libc_dep,
 	override_options: 'b_sanitize=none',
 	link_args: test_additional_link_args,
 )

--- a/tests/rtdl/rtld_next/meson.build
+++ b/tests/rtdl/rtld_next/meson.build
@@ -2,11 +2,11 @@
 no_tail_calls = '-fno-optimize-sibling-calls'
 
 libfoo = shared_library('foo', 'libfoo.c',
-	link_with: libc, include_directories: libc_include_dirs,
+	dependencies: libc_dep,
 	c_args: no_tail_calls,
 )
 libbar = shared_library('bar', 'libbar.c',
-	link_with: libc, include_directories: libc_include_dirs,
+	dependencies: libc_dep,
 	c_args: no_tail_calls,
 )
 test_link_with = [libfoo, libbar] # foo is linked before bar


### PR DESCRIPTION
When only using link_with it doesn't look to be properly taking transitive dependencies into account leading into issues when using the headers that cshim provides.