### PR TITLE
meson: hide all libc.so C++ symbols via a linker script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -507,12 +507,16 @@ if not headers_only
 			dependencies: rtld_deps + rtlib_deps,
 			install: true
 		)
+		hide_everything_ld = (meson.current_source_dir()
+				      / 'scripts/hide-everything.ld')
 		libc_shared = shared_library('c', libc_all_sources + internal_dso_sources,
 			cpp_args: [libc_cpp_args],
 			include_directories: libc_include_dirs,
 			dependencies: libc_deps + rtlib_deps,
 			link_with: [ld_shared_lib],
 			link_whole: libc_sublibs,
+			link_args: ['-Wl,--version-script,' + hide_everything_ld],
+			link_depends: [hide_everything_ld],
 			install: true
 		)
 	endif

--- a/scripts/hide-everything.ld
+++ b/scripts/hide-everything.ld
@@ -1,0 +1,4 @@
+{
+  /* Hide all C++ symbols.  */
+  local: _Z*;
+};


### PR DESCRIPTION
result: https://gist.github.com/ArsenArsen/570e87410c48f5b17f46d579269f10c2

btw, I noticed that we have a C++ function that probably should not be a C++ function:

```
0000000000068a58 T seed48(unsigned short*)
000000000008354a T login_tty(int)
000000000009f478 T wcstoimax(wchar_t const*, wchar_t**, int)
000000000009f4b7 T wcstoumax(wchar_t const*, wchar_t**, int)
```

this would imply we lack tests for those..

I recall some discussion about how to detect such cases before in the mlibc channel, but I do not recall the result.  if you can find it/remember it, please share