### PR TITLE
tests/pthread_attr: fix trampling of the stack

### DIFF
--- a/tests/posix/pthread_attr.c
+++ b/tests/posix/pthread_attr.c
@@ -21,7 +21,7 @@ static void *stacksize_worker(void *arg) {
 	size_t alloc_size = default_stacksize + default_stacksize/2;
 	void *area = alloca(alloc_size);
 	// If the allocated stack was not enough this will crash.
-	*(volatile int*)(area + alloc_size) = 1;
+	*(volatile int*)area = 1;
 	return NULL;
 }
 

--- a/tests/posix/pthread_attr.c
+++ b/tests/posix/pthread_attr.c
@@ -21,7 +21,10 @@ static void *stacksize_worker(void *arg) {
 	size_t alloc_size = default_stacksize + default_stacksize/2;
 	void *area = alloca(alloc_size);
 	// If the allocated stack was not enough this will crash.
-	*(volatile int*)area = 1;
+	// Trample both the start and end of the area so it works on both upwards-
+	// and downwards-growing stacks.
+	*(volatile char*)area = 1;
+	*(volatile char*)(area + alloc_size - 1) = 1;
 	return NULL;
 }
 


### PR DESCRIPTION
It was previously writing to what was likely the current stack pointer, but should have been writing to the start of the alloca()'d area.