### PR TITLE
x86: Correctly set time fields in stat on Linux

### DIFF
--- a/abis/linux/stat.h
+++ b/abis/linux/stat.h
@@ -108,6 +108,11 @@ struct stat {
 		long tv_nsec;
 	} __st_atim32, __st_mtim32, __st_ctim32;
 	ino_t st_ino;
+
+	// These fields are not in the ABI. Their values are
+	// copied from __st_atim32, __st_mtim32, __st_ctim32
+	// accordingly.
+
 	struct timespec st_atim;
 	struct timespec st_mtim;
 	struct timespec st_ctim;

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -267,8 +267,19 @@ int sys_stat(fsfd_target fsfdt, int fd, const char *path, int flags, struct stat
 #else
 	auto ret = do_cp_syscall(SYS_fstatat64, fd, path, statbuf, flags);
 #endif
-	if (int e = sc_error(ret); e)
+	if (int e = sc_error(ret); e) {
 		return e;
+	}
+
+#if defined(__i386__)
+	statbuf->st_atim.tv_sec = statbuf->__st_atim32.tv_sec;
+	statbuf->st_atim.tv_nsec = statbuf->__st_atim32.tv_nsec;
+	statbuf->st_mtim.tv_sec = statbuf->__st_mtim32.tv_sec;
+	statbuf->st_mtim.tv_nsec = statbuf->__st_mtim32.tv_nsec;
+	statbuf->st_ctim.tv_sec = statbuf->__st_ctim32.tv_sec;
+	statbuf->st_ctim.tv_nsec = statbuf->__st_ctim32.tv_nsec;
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
Set `st_atim`, `st_mtim` and `st_ctim` based on internal (`__st_xxx32`) fields.
