### PR TITLE
Fix functions that were mangled by accident

### DIFF
--- a/options/ansi/include/inttypes.h
+++ b/options/ansi/include/inttypes.h
@@ -2,6 +2,7 @@
 #define _STDINT_H
 
 #include <stdint.h>
+#include <bits/wchar_t.h>
 
 /* Even though this is not strictly not-ABI, it is mlibc-printf specific therefore */
 /* gate behind !__MLIBC_ABI_ONLY */
@@ -136,8 +137,8 @@ intmax_t imaxabs(intmax_t);
 imaxdiv_t imaxdiv(intmax_t, intmax_t);
 intmax_t strtoimax(const char *__restrict, char **__restrict, int);
 uintmax_t strtoumax(const char *__restrict, char **__restrict, int);
-intmax_t wcstoimax(const __WCHAR_TYPE__ *__restrict, __WCHAR_TYPE__ **__restrict, int);
-uintmax_t wcstoumax(const __WCHAR_TYPE__ *__restrict, __WCHAR_TYPE__ **__restrict, int);
+intmax_t wcstoimax(const wchar_t *__restrict, wchar_t **__restrict, int);
+uintmax_t wcstoumax(const wchar_t *__restrict, wchar_t **__restrict, int);
 
 #endif /* !__MLIBC_ABI_ONLY */
 

--- a/options/linux/generic/pty-stubs.cpp
+++ b/options/linux/generic/pty-stubs.cpp
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <pty.h>
+#include <utmp.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>

--- a/options/linux/include/utmp.h
+++ b/options/linux/include/utmp.h
@@ -74,6 +74,7 @@ struct utmp *pututline(const struct utmp *);
 struct utmp *getutline(const struct utmp *);
 struct utmp *getutid(const struct utmp *);
 int utmpname(const char *);
+int login_tty(int fd);
 
 #endif /* !__MLIBC_ABI_ONLY */
 

--- a/options/posix/include/bits/posix/posix_stdlib.h
+++ b/options/posix/include/bits/posix/posix_stdlib.h
@@ -14,6 +14,7 @@ extern "C" {
 long random(void);
 double drand48(void);
 double erand48(unsigned short s[3]);
+unsigned short *seed48(unsigned short s[3]);
 void srand48(long int);
 long jrand48(unsigned short s[3]);
 char *initstate(unsigned int, char *, size_t);


### PR DESCRIPTION
As discovered by #1119, some functions were erroneously mangled, which was caused by missing/broken prototypes in headers.