### PR TITLE
sysdeps/{linux,managarm}: Set RISC-V gp from .preinit_array

### DIFF
--- a/sysdeps/linux/riscv64/crt-src/Scrt1.S
+++ b/sysdeps/linux/riscv64/crt-src/Scrt1.S
@@ -1,18 +1,30 @@
+.weak __global_pointer$
+.hidden __global_pointer$
+
 .section .text
 .global _start
 _start:
-	.weak __global_pointer$
-	.hidden __global_pointer$
-	.option push
-	.option norelax
+	# Load gp.
+.option push
+.option norelax
 	lla gp, __global_pointer$
-	.option pop
+.option pop
 
 	mv a0, sp
 	la a1, main
 	call __mlibc_entry@plt
 	unimp
 
+# Load gp from .preinit_array since it may be used by the executable's .init_array.
+# We still load it in _start to account for static binaries. This matches glibc's behavior.
+load_gp:
+.option push
+.option norelax
+	lla gp, __global_pointer$
+.option pop
+	ret
+
+.section .preinit_array,"aw"
+	.dword load_gp
 
 .section .note.GNU-stack,"",%progbits
-

--- a/sysdeps/linux/riscv64/crt-src/crt1.S
+++ b/sysdeps/linux/riscv64/crt-src/crt1.S
@@ -1,15 +1,30 @@
+.weak __global_pointer$
+.hidden __global_pointer$
+
 .section .text
 .global _start
 _start:
-	.weak __global_pointer$
-	.hidden __global_pointer$
-	.option push
-	.option norelax
+	# Load gp.
+.option push
+.option norelax
 	lla gp, __global_pointer$
-	.option pop
+.option pop
 
 	mv a0, sp
 	la a1, main
 	call __mlibc_entry
-.section .note.GNU-stack,"",%progbits
+	unimp
 
+# Load gp from .preinit_array since it may be used by the executable's .init_array.
+# We still load it in _start to account for static binaries. This matches glibc's behavior.
+load_gp:
+.option push
+.option norelax
+	lla gp, __global_pointer$
+.option pop
+	ret
+
+.section .preinit_array,"aw"
+	.dword load_gp
+
+.section .note.GNU-stack,"",%progbits

--- a/sysdeps/managarm/riscv64/crt-src/Scrt1.S
+++ b/sysdeps/managarm/riscv64/crt-src/Scrt1.S
@@ -1,18 +1,30 @@
+.weak __global_pointer$
+.hidden __global_pointer$
+
 .section .text
 .global _start
 _start:
-	.weak __global_pointer$
-	.hidden __global_pointer$
-	.option push
-	.option norelax
+	# Load gp.
+.option push
+.option norelax
 	lla gp, __global_pointer$
-	.option pop
+.option pop
 
 	mv a0, sp
 	la a1, main
 	call __mlibc_entry@plt
 	unimp
 
+# Load gp from .preinit_array since it may be used by the executable's .init_array.
+# We still load it in _start to account for static binaries. This matches glibc's behavior.
+load_gp:
+.option push
+.option norelax
+	lla gp, __global_pointer$
+.option pop
+	ret
+
+.section .preinit_array,"aw"
+	.dword load_gp
 
 .section .note.GNU-stack,"",%progbits
-

--- a/sysdeps/managarm/riscv64/crt-src/crt0.S
+++ b/sysdeps/managarm/riscv64/crt-src/crt0.S
@@ -1,15 +1,30 @@
+.weak __global_pointer$
+.hidden __global_pointer$
+
 .section .text
 .global _start
 _start:
-	.weak __global_pointer$
-	.hidden __global_pointer$
-	.option push
-	.option norelax
+	# Load gp.
+.option push
+.option norelax
 	lla gp, __global_pointer$
-	.option pop
+.option pop
 
 	mv a0, sp
 	la a1, main
 	call __mlibc_entry
-.section .note.GNU-stack,"",%progbits
+	unimp
 
+# Load gp from .preinit_array since it may be used by the executable's .init_array.
+# We still load it in _start to account for static binaries. This matches glibc's behavior.
+load_gp:
+.option push
+.option norelax
+	lla gp, __global_pointer$
+.option pop
+	ret
+
+.section .preinit_array,"aw"
+	.dword load_gp
+
+.section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
This ensures that `gp` is properly set up even if it is used in `.init_array`.