### PR TITLE
misc: Remove C99+ style comment from mlibc-config.h.in

### DIFF
--- a/mlibc-config.h.in
+++ b/mlibc-config.h.in
@@ -10,4 +10,4 @@
 #mesondefine __MLIBC_CRYPT_OPTION
 #mesondefine __MLIBC_SYSDEP_HAS_BITS_SYSCALL_H
 
-#endif // _MLIBC_CONFIG_H
+#endif /* _MLIBC_CONFIG_H */


### PR DESCRIPTION
This was not removed by 6dff15d7ca0aa40f15b66da7465e0cf4042a64d6 so do that now. Further addresses #1150