### PR TITLE
Several additions for VLC

### DIFF
--- a/abis/linux/in.h
+++ b/abis/linux/in.h
@@ -193,6 +193,7 @@ struct group_source_req {
 #define IP_PMTUDISC_INTERFACE 4
 #define IP_PMTUDISC_OMIT 5
 
+#define MCAST_JOIN_GROUP 42
 #define MCAST_BLOCK_SOURCE 43
 #define MCAST_UNBLOCK_SOURCE 44
 #define MCAST_JOIN_SOURCE_GROUP 46

--- a/options/ansi/include/inttypes.h
+++ b/options/ansi/include/inttypes.h
@@ -117,6 +117,8 @@
 #define SCNd32 "d"
 #define SCNd64 __PRI64 "d"
 
+#define SCNu16 "hu"
+
 #endif /* !__MLIBC_ABI_ONLY */
 
 #ifdef __cplusplus

--- a/options/posix/generic/posix_stdio.cpp
+++ b/options/posix/generic/posix_stdio.cpp
@@ -205,6 +205,11 @@ char *fgetln(FILE *, size_t *) {
 	__builtin_unreachable();
 }
 
+char *tempnam(const char *, const char *) {
+	__ensure(!"Not implemented");
+	__builtin_unreachable();
+}
+
 FILE *fopencookie(void *cookie, const char *__restrict mode, cookie_io_functions_t funcs) {
 	int flags = mlibc::fd_file::parse_modestring(mode);
 

--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -152,6 +152,11 @@ void *memrchr(const void *m, int c, size_t n) {
 	return 0;
 }
 
+char *strerror_l(int errnum, locale_t) {
+	mlibc::infoLogger() << "mlibc: strerror_l locale is ignored!" << frg::endlog;
+	return strerror(errnum);
+}
+
 // BSD extensions.
 // Taken from musl
 size_t strlcpy(char *d, const char *s, size_t n) {

--- a/options/posix/include/bits/posix/posix_stdio.h
+++ b/options/posix/include/bits/posix/posix_stdio.h
@@ -36,6 +36,8 @@ int vdprintf(int fd, const char *format, __builtin_va_list args);
 
 char *fgetln(FILE *, size_t *);
 
+char *tempnam(const char *dir, const char *pfx);
+
 #endif /* !__MLIBC_ABI_ONLY */
 
 #define RENAME_EXCHANGE (1 << 1)

--- a/options/posix/include/bits/posix/posix_string.h
+++ b/options/posix/include/bits/posix/posix_string.h
@@ -24,6 +24,8 @@ void *memccpy(void *__restrict dest, const void *__restrict src, int c, size_t n
 
 int strcoll_l(const char *s1, const char *s2, locale_t locale);
 
+char *strerror_l(int errnum, locale_t locale);
+
 // GNU extensions.
 #if defined(_GNU_SOURCE)
 char *strcasestr(const char *, const char *);

--- a/sysdeps/managarm/generic/socket.cpp
+++ b/sysdeps/managarm/generic/socket.cpp
@@ -534,6 +534,9 @@ int sys_setsockopt(int fd, int layer, int number,
 	}else if(layer == SOL_SOCKET && number == SO_OOBINLINE) {
 		mlibc::infoLogger() << "\e[31mmlibc: setsockopt() call with SOL_SOCKET and SO_OOBINLINE is unimplemented\e[39m" << frg::endlog;
 		return 0;
+	}else if(layer == SOL_SOCKET && number == SO_PRIORITY) {
+		mlibc::infoLogger() << "\e[31mmlibc: setsockopt() call with SOL_SOCKET and SO_PRIORITY is unimplemented\e[39m" << frg::endlog;
+		return 0;
 	}else{
 		mlibc::panicLogger() << "\e[31mmlibc: Unexpected setsockopt() call, layer: " << layer << " number: " << number << "\e[39m" << frg::endlog;
 		__builtin_unreachable();


### PR DESCRIPTION
Notably, this misses an implementation for `tdelete` and `twalk`, which are used for even the simplest things like `vlc --help`.