### PR TITLE
ci: check more public headers for pedantic warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,16 @@ jobs:
           - name: Check public headers conform to ISO standards with pedantic warnings
             if: ${{matrix.builds == 'mlibc-headers-only'}}
             working-directory: build/
+            shell: bash
             run: |
+                shopt -s globstar
                 GCC_ARCH="${{matrix.arch}}"
                 case "$GCC_ARCH" in
                   "x86")
                     GCC_ARCH="i686"
                     ;;
                 esac
-                ALL_INCLUDES="-- -include\0%s\0 packages/${{matrix.builds}}/usr/include/**.h"
+                ALL_INCLUDES="-- -include\0%s\0 packages/${{matrix.builds}}/usr/include/**/*.h"
                 GCC_ARGS="-S /dev/null -o /dev/null -I packages/${{matrix.builds}}/usr/include -I packages/linux-headers/usr/include -nostdlib -Werror -Wpedantic -Wsystem-headers"
                 GCC_C_ARGS="$GCC_ARCH-linux-mlibc-gcc -x c $GCC_ARGS"
                 GCC_CXX_ARGS="$GCC_ARCH-linux-mlibc-g++ -x c++ $GCC_ARGS"

--- a/options/glibc/include/net/ethernet.h
+++ b/options/glibc/include/net/ethernet.h
@@ -10,7 +10,11 @@ extern "C" {
 #endif
 
 #if __MLIBC_LINUX_OPTION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #	include <linux/if_ether.h>
+#pragma GCC diagnostic pop
 #endif /* __MLIBC_LINUX_OPTION */
 
 #define ETHERTYPE_PUP 0x0200

--- a/options/glibc/include/sys/reg.h
+++ b/options/glibc/include/sys/reg.h
@@ -29,8 +29,8 @@
 #define ES 24
 #define FS 25
 #define GS 26
-#else
-#error "Add architecture specific code here"
+#elif !(defined(__i386__) || defined(__riscv) || defined(__aarch64__) || defined(__m68k__))
+#error "Missing architecture specific code."
 #endif
 
 #endif


### PR DESCRIPTION
The previous glob was not checking all headers. Fix this, and fix any new issues that have arisen.
