### PR TITLE
fix: options/ansi make UINT_MAX unsigned

### DIFF
--- a/options/ansi/include/limits.h
+++ b/options/ansi/include/limits.h
@@ -73,7 +73,7 @@
 
 #define INT_MIN (-__INT_MAX__ - 1)
 #define INT_MAX __INT_MAX__
-#define UINT_MAX (__INT_MAX__ * 2 + 1)
+#define UINT_MAX (__INT_MAX__ * 2U + 1U)
 
 #define LONG_MIN (-__LONG_MAX__ - 1L)
 #define LONG_MAX __LONG_MAX__

--- a/options/ansi/include/limits.h
+++ b/options/ansi/include/limits.h
@@ -65,7 +65,7 @@
 
 #define SHRT_MIN (-__SHRT_MAX__ - 1)
 #define SHRT_MAX __SHRT_MAX__
-#if __SHRT_MAX_ == __INT_MAX__
+#if __SHRT_MAX__ == __INT_MAX__
 # define USHRT_MAX (__SHRT_MAX__ * 2U + 1U)
 #else
 # define USHRT_MAX (__SHRT_MAX__ * 2 + 1)


### PR DESCRIPTION
Compiling MPFR yielded the following messages:
```
/host/usr/include/limits.h:76:31: warning: integer overflow in expression of type 'int' results in '-2' [-Woverflow]
   76 | #define UINT_MAX (__INT_MAX__ * 2 + 1)
../../mpfr-src/src/invert_limb.h:136:7: note: in expansion of macro 'MPFR_STAT_STATIC_ASSERT'
  136 |       MPFR_STAT_STATIC_ASSERT (4182025 <= UINT_MAX);   
```

After some time looking through at possible fixes, I have discovered that UINT_MAX is evaluated to be a signed integer
rather than an unsigned one in ansi/include/limits.h, this can be fixed by adding 2 U's.