### PR TITLE
options/posix: Implement dladdr1

### DIFF
--- a/options/posix/include/dlfcn.h
+++ b/options/posix/include/dlfcn.h
@@ -2,6 +2,8 @@
 #ifndef _DLFCN_H
 #define _DLFCN_H
 
+#include <mlibc-config.h>
+
 #define RTLD_LOCAL 0
 #define RTLD_NOW 1
 #define RTLD_GLOBAL 2
@@ -12,6 +14,9 @@
 
 #define RTLD_NEXT ((void *)-1)
 #define RTLD_DEFAULT ((void *)0)
+
+#define RTLD_DL_SYMENT 1
+#define RTLD_DL_LINKMAP 2
 
 #define RTLD_DI_LINKMAP 2
 
@@ -29,6 +34,8 @@ void *dlvsym(void *__restrict, const char *__restrict, const char *__restrict);
 
 #endif /* !__MLIBC_ABI_ONLY */
 
+#if defined(_GNU_SOURCE) && __MLIBC_GLIBC_OPTION
+
 //gnu extension
 typedef struct {
 	const char *dli_fname;
@@ -39,10 +46,13 @@ typedef struct {
 
 #ifndef __MLIBC_ABI_ONLY
 
-int dladdr(const void *, Dl_info *);
-int dlinfo(void *, int, void *);
+int dladdr(const void *__ptr, Dl_info *__out);
+int dladdr1(const void *__ptr, Dl_info *__out, void **__extra, int __flags);
+int dlinfo(void *__restrict __handle, int __request, void *__restrict __info);
 
 #endif /* !__MLIBC_ABI_ONLY */
+
+#endif /* defined(_GNU_SOURCE) && __MLIBC_GLIBC_OPTION */
 
 #ifdef __cplusplus
 }

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -691,6 +691,8 @@ struct __dlapi_symbol {
 	void *base;
 	const char *symbol;
 	void *address;
+	const void *elf_symbol;
+	void *link_map;
 };
 
 extern "C" [[ gnu::visibility("default") ]]
@@ -726,6 +728,8 @@ int __dlapi_reverse(const void *ptr, __dlapi_symbol *info) {
 				info->base = reinterpret_cast<void *>(object->baseAddress);
 				info->symbol = cand.getString();
 				info->address = reinterpret_cast<void *>(cand.virtualAddress());
+				info->elf_symbol = cand.symbol();
+				info->link_map = &object->linkMap;
 				return 0;
 			}
 		}
@@ -748,6 +752,8 @@ int __dlapi_reverse(const void *ptr, __dlapi_symbol *info) {
 				info->base = reinterpret_cast<void *>(object->baseAddress);
 				info->symbol = nullptr;
 				info->address = 0;
+				info->elf_symbol = nullptr;
+				info->link_map = &object->linkMap;
 				return 0;
 			}
 		}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -138,11 +138,8 @@ extra_cflags_test_cases = {
 
 test_sources = []
 test_link_args = []
-test_c_args = []
+test_c_args = ['-D_GNU_SOURCE']
 use_pie = false
-
-test_c_args = []
-test_link_args = []
 
 # Our ubsan implementation can't be used by the tests themselves,
 # since it is internal to libc.so and ld.so.


### PR DESCRIPTION
This is also a gnu extension so I am not sure if it should be guarded behind _GNU_SOURCE or __MLIBC_GLIBC_OPTION but it doesn't look like the existing `dladdr` is guarded either.