### PR TITLE
options/linux: add sys-statx.cpp to sources

### DIFF
--- a/options/linux/meson.build
+++ b/options/linux/meson.build
@@ -32,6 +32,7 @@ libc_sources += files(
 	'generic/cpuset.cpp',
 	'generic/sys-swap.cpp',
 	'generic/sys-statfs-stubs.cpp',
+	'generic/sys-statx.cpp',
 )
 
 if not no_headers


### PR DESCRIPTION
Add missing `sys-statx.cpp` source to `options/linux/meson.build`
