### PR TITLE
options/posix: fix realpath(3) absolute symlink handling

### DIFF
--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -360,9 +360,14 @@ char *realpath(const char *path, char *out) {
 
 			if (path[0] == '/') {
 				// Absolute path, replace resolv
-				resolv.resize(sz);
-				strncpy(resolv.data(), path, sz - 1);
-				resolv.data()[sz - 1] = 0;
+
+				// Ignore any trailing '/' so all results will not have one to keep consistency.
+				while(sz > 1 && path[sz - 1] == '/')
+					sz -= 1;
+
+				resolv.resize(sz + 1);
+				strncpy(resolv.data(), path, sz);
+				resolv.data()[sz] = 0;
 
 				if(debugPathResolution) {
 					mlibc::infoLogger() << "mlibc realpath(): Symlink is absolute, resolv: '"

--- a/tests/posix/realpath.c
+++ b/tests/posix/realpath.c
@@ -17,6 +17,8 @@ void prepare() {
 	assert(!mkdir(TEST_BASE "/dir1", S_IRWXU));
 	assert(!mkdir(TEST_BASE "/dir2", S_IRWXU));
 	assert(!symlink(TEST_BASE "/dir2/", TEST_BASE "/dir1/abs-link"));
+	assert(!symlink(TEST_BASE "/dir2///", TEST_BASE "/dir1/abs-link-trail"));
+	assert(!symlink(TEST_BASE "/dir2", TEST_BASE "/dir1/abs-link-no-trail"));
 	assert(!chdir(TEST_BASE "/dir1"));
 	assert(!symlink("../dir2/", TEST_BASE "/dir1/rel-link"));
 }
@@ -25,12 +27,16 @@ void cleanup(int do_assert) {
 	if (do_assert) {
 		assert(!unlink(TEST_BASE "/dir1/rel-link"));
 		assert(!unlink(TEST_BASE "/dir1/abs-link"));
+		assert(!unlink(TEST_BASE "/dir1/abs-link-trail"));
+		assert(!unlink(TEST_BASE "/dir1/abs-link-no-trail"));
 		assert(!rmdir(TEST_BASE "/dir2"));
 		assert(!rmdir(TEST_BASE "/dir1"));
 		assert(!rmdir(TEST_BASE "/"));
 	} else {
 		unlink(TEST_BASE "/dir1/rel-link");
 		unlink(TEST_BASE "/dir1/abs-link");
+		unlink(TEST_BASE "/dir1/abs-link-trail");
+		unlink(TEST_BASE "/dir1/abs-link-no-trail");
 		rmdir(TEST_BASE "/dir2");
 		rmdir(TEST_BASE "/dir1");
 		rmdir(TEST_BASE "/");
@@ -53,6 +59,13 @@ void signal_handler(int sig, siginfo_t *info, void *ctx) {
 	abort();
 }
 
+#define TEST_PATH(rpath, expected) \
+	path = realpath(rpath, NULL); \
+	assert(path); \
+	assert(!strcmp(path, expected)); \
+	free(path);
+
+
 int main() {
 	char *path;
 
@@ -64,70 +77,22 @@ int main() {
 
 	prepare();
 
-	path = realpath(TEST_BASE "/dir1/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir1"));
-	free(path);
+	TEST_PATH(TEST_BASE "/dir1/",                           TEST_BASE "/dir1");
+	TEST_PATH(TEST_BASE "/dir1/../dir2",                    TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/abs-link/",                  TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/rel-link/",                  TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/abs-link/../",               TEST_BASE "");
+	TEST_PATH(TEST_BASE "/dir1/rel-link/../",               TEST_BASE "");
+	TEST_PATH(TEST_BASE "/dir1/abs-link/../dir1/abs-link/", TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/rel-link/../dir1/rel-link/", TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/abs-link/../dir1/rel-link/", TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/rel-link/../dir1/abs-link/", TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/abs-link-no-trail/",         TEST_BASE "/dir2");
+	TEST_PATH(TEST_BASE "/dir1/abs-link-trail/",            TEST_BASE "/dir2");
 
-	path = realpath(TEST_BASE "/dir1/../dir2", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/abs-link/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/rel-link/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/abs-link/../", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE ""));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/rel-link/../", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE ""));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/abs-link/../dir1/abs-link/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/rel-link/../dir1/rel-link/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/abs-link/../dir1/rel-link/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath(TEST_BASE "/dir1/rel-link/../dir1/abs-link/", NULL);
-	assert(path);
-	assert(!strcmp(path, TEST_BASE "/dir2"));
-	free(path);
-
-	path = realpath("/tmp", NULL);
-	assert(path);
-	assert(!strcmp(path, "/tmp"));
-	free(path);
-
-	path = realpath("/", NULL);
-	assert(path);
-	assert(!strcmp(path, "/"));
-	free(path);
-
-	path = realpath("//", NULL);
-	assert(path);
-	assert(!strcmp(path, "/"));
-	free(path);
+	TEST_PATH("/tmp", "/tmp");
+	TEST_PATH("/",    "/");
+	TEST_PATH("//",   "/");
 
 	cleanup(1);
 


### PR DESCRIPTION
The old absolute symlink handling code unconditionally ignored one character from the end of the path returned by readlink, which broke realpath on any absolute links without a trailing slash. (discovered when a ``header.h`` path became ``header.`` while compiling GCC)
This new code will ignore all trailing slashes instead.