### PR TITLE
options/ansi: Various fixes to strftime

### DIFF
--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -1,4 +1,5 @@
-
+#include <algorithm>
+#include <array>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -92,6 +93,7 @@ size_t strftime(char *__restrict dest, size_t max_size,
 		const char *__restrict format, const struct tm *__restrict tm) {
 	auto c = format;
 	auto p = dest;
+	[[maybe_unused]] bool use_alternative_symbols = false;
 
 	while(*c) {
 		int chunk;
@@ -105,6 +107,23 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			c++;
 			p++;
 			continue;
+		}
+
+		if(*(c + 1) == 'O') {
+			std::array<char, 15> valid{{'B', 'b', 'd', 'e', 'H', 'I', 'm', 'M', 'S', 'u', 'U', 'V', 'w', 'W', 'y'}};
+			auto next = *(c + 2);
+			if(std::find(valid.begin(), valid.end(), next) != valid.end()) {
+				use_alternative_symbols = true;
+				c++;
+			} else {
+				*p = '%';
+				p++;
+				c++;
+				*p = 'O';
+				p++;
+				c++;
+				continue;
+			}
 		}
 
 		switch(*++c) {

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -282,6 +282,14 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			c++;
 			break;
 		}
+		case 'k': {
+			chunk = snprintf(p, space, "%2d", tm->tm_hour);
+			if(chunk >= space)
+				return 0;
+			p += chunk;
+			c++;
+			break;
+		}
 		case 'I': {
 			int hour = tm->tm_hour;
 			if(!hour)

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -311,6 +311,18 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			c++;
 			break;
 		}
+		case 'P': {
+			char *str = mlibc::nl_langinfo((tm->tm_hour < 12) ? AM_STR : PM_STR);
+			for(size_t i = 0; str[i]; i++)
+				str[i] = tolower(str[i]);
+
+			chunk = snprintf(p, space, "%s", str_lower);
+			if(chunk >= space)
+				return 0;
+			p += chunk;
+			c++;
+			break;
+		}
 		case 'C': {
 			chunk = snprintf(p, space, "%.2d", (1900 + tm->tm_year) / 100);
 			if(chunk >= space)

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -94,6 +94,7 @@ size_t strftime(char *__restrict dest, size_t max_size,
 	auto c = format;
 	auto p = dest;
 	[[maybe_unused]] bool use_alternative_symbols = false;
+	[[maybe_unused]] bool use_alternative_era_format = false;
 
 	while(*c) {
 		int chunk;
@@ -120,6 +121,21 @@ size_t strftime(char *__restrict dest, size_t max_size,
 				p++;
 				c++;
 				*p = 'O';
+				p++;
+				c++;
+				continue;
+			}
+		} else if(*(c + 1) == 'E') {
+			std::array<char, 6> valid{{'c', 'C', 'x', 'X', 'y', 'Y'}};
+			auto next = *(c + 2);
+			if(std::find(valid.begin(), valid.end(), next) != valid.end()) {
+				use_alternative_era_format = true;
+				c++;
+			} else {
+				*p = '%';
+				p++;
+				c++;
+				*p = 'E';
 				p++;
 				c++;
 				continue;

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -245,8 +245,16 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			break;
 		}
 		case 'c': {
-			chunk = snprintf(p, space, "%d/%.2d/%.2d %.2d:%.2d:%.2d", 1900 + tm->tm_year,
-					tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+			int day = tm->tm_wday;
+			if(day < 0 || day > 6)
+				__ensure(!"Day not in bounds.");
+
+			int mon = tm->tm_mon;
+			if(mon < 0 || mon > 11)
+				__ensure(!"Month not in bounds.");
+
+			chunk = snprintf(p, space, "%s %s %2d %.2i:%.2i:%.2d %d", mlibc::nl_langinfo(ABDAY_1 + day), 
+					mlibc::nl_langinfo(ABMON_1 + mon), tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, 1900 + tm->tm_year);
 			if(chunk >= space)
 				return 0;
 			p += chunk;

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -209,7 +209,7 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			break;
 		}
 		case 'D': {
-			chunk = snprintf(p, space, "%.2d/%.2d/%.2d", tm->tm_mon + 1, tm->tm_mday, tm->tm_year % 100);
+			chunk = snprintf(p, space, "%.2d/%.2d/%.2d", tm->tm_mon + 1, tm->tm_mday, (tm->tm_year + 1900) % 100);
 			if(chunk >= space)
 				return 0;
 			p += chunk;

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -269,7 +269,7 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			if(mon < 0 || mon > 11)
 				__ensure(!"Month not in bounds.");
 
-			chunk = snprintf(p, space, "%s %s %2d %.2i:%.2i:%.2d %d", mlibc::nl_langinfo(ABDAY_1 + day), 
+			chunk = snprintf(p, space, "%s %s %2d %.2i:%.2i:%.2d %d", mlibc::nl_langinfo(ABDAY_1 + day),
 					mlibc::nl_langinfo(ABMON_1 + mon), tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, 1900 + tm->tm_year);
 			if(chunk >= space)
 				return 0;
@@ -329,8 +329,10 @@ size_t strftime(char *__restrict dest, size_t max_size,
 		}
 		case 'P': {
 			char *str = mlibc::nl_langinfo((tm->tm_hour < 12) ? AM_STR : PM_STR);
+			char *str_lower = reinterpret_cast<char *>(getAllocator().allocate(strlen(str) + 1));
 			for(size_t i = 0; str[i]; i++)
-				str[i] = tolower(str[i]);
+				str_lower[i] = tolower(str[i]);
+			str_lower[strlen(str)] = '\0';
 
 			chunk = snprintf(p, space, "%s", str_lower);
 			if(chunk >= space)

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -152,7 +152,7 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			break;
 		}
 		case 'Z': {
-			chunk = snprintf(p, space, "%s", "GMT");
+			chunk = snprintf(p, space, "%s", "UTC");
 			if(chunk >= space)
 				return 0;
 			p += chunk;

--- a/options/ansi/generic/time-stubs.cpp
+++ b/options/ansi/generic/time-stubs.cpp
@@ -377,6 +377,14 @@ size_t strftime(char *__restrict dest, size_t max_size,
 			c++;
 			break;
 		}
+		case 'n': {
+			chunk = snprintf(p, space, "\n");
+			if(chunk >= space)
+				return 0;
+			p += chunk;
+			c++;
+			break;
+		}
 		case 't': {
 			chunk = snprintf(p, space, "\t");
 			if(chunk >= space)

--- a/options/internal/generic/locale.cpp
+++ b/options/internal/generic/locale.cpp
@@ -77,6 +77,8 @@ char *nl_langinfo(nl_item item) {
 		return const_cast<char *>("%m/%d/%y");
 	}else if(item == T_FMT) {
 		return const_cast<char *>("%H:%M:%S");
+	}else if(item == T_FMT_AMPM) {
+		return const_cast<char *>("%I:%M:%S %p");
 	}else{
 		mlibc::infoLogger() << "mlibc: nl_langinfo item "
 				<< item << " is not implemented properly" << frg::endlog;

--- a/options/internal/generic/locale.cpp
+++ b/options/internal/generic/locale.cpp
@@ -81,6 +81,8 @@ char *nl_langinfo(nl_item item) {
 		return const_cast<char *>("%I:%M:%S %p");
 	}else if(item == D_T_FMT) {
 		return const_cast<char *>("%a %b %e %T %Y");
+	}else if(item == YESEXPR) {
+		return const_cast<char *>("^[yY]");
 	}else{
 		mlibc::infoLogger() << "mlibc: nl_langinfo item "
 				<< item << " is not implemented properly" << frg::endlog;

--- a/options/internal/generic/locale.cpp
+++ b/options/internal/generic/locale.cpp
@@ -79,6 +79,8 @@ char *nl_langinfo(nl_item item) {
 		return const_cast<char *>("%H:%M:%S");
 	}else if(item == T_FMT_AMPM) {
 		return const_cast<char *>("%I:%M:%S %p");
+	}else if(item == D_T_FMT) {
+		return const_cast<char *>("%a %b %e %T %Y");
 	}else{
 		mlibc::infoLogger() << "mlibc: nl_langinfo item "
 				<< item << " is not implemented properly" << frg::endlog;

--- a/options/internal/generic/locale.cpp
+++ b/options/internal/generic/locale.cpp
@@ -83,6 +83,8 @@ char *nl_langinfo(nl_item item) {
 		return const_cast<char *>("%a %b %e %T %Y");
 	}else if(item == YESEXPR) {
 		return const_cast<char *>("^[yY]");
+	}else if(item == NOEXPR) {
+		return const_cast<char *>("^[nN]");
 	}else{
 		mlibc::infoLogger() << "mlibc: nl_langinfo item "
 				<< item << " is not implemented properly" << frg::endlog;

--- a/tests/ansi/strftime.c
+++ b/tests/ansi/strftime.c
@@ -11,8 +11,8 @@ int main() {
 		fputs("strftime testcase could not set locale, errors may be expected!", stderr);
 	}
 
-	char timebuf[16];
-	char result[16] = " 8";
+	char timebuf[32];
+	char result[32] = " 8";
 	struct tm tm;
 	tm.tm_sec = 0;
 	tm.tm_min = 17;
@@ -32,6 +32,24 @@ int main() {
 	memset(timebuf, 0, sizeof(timebuf));
 	strftime(timebuf, sizeof(timebuf), "%X", &tm);
 	assert(!strcmp(timebuf, "17:17:00"));
+
+	memset(timebuf, 0, sizeof(timebuf));
+	strftime(timebuf, sizeof(timebuf), "%D", &tm);
+	assert(!strcmp(timebuf, "03/08/21"));
+
+	memset(timebuf, 0, sizeof(timebuf));
+	strftime(timebuf, sizeof(timebuf), "%OB %Ob", &tm);
+	assert(!strcmp(timebuf, "March Mar"));
+
+	memset(timebuf, 0, sizeof(timebuf));
+	strftime(timebuf, sizeof(timebuf), "%c", &tm);
+	memset(result, 0, sizeof(result));
+	strftime(result, sizeof(result), "%a %b %e %H:%M:%S %Y", &tm);
+	assert(!strcmp(timebuf, result));
+
+	memset(timebuf, 0, sizeof(timebuf));
+	strftime(timebuf, sizeof(timebuf), "%k %p %P%n", &tm);
+	assert(!strcmp(timebuf, "17 PM pm\n"));
 
 	memset(timebuf, 0, sizeof(timebuf));
 	strftime(timebuf, sizeof(timebuf), "%a %A", &tm);


### PR DESCRIPTION
This PR fixes 2 bugs and implements 5 new modifiers for strftime.
These were all found while running the testsuite from glib.