### PR TITLE
options/rtdl: Fix tls in tlsAboveTp case

### DIFF
--- a/sysdeps/managarm/rtld-generic/support.cpp
+++ b/sysdeps/managarm/rtld-generic/support.cpp
@@ -177,7 +177,9 @@ namespace mlibc {
 
 int sys_tcb_set(void *pointer) {
 #if defined(__aarch64__)
-	asm volatile ("msr tpidr_el0, %0" :: "r"(pointer));
+	uintptr_t addr = reinterpret_cast<uintptr_t>(pointer);
+	addr += sizeof(Tcb) - 0x10;
+	asm volatile ("msr tpidr_el0, %0" :: "r"(addr));
 #else
 	HEL_CHECK(helWriteFsBase(pointer));
 #endif


### PR DESCRIPTION
Store the tls offset relative to the end of the tcb instead of the start of the tp in the tlsAboveTp case and take into account possible padding between the tls space and the tp in relocations.