### PR TITLE
options/rtdl: Return LinkerError instead of nullptr on error

### DIFF
--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -245,7 +245,7 @@ frg::expected<LinkerError, SharedObject *> ObjectRepository::requestObjectWithNa
 		}
 	}
 	if(fd == -1)
-		return nullptr;
+		return LinkerError::notFound;
 
 	if (createScope) {
 		__ensure(localScope == nullptr);


### PR DESCRIPTION
I forgot to update this case in the dl non-elf pr.