### PR TITLE
fix(abis/linux): remove redefinition of `S_IEXEC`

### DIFF
--- a/abis/linux/stat.h
+++ b/abis/linux/stat.h
@@ -26,7 +26,6 @@
 #define S_IRUSR 0400
 #define S_IWUSR 0200
 #define S_IXUSR 0100
-#define S_IEXEC S_IXUSR
 #define S_IRWXG 070
 #define S_IRGRP 040
 #define S_IWGRP 020


### PR DESCRIPTION
First defined: https://github.com/managarm/mlibc/blob/266ec427d78fa3deae7c288aaffc3709dbdb2903/abis/linux/stat.h#L29
Redefined in the same file but a few lines below: https://github.com/managarm/mlibc/blob/266ec427d78fa3deae7c288aaffc3709dbdb2903/abis/linux/stat.h#L44