### PR TITLE
options/internal: fix static asserts for pre-C++03

### DIFF
--- a/options/internal/include/bits/types.h
+++ b/options/internal/include/bits/types.h
@@ -324,11 +324,13 @@ typedef __SIZE_TYPE__    __mlibc_size;
 /* Sanity checking. Make sure that we agree with the compiler's ABI. */
 /* ---------------------------------------------------------------------------- */
 
-#if defined(__cpp_static_assert)
+#if defined(__cplusplus) && defined(__cpp_static_assert) && __cpp_static_assert >= 200410L
 #	define __MLIBC_STATIC_ASSERT(c, text) static_assert(c, text)
-#else
+#elif !defined(__cplusplus)
 /* _Static_assert is an extension in C89/C99. */
 #	define __MLIBC_STATIC_ASSERT(c, text) __extension__ _Static_assert(c, text)
+#else
+#	define __MLIBC_STATIC_ASSERT(c, text) extern int __static_assert_unavailable
 #endif
 
 #define __MLIBC_CHECK_TYPE(T1, T2) __MLIBC_STATIC_ASSERT(sizeof(T1) == sizeof(T2),\


### PR DESCRIPTION
This commit correctly checks whether the C++ standard is new enough, and if so, uses the standard-defined `static_assert`. In the case of C, gcc and clang implement `_Static_assert` as an extension irrespective of the chosen C standard. Otherwise, we fall back to not checking the condition. We need to do the `extern int` hack in order to not produce errors in pedantic mode, as a single semicolon or `(void)0` at file scope give warnings or errors then.

This was originally discovered when compiling libstdc++, which uses `-std=gnu++98` and was throwing errors.