### PR TITLE
options/internal: correct setjmp/longjmp on aarch64

### DIFF
--- a/options/internal/aarch64/setjmp.S
+++ b/options/internal/aarch64/setjmp.S
@@ -6,10 +6,9 @@
 __setjmp:
 	stp x19, x20, [x0, #0]
 	stp x21, x22, [x0, #16]
-	stp x23, x24, [x0, #24]
-	stp x25, x26, [x0, #32]
-	stp x27, x28, [x0, #48]
-	stp x29, x30, [x0, #64]
+	stp x23, x24, [x0, #32]
+	stp x25, x26, [x0, #48]
+	stp x27, x28, [x0, #64]
 	stp x29, x30, [x0, #80]
 	mov x4, sp
 	str x4, [x0, #96]
@@ -43,10 +42,9 @@ sigsetjmp:
 longjmp:
 	ldp x19, x20, [x0, #0]
 	ldp x21, x22, [x0, #16]
-	ldp x23, x24, [x0, #24]
-	ldp x25, x26, [x0, #32]
-	ldp x27, x28, [x0, #48]
-	ldp x29, x30, [x0, #64]
+	ldp x23, x24, [x0, #32]
+	ldp x25, x26, [x0, #48]
+	ldp x27, x28, [x0, #64]
 	ldp x29, x30, [x0, #80]
 	ldr x4, [x0, #96]
 	mov sp, x4


### PR DESCRIPTION
The __mlibc_jmpbuf_register_state struct is good,
but the saving/restoring it was not.
As such, no ABI break.