### PR TITLE
options/internal: add padding to Guard

### DIFF
--- a/options/internal/gcc/guard-abi.cpp
+++ b/options/internal/gcc/guard-abi.cpp
@@ -31,6 +31,8 @@ struct Guard {
 	// the first byte's meaning is fixed by the ABI.
 	// it indicates whether initialization has already been completed.
 	uint8_t complete;
+	// padding to ensure correct alignment on certain platforms.
+	uint8_t padding[3];
 
 	// we use some of the remaining bytes to implement a mutex.
 	uint32_t mutex;


### PR DESCRIPTION
Compilers targeting the Motorola 68k generally align on a 2-byte boundary, so the guard is laid out wrongly and becomes a 6-byte structure.