### PR TITLE
ci: check public headers conform to c++ ISO standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - name: Build mlibc
             run: 'xbstrap install ${{matrix.builds}}'
             working-directory: build/
-          - name: Check public headers conform to C89/C99/C11
+          - name: Check public headers conform to ISO standards with pedantic warnings
             if: ${{matrix.builds == 'mlibc-headers-only'}}
             working-directory: build/
             run: |
@@ -63,13 +63,20 @@ jobs:
                     GCC_ARCH="i686"
                     ;;
                 esac
-                ALL_HDRS="packages/${{matrix.builds}}/usr/include/**.h"
-                GCC_ARGS="$GCC_ARCH-linux-mlibc-gcc -x c -S /dev/null -o /dev/null -I packages/${{matrix.builds}}/usr/include -I packages/linux-headers/usr/include -nostdlib -Werror -Wpedantic -Wsystem-headers"
+                ALL_INCLUDES="-- -include\0%s\0 packages/${{matrix.builds}}/usr/include/**.h"
+                GCC_ARGS="-S /dev/null -o /dev/null -I packages/${{matrix.builds}}/usr/include -I packages/linux-headers/usr/include -nostdlib -Werror -Wpedantic -Wsystem-headers"
+                GCC_C_ARGS="$GCC_ARCH-linux-mlibc-gcc -x c $GCC_ARGS"
+                GCC_CXX_ARGS="$GCC_ARCH-linux-mlibc-g++ -x c++ $GCC_ARGS"
 
-                # For C89, exclude complex.h, and -Wlong-long
-                printf -- '-include\0%s\0' $ALL_HDRS | sed 's/complex.h/stdio.h/' | xargs -0 $GCC_ARGS -std=c89 -Wno-long-long
-                printf -- '-include\0%s\0' $ALL_HDRS | xargs -0 $GCC_ARGS -std=c99
-                printf -- '-include\0%s\0' $ALL_HDRS | xargs -0 $GCC_ARGS -std=c11
+                # For C89, exclude complex.h. We also exclude -Wlong-long because fixing it mostly involves adding
+                # __extension__ to a bunch of places (and musl doesn't even bother).
+                printf $ALL_INCLUDES | sed 's/complex.h/stdio.h/' | xargs -0 $GCC_C_ARGS -std=c89 -Wno-long-long
+                printf $ALL_INCLUDES | xargs -0 $GCC_C_ARGS -std=c99
+                printf $ALL_INCLUDES | xargs -0 $GCC_C_ARGS -std=c11
+                printf $ALL_INCLUDES | xargs -0 $GCC_CXX_ARGS -std=c++98 -Wno-long-long
+                printf $ALL_INCLUDES | xargs -0 $GCC_CXX_ARGS -std=c++11
+                printf $ALL_INCLUDES | xargs -0 $GCC_CXX_ARGS -std=c++14
+                printf $ALL_INCLUDES | xargs -0 $GCC_CXX_ARGS -std=c++17
           - name: Test mlibc
             run: 'meson test -v -C pkg-builds/${{matrix.builds}}'
             working-directory: build/

--- a/options/ansi/include/uchar.h
+++ b/options/ansi/include/uchar.h
@@ -8,10 +8,11 @@ extern "C" {
 #include <bits/mbstate.h>
 #include <bits/size_t.h>
 
-#ifndef __cplusplus
+/* These are builtin types since C++11. */
+#if !defined(__cplusplus) || __cplusplus < 201100L
 typedef __CHAR16_TYPE__ char16_t;
 typedef __CHAR32_TYPE__ char32_t;
-#endif /* __cplusplus */
+#endif
 
 #ifndef __MLIBC_ABI_ONLY
 

--- a/options/posix/include/fcntl.h
+++ b/options/posix/include/fcntl.h
@@ -53,7 +53,7 @@ int posix_fallocate(int __fd, off_t __offset, off_t __size);
 struct file_handle {
         unsigned int handle_bytes;
         int handle_type;
-        unsigned char f_handle[0];
+        __extension__ unsigned char f_handle[0];
 };
 #endif
 


### PR DESCRIPTION
Previously only C ISO versions were checked. Check C++ versions too.
