### PR TITLE
ci: don't run hooks on push

### DIFF
--- a/.github/workflows/abidiff.yml
+++ b/.github/workflows/abidiff.yml
@@ -1,15 +1,10 @@
 name: Check for ABI breaks
 
 on:
-  push:
-    branches-ignore:
-      - abi-break
   pull_request:
     branches-ignore:
       - abi-break
   merge_group:
-    branches-ignore:
-      - abi-break
 
 jobs:
   run-abidiff:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group]
 
 jobs:
     build-mlibc:

--- a/.github/workflows/detect-bad-ifs.yml
+++ b/.github/workflows/detect-bad-ifs.yml
@@ -1,6 +1,6 @@
 name: Detect ifdef/defined (mis)use
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group]
 
 jobs:
   find-misuse:

--- a/.github/workflows/detect-missing-mlibc-config.yml
+++ b/.github/workflows/detect-missing-mlibc-config.yml
@@ -1,6 +1,6 @@
 name: Detect missing mlibc-config.h
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group]
 
 jobs:
   find-misuse:

--- a/.github/workflows/rust-libc.yml
+++ b/.github/workflows/rust-libc.yml
@@ -1,6 +1,6 @@
 name: Rust libc bindings
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group]
 
 jobs:
     check-bindings:


### PR DESCRIPTION
Given we use a merge queue now, I don't see a reason to run checks on `push` anymore.
