### PR TITLE
options/rtld: Call fini functions on exit

### DIFF
--- a/options/internal/gcc/initfini.cpp
+++ b/options/internal/gcc/initfini.cpp
@@ -10,6 +10,8 @@ typedef void (*InitPtr)();
 
 extern InitPtr __CTOR_LIST__ [[ gnu::visibility("hidden") ]] [];
 extern InitPtr __CTOR_END__ [[ gnu::visibility("hidden") ]] [];
+extern InitPtr __DTOR_LIST__ [[ gnu::visibility("hidden") ]] [];
+extern InitPtr __DTOR_END__ [[ gnu::visibility("hidden") ]] [];
 
 extern "C" [[ gnu::visibility("hidden") ]] void __mlibc_do_ctors() {
 	const size_t n = __CTOR_END__ - __CTOR_LIST__;
@@ -24,6 +26,13 @@ extern "C" [[ gnu::visibility("hidden") ]] void __mlibc_do_ctors() {
 }
 
 extern "C" [[ gnu::visibility("hidden") ]] void __mlibc_do_dtors() {
-	mlibc::sys_libc_log("__mlibc_do_dtors() called");
-}
+	const size_t n = __DTOR_END__ - __DTOR_LIST__;
+	if(!n)
+		return;
 
+	size_t num = frg::min(n - 1, size_t(__DTOR_LIST__[0]));
+
+	for(size_t i = num; i >= 1; i--) {
+		__DTOR_LIST__[i]();
+	}
+}

--- a/options/rtld/generic/linker.hpp
+++ b/options/rtld/generic/linker.hpp
@@ -69,6 +69,9 @@ struct ObjectRepository {
 
 	SharedObject *findLoadedObject(frg::string_view name);
 
+	void addObjectToDestructQueue(SharedObject *object);
+	void destructObjects();
+
 	// Used by dl_iterate_phdr: stores objects in the order they are loaded.
 	frg::vector<SharedObject *, MemoryAllocator> loadedObjects;
 
@@ -86,6 +89,9 @@ private:
 
 	frg::hash_map<frg::string_view, SharedObject *,
 			frg::hash<frg::string_view>, MemoryAllocator> _nameMap;
+
+	// Used for destructing the objects, stores all the objects in the order they are initialized.
+	frg::vector<SharedObject *, MemoryAllocator> _destructQueue;
 };
 
 // --------------------------------------------------------
@@ -148,9 +154,12 @@ struct SharedObject {
 
 	// object initialization information
 	InitFuncPtr initPtr = nullptr;
+	InitFuncPtr finiPtr = nullptr;
 	InitFuncPtr *initArray = nullptr;
+	InitFuncPtr *finiArray = nullptr;
 	InitFuncPtr *preInitArray = nullptr;
 	size_t initArraySize = 0;
+	size_t finiArraySize = 0;
 	size_t preInitArraySize = 0;
 
 
@@ -189,6 +198,8 @@ struct SharedObject {
 	bool scheduledForInit;
 	bool onInitStack;
 	bool wasInitialized;
+
+	bool wasDestroyed = false;
 
 	// PHDR related stuff, we only set these for the main executable
 	void *phdrPointer = nullptr;
@@ -372,7 +383,7 @@ private:
 	void _processRelocations(Relocation &rel);
 
 public:
-	void initObjects();
+	void initObjects(ObjectRepository *repository);
 
 private:
 	void _scheduleInit(SharedObject *object);

--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -303,6 +303,8 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 		case DT_RELRSZ:
 		case DT_RELRENT:
 		case DT_PLTGOT:
+		case DT_FLAGS:
+		case DT_FLAGS_1:
 			continue;
 		default:
 			mlibc::panicLogger() << "rtld: unexpected dynamic entry " << ent->d_tag << " in program interpreter" << frg::endlog;
@@ -453,9 +455,13 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 	auto ldso = initialRepository->injectObjectFromDts(ldso_soname,
 		frg::string<MemoryAllocator> { getAllocator() },
 		ldso_base, _DYNAMIC, 1);
-	ldso->phdrPointer = phdr_pointer;
-	ldso->phdrCount = phdr_count;
-	ldso->phdrEntrySize = phdr_entry_size;
+
+	auto ldso_ehdr = reinterpret_cast<elf_ehdr *>(__ehdr_start);
+	auto ldso_phdr = reinterpret_cast<elf_phdr *>(ldso_base + ldso_ehdr->e_phoff);
+
+	ldso->phdrPointer = ldso_phdr;
+	ldso->phdrCount = ldso_ehdr->e_phnum;
+	ldso->phdrEntrySize = ldso_ehdr->e_phentsize;
 
 	// TODO: support non-zero base addresses?
 	executableSO = initialRepository->injectObjectFromPhdrs(execfn,
@@ -491,7 +497,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 	globalDebugInterface.state = 0;
 	dl_debug_state();
 
-	linker.initObjects();
+	linker.initObjects(initialRepository.get());
 
 	if(logEntryExit)
 		mlibc::infoLogger() << "Leaving ld.so, jump to "
@@ -520,6 +526,10 @@ void *__dlapi_get_tls(struct __abi_tls_entry *entry) {
 extern "C" [[ gnu::visibility("default") ]]
 const mlibc::RtldConfig &__dlapi_get_config() {
 	return rtldConfig;
+}
+
+extern "C" [[ gnu::visibility("default") ]] void __dlapi_exit() {
+	initialRepository->destructObjects();
 }
 
 #if __MLIBC_POSIX_OPTION
@@ -594,7 +604,7 @@ void *__dlapi_open(const char *file, int flags, void *returnAddress) {
 
 		Loader linker{object->localScope, nullptr, false, rts};
 		linker.linkObjects(object);
-		linker.initObjects();
+		linker.initObjects(initialRepository.get());
 	}
 
 	dl_debug_state();

--- a/tests/rtld/destroy/test.c
+++ b/tests/rtld/destroy/test.c
@@ -1,0 +1,9 @@
+#include <unistd.h>
+
+__attribute__((destructor)) void destroy() {
+	_exit(0);
+}
+
+int main() {
+	return 1;
+}

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -6,6 +6,7 @@ rtld_test_cases = [
 	'rtld_next',
 	'soname',
 	'preinit',
+	'destroy',
 	'scope1',
 	'scope2',
 	'scope3',


### PR DESCRIPTION
This is needed to support functions marked with attribute gnu::destructor. ~The way I implemented it it destructs the objects in reverse order that they were initialized in and first runs functions registered with __cxa_atexit for the object and after that the fini functions for that object, I am not sure if that's completely correct but to me it seems reasonable enough so in case of an object that doesn't have any circular dependencies both the atexit functions and destructor functions are run after the object can't be used by anything anymore.~ It turned out that there is an autogenerated call to __cxa_finalize that should call the functions registered for that dso, so I implemented that.