### PR TITLE
rtld: Ignore DT_BIND_NOW for ld.so

### DIFF
--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -345,6 +345,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
 		case DT_RELRSZ:
 		case DT_RELRENT:
 		case DT_PLTGOT:
+		case DT_BIND_NOW:
 			continue;
 		case DT_FLAGS: {
 			if((ent->d_un.d_val & ~supportedDtFlags) == 0) {


### PR DESCRIPTION
ld.so can contain an `DT_BIND_NOW` entry if mlibc is compiled with `-Wl,-z,now`.