### PR TITLE
rtdl: make default library search paths configurable at build time

### DIFF
--- a/internal-config.h.in
+++ b/internal-config.h.in
@@ -1,6 +1,8 @@
 #pragma once
 
 #mesondefine MLIBC_SYSTEM_NAME
+#mesondefine MLIBC_DEFAULT_LIBRARY_PATHS
+#mesondefine MLIBC_NUM_DEFAULT_LIBRARY_PATHS
 #mesondefine MLIBC_MAP_DSO_SEGMENTS
 #mesondefine MLIBC_MMAP_ALLOCATE_DSO
 #mesondefine MLIBC_MAP_FILE_WINDOWS

--- a/meson.build
+++ b/meson.build
@@ -157,7 +157,26 @@ if not headers_only
 	endif
 endif
 
+default_library_paths = get_option('default_library_paths')
+if default_library_paths.length() == 0
+	target_word_size = {
+		'x86_64': 64,
+		'x86': 32,
+		'riscv64': 64,
+		'riscv32': 32,
+		'aarch64': 64,
+		'arm': 32
+	}
+	if target_word_size.get(target_machine.cpu_family()) == 64
+		default_library_paths = ['/lib', '/lib64', '/usr/lib', '/usr/lib64']
+	else
+		default_library_paths = ['/lib', '/usr/lib']
+	endif
+endif
+
 internal_conf.set_quoted('MLIBC_SYSTEM_NAME', host_machine.system())
+internal_conf.set_quoted('MLIBC_DEFAULT_LIBRARY_PATHS', '\\n'.join(default_library_paths))
+internal_conf.set('MLIBC_NUM_DEFAULT_LIBRARY_PATHS', default_library_paths.length())
 internal_conf.set10('MLIBC_MAP_DSO_SEGMENTS', false)
 internal_conf.set10('MLIBC_MMAP_ALLOCATE_DSO', false)
 internal_conf.set10('MLIBC_MAP_FILE_WINDOWS', false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,5 +12,6 @@ option('disable_glibc_option', type: 'boolean', value : false)
 option('disable_bsd_option', type: 'boolean', value : false)
 option('disable_libgcc_dependency', type : 'boolean', value : false)
 option('linux_kernel_headers', type: 'string', value : '')
+option('default_library_paths', type: 'array', value: [])
 option('debug_allocator', type : 'boolean', value : false,
 	description : 'Enable the debug allocator, which uses mmap for every allocation and adds guard pages for each allocation')

--- a/options/rtdl/generic/linker.cpp
+++ b/options/rtdl/generic/linker.cpp
@@ -45,7 +45,7 @@ constexpr inline bool tlsAboveTp = true;
 extern DebugInterface globalDebugInterface;
 extern uintptr_t __stack_chk_guard;
 
-extern frg::manual_box<frg::small_vector<frg::string_view, 4, MemoryAllocator>> libraryPaths;
+extern frg::manual_box<frg::small_vector<frg::string_view, MLIBC_NUM_DEFAULT_LIBRARY_PATHS, MemoryAllocator>> libraryPaths;
 extern frg::manual_box<frg::vector<frg::string_view, MemoryAllocator>> preloads;
 
 #if MLIBC_STATIC_BUILD

--- a/options/rtdl/generic/main.cpp
+++ b/options/rtdl/generic/main.cpp
@@ -48,8 +48,8 @@ frg::manual_box<Scope> globalScope;
 
 frg::manual_box<RuntimeTlsMap> runtimeTlsMap;
 
-// We use a small vector of size 4 to avoid memory allocation for the default library paths
-frg::manual_box<frg::small_vector<frg::string_view, 4, MemoryAllocator>> libraryPaths;
+// We use a small vector to avoid memory allocation for the default library paths
+frg::manual_box<frg::small_vector<frg::string_view, MLIBC_NUM_DEFAULT_LIBRARY_PATHS, MemoryAllocator>> libraryPaths;
 
 frg::manual_box<frg::vector<frg::string_view, MemoryAllocator>> preloads;
 
@@ -340,11 +340,9 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 	}
 	aux++;
 
-	// Add default library paths
-	libraryPaths->push_back("/lib");
-	libraryPaths->push_back("/lib64");
-	libraryPaths->push_back("/usr/lib");
-	libraryPaths->push_back("/usr/lib64");
+	for (const frg::string_view path : parseList(MLIBC_DEFAULT_LIBRARY_PATHS, "\n")) {
+		libraryPaths->push_back(path);
+	}
 
 	// Parse the actual vector.
 	while(true) {


### PR DESCRIPTION
One scenario where overriding the default search paths is useful is when mlibc is used as a 'secondary' libc on a system. Absent this patch, mlibc will look for libraries in `/lib` and `/usr/lib`, but we want it to look in `/some/mlibc/sysroot/lib` instead.

Note that this is only needed if dynamic linking is used. To my knowledge, `musl` and `glibc` do not support a similar feature, requiring local patching instead.
