### PR TITLE
options/rtdl: Implement tlsdesc for x86_64

### DIFF
--- a/options/internal/include/mlibc/tcb.hpp
+++ b/options/internal/include/mlibc/tcb.hpp
@@ -155,6 +155,8 @@ struct Tcb {
 static_assert(offsetof(Tcb, stackCanary) == 0x28);
 // sysdeps/linux/x86_64/cp_syscall.S uses the offset of cancelBits.
 static_assert(offsetof(Tcb, cancelBits) == 0x30);
+// options/linker/x86_64/runtime.S uses the offset of dtvPointers.
+static_assert(offsetof(Tcb, dtvPointers) == 16);
 #elif defined(__i386__)
 // GCC expects the stack canary to be at gs:0x14.
 // The offset differs from x86_64 due to the change in the pointer size

--- a/options/rtdl/x86_64/runtime.S
+++ b/options/rtdl/x86_64/runtime.S
@@ -1,3 +1,30 @@
+.global __mlibcTlsdescStatic
+.hidden __mlibcTlsdescStatic
+.type __mlibcTlsdescStatic, @function
+__mlibcTlsdescStatic:
+	mov 8(%rax), %rax
+	ret
+
+.global __mlibcTlsdescDynamic
+.hidden __mlibcTlsdescDynamic
+.type __mlibcTlsdescDynamic, @function
+__mlibcTlsdescDynamic:
+	push %rbx
+	push %rcx
+
+	mov 8(%rax), %rax
+
+	mov (%rax), %rbx // index
+	mov 8(%rax), %rcx // addend
+
+	mov %fs:16, %rax // *tp->dtvPointers
+	mov (%rax, %rbx, 8), %rax // dtvPointers[0][index]
+	add %rcx, %rax // + addend
+	sub %fs:0, %rax
+
+	pop %rcx
+	pop %rbx
+	ret
 
 .global pltRelocateStub
 pltRelocateStub:


### PR DESCRIPTION
I am not sure if the dynamic tlsdesc assembly is right at all, so someone should check it.