### PR TITLE
Symbol versioning support

### DIFF
--- a/options/elf/include/elf.h
+++ b/options/elf/include/elf.h
@@ -112,12 +112,28 @@ typedef struct {
 } Elf64_Verdaux;
 
 typedef struct {
+	Elf32_Half vn_version;
+	Elf32_Half vn_cnt;
+	Elf32_Word vn_file;
+	Elf32_Word vn_aux;
+	Elf32_Word vn_next;
+} Elf32_Verneed;
+
+typedef struct {
 	Elf64_Half vn_version;
 	Elf64_Half vn_cnt;
 	Elf64_Word vn_file;
 	Elf64_Word vn_aux;
 	Elf64_Word vn_next;
 } Elf64_Verneed;
+
+typedef struct {
+	Elf32_Word vna_hash;
+	Elf32_Half vna_flags;
+	Elf32_Half vna_other;
+	Elf32_Word vna_name;
+	Elf32_Word vna_next;
+} Elf32_Vernaux;
 
 typedef struct {
 	Elf64_Word vna_hash;

--- a/options/elf/include/elf.h
+++ b/options/elf/include/elf.h
@@ -686,6 +686,10 @@ typedef struct {
 #define AT_GID 13
 #define AT_EGID 14
 
+/* Values for Elfxx_Verdef::vd_flags and Elfxx_Vernaux::vna_flags */
+#define VER_FLG_BASE 1 /* Version definition of the file itself */
+#define VER_FLG_WEAK 2 /* Weak version identifier */
+
 /* rtld requires presence of some a_type (AT_*) values that are not standardized in the ELF spec */
 #if !defined(AT_EXECFN) || !defined(AT_RANDOM) || !defined(AT_SECURE)
 #error "sysdeps' auxv.h is missing some defines that are required for rtld operation"

--- a/options/internal/aarch64-include/mlibc/thread.hpp
+++ b/options/internal/aarch64-include/mlibc/thread.hpp
@@ -8,13 +8,13 @@ namespace mlibc {
 inline Tcb *get_current_tcb() {
 	// On AArch64, TPIDR_EL0 points to 0x10 bytes before the first TLS block.
 	uintptr_t ptr;
-	asm ("mrs %0, tpidr_el0" : "=r"(ptr));
+	asm volatile ("mrs %0, tpidr_el0" : "=r"(ptr));
 	return reinterpret_cast<Tcb *>(ptr + 0x10 - sizeof(Tcb));
 }
 
 inline uintptr_t get_sp() {
 	uintptr_t sp;
-	asm ("mov %0, sp" : "=r"(sp));
+	asm volatile ("mov %0, sp" : "=r"(sp));
 	return sp;
 }
 

--- a/options/internal/m68k-include/mlibc/thread.hpp
+++ b/options/internal/m68k-include/mlibc/thread.hpp
@@ -17,7 +17,7 @@ inline Tcb *get_current_tcb() {
 
 inline uintptr_t get_sp() {
 	uintptr_t sp;
-	asm ("move.l %%sp, %0" : "=r"(sp));
+	asm volatile ("move.l %%sp, %0" : "=r"(sp));
 	return sp;
 }
 

--- a/options/internal/riscv64-include/mlibc/thread.hpp
+++ b/options/internal/riscv64-include/mlibc/thread.hpp
@@ -16,7 +16,7 @@ inline Tcb *get_current_tcb() {
 
 inline uintptr_t get_sp() {
 	uintptr_t sp;
-	asm ("mv %0, sp" : "=r"(sp));
+	asm volatile ("mv %0, sp" : "=r"(sp));
 	return sp;
 }
 

--- a/options/internal/x86-include/mlibc/thread.hpp
+++ b/options/internal/x86-include/mlibc/thread.hpp
@@ -7,13 +7,13 @@ namespace mlibc {
 
 inline Tcb *get_current_tcb() {
 	uintptr_t ptr;
-	asm ("movl %%gs:0, %0" : "=r"(ptr));
+	asm volatile ("movl %%gs:0, %0" : "=r"(ptr));
 	return reinterpret_cast<Tcb *>(ptr);
 }
 
 inline uintptr_t get_sp() {
 	uintptr_t esp;
-	asm ("mov %%esp, %0" : "=r"(esp));
+	asm volatile ("mov %%esp, %0" : "=r"(esp));
 	return esp;
 }
 

--- a/options/internal/x86_64-include/mlibc/thread.hpp
+++ b/options/internal/x86_64-include/mlibc/thread.hpp
@@ -7,13 +7,13 @@ namespace mlibc {
 
 inline Tcb *get_current_tcb() {
 	uintptr_t ptr;
-	asm ("movq %%fs:0, %0" : "=r"(ptr));
+	asm volatile ("movq %%fs:0, %0" : "=r"(ptr));
 	return reinterpret_cast<Tcb *>(ptr);
 }
 
 inline uintptr_t get_sp() {
 	uintptr_t rsp;
-	asm ("mov %%rsp, %0" : "=r"(rsp));
+	asm volatile ("mov %%rsp, %0" : "=r"(rsp));
 	return rsp;
 }
 

--- a/options/posix/generic/dlfcn.cpp
+++ b/options/posix/generic/dlfcn.cpp
@@ -15,7 +15,7 @@ struct __dlapi_symbol {
 
 extern "C" const char *__dlapi_error();
 extern "C" void *__dlapi_open(const char *, int, void *);
-extern "C" void *__dlapi_resolve(void *, const char *, void *);
+extern "C" void *__dlapi_resolve(void *, const char *, void *, const char *);
 extern "C" int __dlapi_reverse(const void *, __dlapi_symbol *);
 extern "C" int __dlapi_close(void *);
 
@@ -36,14 +36,13 @@ void *dlopen(const char *file, int flags) {
 [[gnu::noinline]]
 void *dlsym(void *__restrict handle, const char *__restrict string) {
 	auto ra = __builtin_extract_return_addr(__builtin_return_address(0));
-	return __dlapi_resolve(handle, string, ra);
+	return __dlapi_resolve(handle, string, ra, NULL);
 }
 
 [[gnu::noinline]]
 void *dlvsym(void *__restrict handle, const char *__restrict string, const char *__restrict version) {
-	mlibc::infoLogger() << "mlibc: dlvsym ignores version " << version << frg::endlog;
 	auto ra = __builtin_extract_return_addr(__builtin_return_address(0));
-	return __dlapi_resolve(handle, string, ra);
+	return __dlapi_resolve(handle, string, ra, version);
 }
 
 //gnu extensions

--- a/options/rtld/aarch64/elf.hpp
+++ b/options/rtld/aarch64/elf.hpp
@@ -17,6 +17,12 @@ using elf_addr = Elf64_Addr;
 using elf_info = Elf64_Xword;
 using elf_addend = Elf64_Sxword;
 
+using elf_version = Elf64_Half;
+using elf_verdef = Elf64_Verdef;
+using elf_verdaux = Elf64_Verdaux;
+using elf_verneed = Elf64_Verneed;
+using elf_vernaux = Elf64_Vernaux;
+
 #define ELF_R_SYM ELF64_R_SYM
 #define ELF_R_TYPE ELF64_R_TYPE
 #define ELF_ST_BIND ELF64_ST_BIND

--- a/options/rtld/generic/linker.hpp
+++ b/options/rtld/generic/linker.hpp
@@ -14,6 +14,8 @@ struct ObjectRepository;
 struct Scope;
 struct Loader;
 struct SharedObject;
+struct ObjectSymbol;
+struct SymbolVersion;
 
 extern uint64_t rtsCounter;
 
@@ -32,6 +34,8 @@ enum class LinkerError {
 	outOfMemory,
 	invalidProgramHeader
 };
+
+uint32_t elf64Hash(frg::string_view string);
 
 // --------------------------------------------------------
 // ObjectRepository
@@ -83,6 +87,9 @@ private:
 	frg::expected<LinkerError, void> _fetchFromFile(SharedObject *object, int fd);
 
 	void _parseDynamic(SharedObject *object);
+
+	void _parseVerdef(SharedObject *object);
+	void _parseVerneed(SharedObject *object);
 
 	void _discoverDependencies(SharedObject *object, Scope *localScope, uint64_t rts);
 
@@ -174,6 +181,23 @@ struct SharedObject {
 	uintptr_t hashTableOffset;
 	uintptr_t symbolTableOffset;
 	uintptr_t stringTableOffset;
+
+	// Version tables of this shared object
+	uintptr_t versionTableOffset = 0;
+	uintptr_t versionDefinitionTableOffset = 0;
+	size_t versionDefinitionCount = 0;
+	uintptr_t versionRequirementTableOffset = 0;
+	size_t versionRequirementCount = 0;
+
+	// Versions we know about for this object's VERSYM.
+	frg::hash_map<
+		elf_version,
+		SymbolVersion,
+		frg::hash<unsigned int>,
+		MemoryAllocator
+	> knownVersions;
+	// Versions that this object defines.
+	frg::vector<SymbolVersion, MemoryAllocator> definedVersions;
 
 	const char *runPath = nullptr;
 
@@ -332,6 +356,68 @@ private:
 };
 
 frg::optional<ObjectSymbol> resolveInObject(SharedObject *object, frg::string_view string);
+
+// --------------------------------------------------------
+// SymbolVersion
+// --------------------------------------------------------
+
+struct SymbolVersion {
+	SymbolVersion(const char *name, uint32_t hash)
+	: _local{false}, _global{false}, _default{false}
+	, _name{name}, _hash{hash} { }
+
+	SymbolVersion(int idx)
+	: _local{idx == 0}, _global{idx == 1}, _default{false}
+	, _name{""}, _hash{0} { }
+
+	SymbolVersion(const char *name)
+	: _local{false}, _global{false}, _default{false}
+	, _name{name}, _hash{elf64Hash(name)} { }
+
+	bool isLocal() const {
+		return _local;
+	}
+
+	bool isGlobal() const {
+		return _global;
+	}
+
+	bool isDefault() const {
+		return _default;
+	}
+
+	frg::string_view name() const {
+		if(_local) return "(*local*)";
+		if(_global) return "(*global*)";
+		return _name;
+	}
+
+	uint32_t hash() const {
+		return _hash;
+	}
+
+	bool operator==(const SymbolVersion &other) const {
+		if(_local || other._local) return _local && other._local;
+		if(_global || other._global) return _global && other._global;
+		if(_hash != other._hash) return false;
+		return _name == other._name;
+	}
+
+	SymbolVersion makeDefault() const {
+		auto copy = *this;
+		copy._default = true;
+
+		return copy;
+	}
+
+private:
+	bool _local, _global;
+	bool _default;
+
+	frg::string_view _name;
+	uint32_t _hash;
+};
+
 
 // --------------------------------------------------------
 // Scope

--- a/options/rtld/generic/linker.hpp
+++ b/options/rtld/generic/linker.hpp
@@ -230,6 +230,8 @@ struct SharedObject {
 	void *phdrPointer = nullptr;
 	size_t phdrEntrySize = 0;
 	size_t phdrCount = 0;
+
+	frg::tuple<ObjectSymbol, SymbolVersion> getSymbolByIndex(size_t index);
 };
 
 struct Relocation {
@@ -355,7 +357,8 @@ private:
 	const elf_sym *_symbol;
 };
 
-frg::optional<ObjectSymbol> resolveInObject(SharedObject *object, frg::string_view string);
+frg::optional<ObjectSymbol> resolveInObject(SharedObject *object, frg::string_view string,
+		frg::optional<SymbolVersion> version);
 
 // --------------------------------------------------------
 // SymbolVersion
@@ -429,20 +432,24 @@ struct Scope {
 	static inline constexpr ResolveFlags skipGlobalAfterRts = 1 << 1;
 
 	static frg::optional<ObjectSymbol> resolveGlobalOrLocal(Scope &globalScope,
-			Scope *localScope, frg::string_view string, uint64_t skipRts, ResolveFlags flags);
+			Scope *localScope, frg::string_view string, uint64_t skipRts, ResolveFlags flags,
+			frg::optional<SymbolVersion> version);
 	static frg::optional<ObjectSymbol> resolveGlobalOrLocalNext(Scope &globalScope,
-			Scope *localScope, frg::string_view string, SharedObject *origin);
+			Scope *localScope, frg::string_view string, SharedObject *origin,
+			frg::optional<SymbolVersion> version);
 
 	Scope(bool isGlobal = false);
 
 	void appendObject(SharedObject *object);
 
-	frg::optional<ObjectSymbol> resolveSymbol(frg::string_view string, uint64_t skipRts, ResolveFlags flags);
+	frg::optional<ObjectSymbol> resolveSymbol(frg::string_view string, uint64_t skipRts, ResolveFlags flags,
+			frg::optional<SymbolVersion> version);
 
 	bool isGlobal;
 
 private:
-	frg::optional<ObjectSymbol> _resolveNext(frg::string_view string, SharedObject *target);
+	frg::optional<ObjectSymbol> _resolveNext(frg::string_view string, SharedObject *target,
+			frg::optional<SymbolVersion> version);
 public: // TODO: Make this private again. (Was made public for __dlapi_reverse()).
 	frg::vector<SharedObject *, MemoryAllocator> _objects;
 };

--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -666,7 +666,7 @@ void *__dlapi_open(const char *file, int flags, void *returnAddress) {
 }
 
 extern "C" [[ gnu::visibility("default") ]]
-void *__dlapi_resolve(void *handle, const char *string, void *returnAddress) {
+void *__dlapi_resolve(void *handle, const char *string, void *returnAddress, const char *version) {
 	if (logDlCalls) {
 		const char *name;
 		bool quote = false;
@@ -685,6 +685,9 @@ void *__dlapi_resolve(void *handle, const char *string, void *returnAddress) {
 
 	frg::optional<ObjectSymbol> target;
 	frg::optional<SymbolVersion> targetVersion = frg::null_opt;
+
+	if(version)
+		targetVersion = SymbolVersion{version};
 
 	if (handle == RTLD_DEFAULT) {
 		target = globalScope->resolveSymbol(string, 0, 0, targetVersion);

--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -207,10 +207,8 @@ extern "C" void *lazyRelocate(SharedObject *object, unsigned int rel_index) {
 	__ensure(type == R_X86_64_JUMP_SLOT);
 	__ensure(ELF_CLASS == ELFCLASS64);
 
-	auto symbol = (elf_sym *)(object->baseAddress + object->symbolTableOffset
-			+ symbol_index * sizeof(elf_sym));
-	ObjectSymbol r(object, symbol);
-	auto p = Scope::resolveGlobalOrLocal(*globalScope, object->localScope, r.getString(), object->objectRts, 0);
+	auto [sym, ver] = object->getSymbolByIndex(symbol_index);
+	auto p = Scope::resolveGlobalOrLocal(*globalScope, object->localScope, sym.getString(), object->objectRts, 0, ver);
 	if(!p)
 		mlibc::panicLogger() << "Unresolved JUMP_SLOT symbol" << frg::endlog;
 
@@ -686,9 +684,10 @@ void *__dlapi_resolve(void *handle, const char *string, void *returnAddress) {
 	}
 
 	frg::optional<ObjectSymbol> target;
+	frg::optional<SymbolVersion> targetVersion = frg::null_opt;
 
 	if (handle == RTLD_DEFAULT) {
-		target = globalScope->resolveSymbol(string, 0, 0);
+		target = globalScope->resolveSymbol(string, 0, 0, targetVersion);
 	} else if (handle == RTLD_NEXT) {
 		SharedObject *origin = initialRepository->findCaller(returnAddress);
 		if (!origin) {
@@ -696,7 +695,7 @@ void *__dlapi_resolve(void *handle, const char *string, void *returnAddress) {
 				<< "(ra = " << returnAddress << ")" << frg::endlog;
 		}
 
-		target = Scope::resolveGlobalOrLocalNext(*globalScope, origin->localScope, string, origin);
+		target = Scope::resolveGlobalOrLocalNext(*globalScope, origin->localScope, string, origin, targetVersion);
 	} else {
 		// POSIX does not unambiguously state how dlsym() is supposed to work; it just
 		// states that "The symbol resolution algorithm used shall be dependency order
@@ -726,7 +725,7 @@ void *__dlapi_resolve(void *handle, const char *string, void *returnAddress) {
 		for(size_t i = 0; i < queue.size(); i++) {
 			auto current = queue[i];
 
-			target = resolveInObject(current, string);
+			target = resolveInObject(current, string, targetVersion);
 			if(target)
 				break;
 

--- a/options/rtld/m68k/elf.hpp
+++ b/options/rtld/m68k/elf.hpp
@@ -17,6 +17,12 @@ using elf_addr = Elf32_Addr;
 using elf_info = Elf32_Word;
 using elf_addend = Elf32_Sword;
 
+using elf_version = Elf32_Half;
+using elf_verdef = Elf32_Verdef;
+using elf_verdaux = Elf32_Verdaux;
+using elf_verneed = Elf32_Verneed;
+using elf_vernaux = Elf32_Vernaux;
+
 #define ELF_R_SYM ELF32_R_SYM
 #define ELF_R_TYPE ELF32_R_TYPE
 #define ELF_ST_BIND ELF32_ST_BIND

--- a/options/rtld/riscv64/elf.hpp
+++ b/options/rtld/riscv64/elf.hpp
@@ -17,6 +17,12 @@ using elf_addr = Elf64_Addr;
 using elf_info = Elf64_Xword;
 using elf_addend = Elf64_Sxword;
 
+using elf_version = Elf64_Half;
+using elf_verdef = Elf64_Verdef;
+using elf_verdaux = Elf64_Verdaux;
+using elf_verneed = Elf64_Verneed;
+using elf_vernaux = Elf64_Vernaux;
+
 #define ELF_R_SYM ELF64_R_SYM
 #define ELF_R_TYPE ELF64_R_TYPE
 #define ELF_ST_BIND ELF64_ST_BIND

--- a/options/rtld/x86/elf.hpp
+++ b/options/rtld/x86/elf.hpp
@@ -17,6 +17,12 @@ using elf_addr = Elf32_Addr;
 using elf_info = Elf32_Word;
 using elf_addend = Elf32_Sword;
 
+using elf_version = Elf32_Half;
+using elf_verdef = Elf32_Verdef;
+using elf_verdaux = Elf32_Verdaux;
+using elf_verneed = Elf32_Verneed;
+using elf_vernaux = Elf32_Vernaux;
+
 #define ELF_R_SYM ELF32_R_SYM
 #define ELF_R_TYPE ELF32_R_TYPE
 #define ELF_ST_BIND ELF32_ST_BIND

--- a/options/rtld/x86_64/elf.hpp
+++ b/options/rtld/x86_64/elf.hpp
@@ -17,6 +17,12 @@ using elf_addr = Elf64_Addr;
 using elf_info = Elf64_Xword;
 using elf_addend = Elf64_Sxword;
 
+using elf_version = Elf64_Half;
+using elf_verdef = Elf64_Verdef;
+using elf_verdaux = Elf64_Verdaux;
+using elf_verneed = Elf64_Verneed;
+using elf_vernaux = Elf64_Vernaux;
+
 #define ELF_R_SYM ELF64_R_SYM
 #define ELF_R_TYPE ELF64_R_TYPE
 #define ELF_ST_BIND ELF64_ST_BIND

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -147,10 +147,10 @@ extra_cflags_test_cases = {
 
 test_sources = []
 test_link_args = []
-test_c_args = ['-D_GNU_SOURCE']
+test_c_args = ['-D_GNU_SOURCE', '-fno-builtin']
 use_pie = false
 
-host_test_c_args = []
+host_test_c_args = ['-fno-builtin']
 
 c_compiler = meson.get_compiler('c')
 

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -15,6 +15,7 @@ rtld_test_cases = [
 	'scope5',
 	'tls_align',
 	'relr',
+	'symver',
 ]
 
 host_libc_rtld_nosan_test_cases = [

--- a/tests/rtld/symver/libfoo.c
+++ b/tests/rtld/symver/libfoo.c
@@ -1,0 +1,15 @@
+int foo_v1(void) {
+	return 1;
+}
+
+int foo_v2(void) {
+	return 2;
+}
+
+int foo_v3(void) {
+	return 3;
+}
+
+asm(".symver foo_v1, foo@FOO_1");
+asm(".symver foo_v2, foo@FOO_2");
+asm(".symver foo_v3, foo@@FOO_3"); // default version (due to @@ vs @)

--- a/tests/rtld/symver/libfoo.ver
+++ b/tests/rtld/symver/libfoo.ver
@@ -1,0 +1,14 @@
+FOO_1 {
+	global: foo;
+	local: *;
+};
+
+FOO_2 {
+	global: foo;
+	local: *;
+};
+
+FOO_3 {
+	global: foo;
+	local: *;
+};

--- a/tests/rtld/symver/meson.build
+++ b/tests/rtld/symver/meson.build
@@ -1,0 +1,11 @@
+version_script = meson.current_source_dir() / 'libfoo.ver'
+
+libfoo = shared_library('foo', 'libfoo.c',
+		link_args : ['-Wl,--version-script', version_script])
+test_depends = [libfoo]
+test_link_with = [libfoo]
+
+libfoo_native = shared_library('native-foo', 'libfoo.c', native: true,
+		link_args : ['-Wl,--version-script', version_script])
+test_native_depends = [libfoo_native]
+test_native_link_with = [libfoo_native]

--- a/tests/rtld/symver/test.c
+++ b/tests/rtld/symver/test.c
@@ -1,0 +1,39 @@
+#include <assert.h>
+#include <stdio.h>
+#include <dlfcn.h>
+
+#ifdef USE_HOST_LIBC
+#define LIBFOO "libnative-foo.so"
+#else
+#define LIBFOO "libfoo.so"
+#endif
+
+int foo(void);
+
+int main() {
+	int ver = foo();
+	fprintf(stderr, "called foo version %d\n", ver);
+	assert(ver == 3); // version 3 is the default for libfoo.so
+
+	void *libfoo_h = dlopen(LIBFOO, RTLD_GLOBAL | RTLD_NOW);
+	assert(libfoo_h);
+
+	int (*foo1)(void) = dlvsym(libfoo_h, "foo", "FOO_1");
+	assert(foo1);
+
+	int (*foo2)(void) = dlvsym(libfoo_h, "foo", "FOO_2");
+	assert(foo2);
+
+	int (*foo3)(void) = dlvsym(libfoo_h, "foo", "FOO_3");
+	assert(foo3);
+
+	int (*foo_def)(void) = dlsym(libfoo_h, "foo");
+	assert(foo_def);
+
+	assert(foo1() == 1);
+	assert(foo2() == 2);
+	assert(foo3() == 3);
+	assert(foo3 == foo_def);
+
+	return 0;
+}


### PR DESCRIPTION
There's some minor TODOs left in the code (handling weak versions and figuring out what to do about VERDEF dependency names), but this is sufficient to fix #1208, and the TODOs aren't a problem when booting Managarm (which has plenty of libraries with versioned symbols).

Closes #1208.