### PR TITLE
Revert "options/rtld: Call fini functions on exit"

### DIFF
--- a/options/internal/gcc/initfini.cpp
+++ b/options/internal/gcc/initfini.cpp
@@ -10,8 +10,6 @@ typedef void (*InitPtr)();
 
 extern InitPtr __CTOR_LIST__ [[ gnu::visibility("hidden") ]] [];
 extern InitPtr __CTOR_END__ [[ gnu::visibility("hidden") ]] [];
-extern InitPtr __DTOR_LIST__ [[ gnu::visibility("hidden") ]] [];
-extern InitPtr __DTOR_END__ [[ gnu::visibility("hidden") ]] [];
 
 extern "C" [[ gnu::visibility("hidden") ]] void __mlibc_do_ctors() {
 	const size_t n = __CTOR_END__ - __CTOR_LIST__;
@@ -26,13 +24,6 @@ extern "C" [[ gnu::visibility("hidden") ]] void __mlibc_do_ctors() {
 }
 
 extern "C" [[ gnu::visibility("hidden") ]] void __mlibc_do_dtors() {
-	const size_t n = __DTOR_END__ - __DTOR_LIST__;
-	if(!n)
-		return;
-
-	size_t num = frg::min(n - 1, size_t(__DTOR_LIST__[0]));
-
-	for(size_t i = num; i >= 1; i--) {
-		__DTOR_LIST__[i]();
-	}
+	mlibc::sys_libc_log("__mlibc_do_dtors() called");
 }
+

--- a/options/lsb/generic/dso_exit.cpp
+++ b/options/lsb/generic/dso_exit.cpp
@@ -32,40 +32,11 @@ extern "C" int __cxa_atexit(void (*function)(void *), void *argument, void *hand
 	return 0;
 }
 
-extern "C" void __dlapi_exit();
-
-extern "C" void __cxa_finalize(void *dso) {
-	ExitQueue &eq = getExitQueue();
-	if(!dso) {
-		for(size_t i = eq.size(); i > 0; i--) {
-			auto handler = &eq[i - 1];
-			if(!handler->function)
-				continue;
-
-			handler->function(handler->argument);
-			handler->function = nullptr;
-		}
-	}else {
-		for(size_t i = eq.size(); i > 0; i--) {
-			auto handler = &eq[i - 1];
-			if(handler->dsoHandle != dso || !handler->function)
-				continue;
-
-			handler->function(handler->argument);
-			handler->function = nullptr;
-		}
-	}
-}
-
 void __mlibc_do_finalize() {
 	ExitQueue &eq = getExitQueue();
 	for(size_t i = eq.size(); i > 0; i--) {
 		auto handler = &eq[i - 1];
-		if(handler->dsoHandle || !handler->function)
-			continue;
 		handler->function(handler->argument);
-		handler->function = nullptr;
 	}
-
-	__dlapi_exit();
 }
+

--- a/options/rtld/generic/linker.cpp
+++ b/options/rtld/generic/linker.cpp
@@ -57,8 +57,6 @@ extern frg::manual_box<frg::vector<frg::string_view, MemoryAllocator>> preloads;
 #if MLIBC_STATIC_BUILD
 extern "C" size_t __init_array_start[];
 extern "C" size_t __init_array_end[];
-extern "C" size_t __fini_array_start[];
-extern "C" size_t __fini_array_end[];
 extern "C" size_t __preinit_array_start[];
 extern "C" size_t __preinit_array_end[];
 #endif
@@ -107,8 +105,7 @@ uintptr_t alignUp(uintptr_t address, size_t align) {
 
 ObjectRepository::ObjectRepository()
 : loadedObjects{getAllocator()},
-	_nameMap{frg::hash<frg::string_view>{}, getAllocator()},
-	_destructQueue{getAllocator()} {}
+	_nameMap{frg::hash<frg::string_view>{}, getAllocator()} {}
 
 SharedObject *ObjectRepository::injectObjectFromDts(frg::string_view name,
 		frg::string<MemoryAllocator> path, uintptr_t base_address,
@@ -157,9 +154,6 @@ SharedObject *ObjectRepository::injectStaticObject(frg::string_view name,
 	object->initArray = reinterpret_cast<InitFuncPtr*>(__init_array_start);
 	object->initArraySize = static_cast<size_t>((uintptr_t)__init_array_end -
 			(uintptr_t)__init_array_start);
-	object->finiArray = reinterpret_cast<InitFuncPtr*>(__fini_array_start);
-	object->finiArraySize = static_cast<size_t>((uintptr_t)__fini_array_end -
-			(uintptr_t)__fini_array_start);
 	object->preInitArray = reinterpret_cast<InitFuncPtr*>(__preinit_array_start);
 	object->preInitArraySize = static_cast<size_t>((uintptr_t)__preinit_array_end -
 			(uintptr_t)__preinit_array_start);
@@ -363,19 +357,6 @@ SharedObject *ObjectRepository::findLoadedObject(frg::string_view name) {
 
 	// TODO: We should also look at the device and inode here as a fallback.
 	return nullptr;
-}
-
-void ObjectRepository::addObjectToDestructQueue(SharedObject *object) {
-	_destructQueue.push_back(object);
-}
-
-void doDestruct(SharedObject *object);
-
-void ObjectRepository::destructObjects() {
-	for (size_t i = _destructQueue.size(); i > 0; i--) {
-		doDestruct(_destructQueue[i - 1]);
-	}
-	_destructQueue.clear();
 }
 
 // --------------------------------------------------------
@@ -721,23 +702,12 @@ void ObjectRepository::_parseDynamic(SharedObject *object) {
 			if(dynamic->d_un.d_ptr != 0)
 				object->initPtr = (InitFuncPtr)(object->baseAddress + dynamic->d_un.d_ptr);
 			break;
-		case DT_FINI:
-			if(dynamic->d_un.d_ptr != 0)
-				object->finiPtr = (InitFuncPtr)(object->baseAddress + dynamic->d_un.d_ptr);
-			break;
 		case DT_INIT_ARRAY:
 			if(dynamic->d_un.d_ptr != 0)
 				object->initArray = (InitFuncPtr *)(object->baseAddress + dynamic->d_un.d_ptr);
 			break;
-		case DT_FINI_ARRAY:
-			if(dynamic->d_un.d_ptr != 0)
-				object->finiArray = (InitFuncPtr *)(object->baseAddress + dynamic->d_un.d_ptr);
-			break;
 		case DT_INIT_ARRAYSZ:
 			object->initArraySize = dynamic->d_un.d_val;
-			break;
-		case DT_FINI_ARRAYSZ:
-			object->finiArraySize = dynamic->d_un.d_val;
 			break;
 		case DT_PREINIT_ARRAY:
 			if(dynamic->d_un.d_ptr != 0) {
@@ -763,6 +733,7 @@ void ObjectRepository::_parseDynamic(SharedObject *object) {
 			break;
 		// ignore unimportant tags
 		case DT_NEEDED: // we handle this later
+		case DT_FINI: case DT_FINI_ARRAY: case DT_FINI_ARRAYSZ:
 		case DT_RELA: case DT_RELASZ: case DT_RELAENT: case DT_RELACOUNT:
 		case DT_REL: case DT_RELSZ: case DT_RELENT: case DT_RELCOUNT:
 		case DT_RELR: case DT_RELRSZ: case DT_RELRENT:
@@ -956,22 +927,9 @@ void doInitialize(SharedObject *object) {
 	__ensure(object->wasLinked);
 	__ensure(!object->wasInitialized);
 
-	// If the object has dependencies we initialize them first
-	// except in the case of a circular dependency.
-	for(auto dep : object->dependencies) {
-		bool circular = false;
-		for(auto dep2 : dep->dependencies) {
-			if(dep2 == object) {
-				circular = true;
-				break;
-			}
-		}
-
-		if(circular)
-			continue;
-
-		__ensure(dep->wasInitialized);
-	}
+	// if the object has dependencies we initialize them first
+	for(size_t i = 0; i < object->dependencies.size(); i++)
+		__ensure(object->dependencies[i]->wasInitialized);
 
 	if(verbose)
 		mlibc::infoLogger() << "rtld: Initialize " << object->name << frg::endlog;
@@ -990,46 +948,6 @@ void doInitialize(SharedObject *object) {
 	if(verbose)
 		mlibc::infoLogger() << "rtld: Object initialization complete" << frg::endlog;
 	object->wasInitialized = true;
-}
-
-void doDestruct(SharedObject *object) {
-	if(!object->wasInitialized || object->wasDestroyed)
-		return;
-
-	// If the object has dependencies they are destroyed after this object
-	// except in the case of a circular dependency.
-	for(auto dep : object->dependencies) {
-		bool circular = false;
-		for(auto dep2 : dep->dependencies) {
-			if(dep2 == object) {
-				circular = true;
-				break;
-			}
-		}
-
-		if(circular)
-			continue;
-
-		__ensure(!dep->wasDestroyed);
-	}
-
-	if(verbose)
-		mlibc::infoLogger() << "rtld: Destruct " << object->name << frg::endlog;
-
-	if(verbose)
-		mlibc::infoLogger() << "rtld: Running DT_FINI_ARRAY functions" << frg::endlog;
-	__ensure((object->finiArraySize % sizeof(InitFuncPtr)) == 0);
-	for(size_t i = object->finiArraySize / sizeof(InitFuncPtr); i > 0; i--)
-		object->finiArray[i - 1]();
-
-	if(verbose)
-		mlibc::infoLogger() << "rtld: Running DT_FINI function" << frg::endlog;
-	if(object->finiPtr != nullptr)
-		object->finiPtr();
-
-	if(verbose)
-		mlibc::infoLogger() << "rtld: Object destruction complete" << frg::endlog;
-	object->wasDestroyed = true;
 }
 
 // --------------------------------------------------------
@@ -1585,7 +1503,7 @@ void Loader::_buildTlsMaps() {
 	}
 }
 
-void Loader::initObjects(ObjectRepository *repository) {
+void Loader::initObjects() {
 	initTlsObjects(mlibc::get_current_tcb(), _linkBfs, true);
 
 	if (_mainExecutable && _mainExecutable->preInitArray) {
@@ -1607,10 +1525,8 @@ void Loader::initObjects(ObjectRepository *repository) {
 	}
 
 	for(auto object : _initQueue) {
-		if(!object->wasInitialized) {
+		if(!object->wasInitialized)
 			doInitialize(object);
-			repository->addObjectToDestructQueue(object);
-		}
 	}
 }
 

--- a/options/rtld/generic/linker.hpp
+++ b/options/rtld/generic/linker.hpp
@@ -69,9 +69,6 @@ struct ObjectRepository {
 
 	SharedObject *findLoadedObject(frg::string_view name);
 
-	void addObjectToDestructQueue(SharedObject *object);
-	void destructObjects();
-
 	// Used by dl_iterate_phdr: stores objects in the order they are loaded.
 	frg::vector<SharedObject *, MemoryAllocator> loadedObjects;
 
@@ -89,9 +86,6 @@ private:
 
 	frg::hash_map<frg::string_view, SharedObject *,
 			frg::hash<frg::string_view>, MemoryAllocator> _nameMap;
-
-	// Used for destructing the objects, stores all the objects in the order they are initialized.
-	frg::vector<SharedObject *, MemoryAllocator> _destructQueue;
 };
 
 // --------------------------------------------------------
@@ -154,12 +148,9 @@ struct SharedObject {
 
 	// object initialization information
 	InitFuncPtr initPtr = nullptr;
-	InitFuncPtr finiPtr = nullptr;
 	InitFuncPtr *initArray = nullptr;
-	InitFuncPtr *finiArray = nullptr;
 	InitFuncPtr *preInitArray = nullptr;
 	size_t initArraySize = 0;
-	size_t finiArraySize = 0;
 	size_t preInitArraySize = 0;
 
 
@@ -198,8 +189,6 @@ struct SharedObject {
 	bool scheduledForInit;
 	bool onInitStack;
 	bool wasInitialized;
-
-	bool wasDestroyed = false;
 
 	// PHDR related stuff, we only set these for the main executable
 	void *phdrPointer = nullptr;
@@ -383,7 +372,7 @@ private:
 	void _processRelocations(Relocation &rel);
 
 public:
-	void initObjects(ObjectRepository *repository);
+	void initObjects();
 
 private:
 	void _scheduleInit(SharedObject *object);

--- a/tests/rtld/destroy/test.c
+++ b/tests/rtld/destroy/test.c
@@ -1,9 +1,0 @@
-#include <unistd.h>
-
-__attribute__((destructor)) void destroy() {
-	_exit(0);
-}
-
-int main() {
-	return 1;
-}

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -6,7 +6,6 @@ rtld_test_cases = [
 	'rtld_next',
 	'soname',
 	'preinit',
-	'destroy',
 	'scope1',
 	'scope2',
 	'scope3',


### PR DESCRIPTION
PR #1092 may have been prematurely merged as it causes issues with certain programs as reported by the Astral project. Revert it for now.