### PR TITLE
options/internal: ensure FutexLockImpl alignment to 4 bytes

### DIFF
--- a/options/internal/include/mlibc/lock.hpp
+++ b/options/internal/include/mlibc/lock.hpp
@@ -8,8 +8,12 @@
 #include <mlibc/tid.hpp>
 #include <bits/ensure.h>
 
+// alignas(4) is specified for the benefit of m68k, where default alignment is
+// 2 bytes for a uint32_t, while the futex syscall requires 4-byte alignment.
+// It is a no-op on any other architecture.
+
 template<bool Recursive>
-struct FutexLockImpl {
+struct alignas(4) FutexLockImpl {
 	FutexLockImpl() : _state{0}, _recursion{0} { }
 
 	FutexLockImpl(const FutexLockImpl &) = delete;


### PR DESCRIPTION
On m68k the default alignment of 2 bytes for a uint32_t may result in futex calls failing under some conditions, as a futex must be 4-byte aligned.