### PR TITLE
sysdeps/managarm: pass a severity parameter to helLog

### DIFF
--- a/sysdeps/managarm/generic/ensure.cpp
+++ b/sysdeps/managarm/generic/ensure.cpp
@@ -23,7 +23,7 @@ namespace mlibc {
 		size_t n = 0;
 		while(message[n])
 			n++;
-		HEL_CHECK(helLog(message, n));
+		HEL_CHECK(helLog(kHelLogSeverityInfo, message, n));
 	}
 
 	void sys_libc_panic() {


### PR DESCRIPTION
Needs to be merged along with managarm/managarm#690.