### PR TITLE
Add two missing defines

### DIFF
--- a/options/posix/include/fcntl.h
+++ b/options/posix/include/fcntl.h
@@ -60,6 +60,7 @@ ssize_t vmsplice(int fd, const struct iovec *iov, size_t nr_segs, unsigned int f
 #define SPLICE_F_MORE 4
 #define SPLICE_F_GIFT 8
 
+#define AT_STATX_SYNC_AS_STAT 0x0000
 #define AT_NO_AUTOMOUNT 0x800
 
 #define F_SETPIPE_SZ 1031

--- a/options/posix/include/netdb.h
+++ b/options/posix/include/netdb.h
@@ -24,6 +24,7 @@
 #define NI_NUMERICSERV 2
 #define NI_MAXSERV 32
 #define NI_IDN 32
+#define NI_IDN_USE_STD3_ASCII_RULES 128
 
 #define NI_MAXHOST 1025
 


### PR DESCRIPTION
The AT_STATX one is for glib, the NI_IDN one is for InitWare