### PR TITLE
options/ansi: inttypes.h: Add SCNdFAST64 macro

### DIFF
--- a/options/ansi/include/inttypes.h
+++ b/options/ansi/include/inttypes.h
@@ -117,6 +117,7 @@
 
 #define SCNd32 "d"
 #define SCNd64 __PRI64 "d"
+#define SCNdFAST64 __PRI64 "d"
 
 #define SCNu16 "hu"
 


### PR DESCRIPTION
This is needed for tzdata 2024b