### PR TITLE
Some small fixes found during elogind debugging

### DIFF
--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -179,7 +179,7 @@ int sys_vm_unmap(void *pointer, size_t size);
 	socklen_t *actual_length);
 [[gnu::weak]] int sys_gethostname(char *buffer, size_t bufsize);
 [[gnu::weak]] int sys_sethostname(const char *buffer, size_t bufsize);
-[[gnu::weak]] int sys_mkfifoat(int dirfd, const char *path, int mode);
+[[gnu::weak]] int sys_mkfifoat(int dirfd, const char *path, mode_t mode);
 [[gnu::weak]] int sys_getentropy(void *buffer, size_t length);
 [[gnu::weak]] int sys_mknodat(int dirfd, const char *path, int mode, int dev);
 [[gnu::weak]] int sys_umask(mode_t mode, mode_t *old);

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -1653,7 +1653,7 @@ int sys_mknodat(int dirfd, const char *path, int mode, int dev) {
 	return 0;
 }
 
-int sys_mkfifoat(int dirfd, const char *path, int mode) {
+int sys_mkfifoat(int dirfd, const char *path, mode_t mode) {
 	return sys_mknodat(dirfd, path, mode | S_IFIFO, 0);
 }
 

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1447,14 +1447,14 @@ int sys_openat(int dirfd, const char *path, int flags, mode_t mode, int *fd) {
 	if(flags & O_NOCTTY)
 		proto_flags |= managarm::posix::OpenFlags::OF_NOCTTY;
 
-	if(flags & O_RDONLY)
-		proto_flags |= managarm::posix::OpenFlags::OF_RDONLY;
-	else if(flags & O_WRONLY)
-		proto_flags |= managarm::posix::OpenFlags::OF_WRONLY;
-	else if(flags & O_RDWR)
-		proto_flags |= managarm::posix::OpenFlags::OF_RDWR;
-	else if(flags & O_PATH)
+	if(flags & O_PATH)
 		proto_flags |= managarm::posix::OpenFlags::OF_PATH;
+	else if((flags & O_ACCMODE) == O_RDONLY)
+		proto_flags |= managarm::posix::OpenFlags::OF_RDONLY;
+	else if((flags & O_ACCMODE) == O_WRONLY)
+		proto_flags |= managarm::posix::OpenFlags::OF_WRONLY;
+	else if((flags & O_ACCMODE) == O_RDWR)
+		proto_flags |= managarm::posix::OpenFlags::OF_RDWR;
 
 	managarm::posix::OpenAtRequest<MemoryAllocator> req(getSysdepsAllocator());
 	req.set_fd(dirfd);


### PR DESCRIPTION
This PR contains a bugfix for Managarm's `sys_openat()` sysdep, and it fixes the function signature for `sys_mkfifoat()`. The signature change has no impact on users of the mlibc ABI, as `mode_t` is an `int` there, but for users of the Linux ABI it matters as `mode_t` is `unsigned int`.