### PR TITLE
Compilation with clang for managarm

### DIFF
--- a/options/internal/gcc-extra/cxxabi.cpp
+++ b/options/internal/gcc-extra/cxxabi.cpp
@@ -9,12 +9,12 @@
 	extern "C" [[gnu::visibility("hidden")]] void _ZdlPv() { // operator delete (void *, size_t)
 		__ensure(!"operator delete called! delete expressions cannot be used in mlibc.");
 	}
-#else
-	extern "C" [[gnu::visibility("hidden")]] void _ZdlPvj() { // operator delete (void *, unsigned int)
-		__ensure(!"operator delete called! delete expressions cannot be used in mlibc.");
-	}
-
-	extern "C" [[gnu::visibility("hidden")]] void _ZdlPvm() { // operator delete (void *, size_t)
-		__ensure(!"operator delete called! delete expressions cannot be used in mlibc.");
-	}
 #endif
+
+extern "C" [[gnu::visibility("hidden")]] void _ZdlPvj() { // operator delete (void *, unsigned int)
+	__ensure(!"operator delete called! delete expressions cannot be used in mlibc.");
+}
+
+extern "C" [[gnu::visibility("hidden")]] void _ZdlPvm() { // operator delete (void *, size_t)
+	__ensure(!"operator delete called! delete expressions cannot be used in mlibc.");
+}

--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -302,6 +302,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 		case DT_RELR:
 		case DT_RELRSZ:
 		case DT_RELRENT:
+		case DT_PLTGOT:
 			continue;
 		default:
 			__ensure(!"Unexpected dynamic entry in program interpreter");

--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -305,7 +305,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 		case DT_PLTGOT:
 			continue;
 		default:
-			__ensure(!"Unexpected dynamic entry in program interpreter");
+			mlibc::panicLogger() << "rtld: unexpected dynamic entry " << ent->d_tag << " in program interpreter" << frg::endlog;
 		}
 	}
 	__ensure(strtab_offset);


### PR DESCRIPTION
These changes are needed to make mlibc compile for managarm, with clang. The result seems to work fine as a drop-in replacement for a gcc-compiled one.