### PR TITLE
options/posix: Implement erand48, drand48, seed48 and srand48

### DIFF
--- a/options/posix/include/bits/posix/posix_stdlib.h
+++ b/options/posix/include/bits/posix/posix_stdlib.h
@@ -13,6 +13,7 @@ extern "C" {
 
 long random(void);
 double drand48(void);
+double erand48(unsigned short s[3]);
 void srand48(long int);
 char *initstate(unsigned int, char *, size_t);
 char *setstate(char *);

--- a/scripts/rust-libc.py
+++ b/scripts/rust-libc.py
@@ -110,6 +110,8 @@ class Type:
                 return prefix + "::c_int"
             case ["unsigned", "char", *_]:
                 return prefix + "::c_uchar"
+            case ["unsigned", "short", *_]:
+                return prefix + "::c_ushort"
             case ["unsigned", "int", *_]:
                 return prefix + "::c_uint"
             case ["unsigned", "long", *_]:


### PR DESCRIPTION
Needed for `perl`, borrowed by @no92 from musl.