### PR TITLE
options/posix: change sys_getgroup parameters and implement putgrent

### DIFF
--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -94,7 +94,7 @@ int sys_close(int fd);
 [[gnu::weak]] int sys_seteuid(uid_t euid);
 [[gnu::weak]] int sys_setgid(gid_t gid);
 [[gnu::weak]] int sys_setegid(gid_t egid);
-[[gnu::weak]] int sys_getgroups(size_t size, const gid_t *list, int *ret);
+[[gnu::weak]] int sys_getgroups(size_t size, gid_t *list, int *ret);
 [[gnu::weak]] void sys_yield();
 [[gnu::weak]] int sys_sleep(time_t *secs, long *nanos);
 [[gnu::weak]] int sys_fork(pid_t *child);

--- a/sysdeps/ironclad/generic/generic.cpp
+++ b/sysdeps/ironclad/generic/generic.cpp
@@ -319,7 +319,7 @@ pid_t sys_getppid() {
 	return ret;
 }
 
-int sys_getgroups(size_t size, const gid_t *list, int *retval) {
+int sys_getgroups(size_t size, gid_t *list, int *retval) {
 	int ret, errno;
 	SYSCALL2(SYSCALL_GETGROUPS, size, list);
 	*retval = ret;

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -1824,7 +1824,7 @@ int sys_getpgid(pid_t pid, pid_t *out) {
 	return 0;
 }
 
-int sys_getgroups(size_t size, const gid_t *list, int *retval) {
+int sys_getgroups(size_t size, gid_t *list, int *retval) {
 	auto ret = do_syscall(SYS_getgroups, size, list);
 	if (int e = sc_error(ret); e)
 		return e;

--- a/sysdeps/lyre/generic/generic.cpp
+++ b/sysdeps/lyre/generic/generic.cpp
@@ -791,7 +791,7 @@ again:
 	return 0;
 }
 
-int sys_getgroups(size_t, const gid_t *, int *) {
+int sys_getgroups(size_t, gid_t *, int *) {
 	mlibc::infoLogger() << "mlibc: sys_getgroups() is unimplemented" << frg::endlog;
 	return ENOSYS;
 }

--- a/sysdeps/vinix/generic/generic.cpp
+++ b/sysdeps/vinix/generic/generic.cpp
@@ -839,7 +839,7 @@ again:
 	return 0;
 }
 
-int sys_getgroups(size_t size, const gid_t *list, int *_ret) {
+int sys_getgroups(size_t size, gid_t *list, int *_ret) {
 	__syscall_ret ret = __syscall(38, size, list);
 
 	if (ret.errno != 0)

--- a/tests/posix/grp.c
+++ b/tests/posix/grp.c
@@ -39,6 +39,12 @@ int main()
 	size_t bufsize;
 	int s;
 	bool password = false;
+	char *members[3];
+	char filename[] = "grpXXXXXX";
+	int tmpfd;
+	FILE *tmp;
+	char *expected = "managarm:passwordhash:12345:managarm,mlibc\n";
+	size_t readsize;
 
 	bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
 	assert(bufsize > 0 && bufsize < 0x100000);
@@ -106,7 +112,44 @@ int main()
 	free(grp.gr_name);
 	if(password)
 		free(grp.gr_passwd);
-	free(buf);
 
+	grp.gr_name = "managarm";
+	grp.gr_passwd = "passwordhash";
+	grp.gr_gid = 12345;
+	members[0] = "managarm";
+	members[1] = "mli:bc";
+	members[2] = NULL;
+	grp.gr_mem = members;
+
+	// tmpfile() cannot be used because its unimplemented in mlibc.
+	tmpfd = mkstemp(filename);
+	assert(tmpfd);
+	tmp = fdopen(tmpfd, "w+");
+	assert(tmp);
+
+	assert(putgrent(NULL, tmp) < 0);
+	assert(putgrent(&grp, tmp) < 0);
+
+	members[1] = "mlibc";
+
+	grp.gr_name = "mana:garm";
+	assert(putgrent(&grp, tmp) < 0);
+	grp.gr_name = "managarm";
+
+	grp.gr_passwd = "passwordhash\n";
+	assert(putgrent(&grp, tmp) < 0);
+	grp.gr_passwd = "passwordhash";
+
+	assert(putgrent(&grp, tmp) == 0);
+	rewind(tmp);
+
+	readsize = fread(buf, 1, bufsize, tmp);
+	assert(readsize == strlen(expected));
+	assert(strncmp(expected, buf, strlen(expected)) == 0);
+
+	fclose(tmp);
+	unlink(filename);
+
+	free(buf);
 	return 0;
 }


### PR DESCRIPTION
``sys_getgroup`` should take a ``gid_t *`` instead of a ``const gid_t *``, as it is expected to write there.
Implement ``putgrent``, needed by ``useradd`` to create the user group when creating a user.