### PR TITLE
sysdeps: simplify entry point

### DIFF
--- a/options/ansi/generic/locale.cpp
+++ b/options/ansi/generic/locale.cpp
@@ -71,7 +71,8 @@ namespace mlibc {
 	const locale_description *messages_facet;
 }
 
-void __mlibc_initLocale() {
+[[gnu::constructor]]
+static void init_locale() {
 	mlibc::collate_facet = &mlibc::c_locale;
 	mlibc::ctype_facet = &mlibc::c_locale;
 	mlibc::monetary_facet = &mlibc::c_locale;

--- a/options/elf/include/mlibc/elf/startup.h
+++ b/options/elf/include/mlibc/elf/startup.h
@@ -1,12 +1,6 @@
 #ifndef MLIBC_ELF_STARTUP
 #define MLIBC_ELF_STARTUP
 
-#ifndef __MLIBC_ABI_ONLY
-
-void __mlibc_run_constructors();
-
-#endif /* !__MLIBC_ABI_ONLY */
-
 namespace mlibc {
 
 struct exec_stack_data {
@@ -14,6 +8,8 @@ struct exec_stack_data {
 	char **argv;
 	char **envp;
 };
+
+extern exec_stack_data entry_stack;
 
 #ifndef __MLIBC_ABI_ONLY
 

--- a/sysdeps/aero/generic/entry.cpp
+++ b/sysdeps/aero/generic/entry.cpp
@@ -3,9 +3,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 
 extern char **environ;
@@ -18,8 +15,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-    __mlibc_initLocale();
-
     // Parse the exec() stack.
     mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
     mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/aero/generic/entry.cpp
+++ b/sysdeps/aero/generic/entry.cpp
@@ -6,26 +6,12 @@
 extern "C" uintptr_t *__dlapi_entrystack();
 
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-    LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-    // Parse the exec() stack.
-    mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-    mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-                            __mlibc_stack_data.envp);
-}
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[],
                                              char *env[])) {
     // TODO: call __dlapi_enter, otherwise static builds will break (see Linux
     // sysdeps)
     auto result =
-        main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+        main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
     exit(result);
 }

--- a/sysdeps/astral/generic/entry.cpp
+++ b/sysdeps/astral/generic/entry.cpp
@@ -3,28 +3,13 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[]), uintptr_t *entry_stack) {
 	__dlapi_enter(entry_stack);
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }
 

--- a/sysdeps/astral/generic/entry.cpp
+++ b/sysdeps/astral/generic/entry.cpp
@@ -3,9 +3,6 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
@@ -19,8 +16,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/dripos/generic/entry.cpp
+++ b/sysdeps/dripos/generic/entry.cpp
@@ -4,9 +4,6 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 
 extern char **environ;
@@ -19,8 +16,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/dripos/generic/entry.cpp
+++ b/sysdeps/dripos/generic/entry.cpp
@@ -4,27 +4,11 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
-
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
 	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }
 

--- a/sysdeps/ironclad/generic/entry.cpp
+++ b/sysdeps/ironclad/generic/entry.cpp
@@ -4,29 +4,14 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 extern "C" void __mlibc_entry(uintptr_t *entry_stack, int (*main_fn)(int argc, char *argv[], char *env[])) {
 	__dlapi_enter(entry_stack);
 
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }
 

--- a/sysdeps/ironclad/generic/entry.cpp
+++ b/sysdeps/ironclad/generic/entry.cpp
@@ -4,9 +4,6 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
@@ -20,8 +17,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/keyronex/generic/entry.cpp
+++ b/sysdeps/keyronex/generic/entry.cpp
@@ -7,9 +7,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 
 extern char **environ;
@@ -23,8 +20,6 @@ static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard()
 {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc,

--- a/sysdeps/keyronex/generic/entry.cpp
+++ b/sysdeps/keyronex/generic/entry.cpp
@@ -7,24 +7,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
-
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard()
-{
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc,
-	    __mlibc_stack_data.argv, __mlibc_stack_data.envp);
-}
 
 namespace mlibc {
 int
@@ -97,7 +80,7 @@ __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[]))
 
 	// TODO: call __dlapi_enter, otherwise static builds will break (see
 	// Linux sysdeps)
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv,
 	    environ);
 	exit(result);
 }

--- a/sysdeps/lemon/generic/entry.cpp
+++ b/sysdeps/lemon/generic/entry.cpp
@@ -3,9 +3,6 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 
 extern char **environ;
@@ -18,8 +15,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/lemon/generic/entry.cpp
+++ b/sysdeps/lemon/generic/entry.cpp
@@ -3,26 +3,10 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
-
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 extern "C" void __mlibc_entry(int (*main_fn)(int argc, char *argv[], char *env[])) {
 	// TODO: call __dlapi_enter, otherwise static builds will break (see Linux sysdeps)
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }

--- a/sysdeps/linux/generic/entry.cpp
+++ b/sysdeps/linux/generic/entry.cpp
@@ -4,9 +4,6 @@
 #include <mlibc/elf/startup.h>
 #include <sys/auxv.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
@@ -22,8 +19,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/linux/generic/entry.cpp
+++ b/sysdeps/linux/generic/entry.cpp
@@ -4,30 +4,15 @@
 #include <mlibc/elf/startup.h>
 #include <sys/auxv.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
 
 size_t __hwcap;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 extern "C" void __mlibc_entry(uintptr_t *entry_stack, int (*main_fn)(int argc, char *argv[], char *env[])) {
 	__dlapi_enter(entry_stack);
 	__hwcap = getauxval(AT_HWCAP);
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }

--- a/sysdeps/lyre/generic/entry.cpp
+++ b/sysdeps/lyre/generic/entry.cpp
@@ -7,24 +7,9 @@
 #include <bits/posix/posix_signal.h>
 #include <lyre/syscall.h>
 
-extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 struct GPRState {
 	uint64_t ds;
@@ -111,7 +96,7 @@ extern "C" void __mlibc_entry(uintptr_t *entry_stack, int (*main_fn)(int argc, c
 
 	//mlibc::sys_sigentry((void *)__mlibc_sigentry);
 
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }
 

--- a/sysdeps/lyre/generic/entry.cpp
+++ b/sysdeps/lyre/generic/entry.cpp
@@ -7,9 +7,6 @@
 #include <bits/posix/posix_signal.h>
 #include <lyre/syscall.h>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
@@ -23,8 +20,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,

--- a/sysdeps/managarm/generic/entry.cpp
+++ b/sysdeps/managarm/generic/entry.cpp
@@ -104,26 +104,11 @@ HelHandle getHandleForFd(int fd) {
 
 void clearCachedInfos() { has_cached_infos = PTHREAD_ONCE_INIT; }
 
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(
-	    __mlibc_stack_data.argc, __mlibc_stack_data.argv, __mlibc_stack_data.envp
-	);
-}
 
 extern "C" void
 __mlibc_entry(uintptr_t *entry_stack, int (*main_fn)(int argc, char *argv[], char *env[])) {
 	__dlapi_enter(entry_stack);
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }

--- a/sysdeps/managarm/generic/entry.cpp
+++ b/sysdeps/managarm/generic/entry.cpp
@@ -14,9 +14,6 @@
 #include <protocols/posix/data.hpp>
 #include <protocols/posix/supercalls.hpp>
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
@@ -117,8 +114,6 @@ extern char **environ;
 static mlibc::exec_stack_data __mlibc_stack_data;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(

--- a/sysdeps/vinix/generic/entry.cpp
+++ b/sysdeps/vinix/generic/entry.cpp
@@ -8,24 +8,9 @@
 
 #include "syscall.h"
 
-extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
 extern char **environ;
-static mlibc::exec_stack_data __mlibc_stack_data;
-
-struct LibraryGuard {
-	LibraryGuard();
-};
-
-static LibraryGuard guard;
-
-LibraryGuard::LibraryGuard() {
-	// Parse the exec() stack.
-	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
-	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,
-			__mlibc_stack_data.envp);
-}
 
 struct GPRState {
 	uint64_t ds;
@@ -110,6 +95,6 @@ extern "C" void __mlibc_entry(uintptr_t *entry_stack, int (*main_fn)(int argc, c
 	mlibc::sys_sigentry((void *)__mlibc_sigentry);
 
 	__dlapi_enter(entry_stack);
-	auto result = main_fn(__mlibc_stack_data.argc, __mlibc_stack_data.argv, environ);
+	auto result = main_fn(mlibc::entry_stack.argc, mlibc::entry_stack.argv, environ);
 	exit(result);
 }

--- a/sysdeps/vinix/generic/entry.cpp
+++ b/sysdeps/vinix/generic/entry.cpp
@@ -8,9 +8,6 @@
 
 #include "syscall.h"
 
-// defined by the POSIX library
-void __mlibc_initLocale();
-
 extern "C" uintptr_t *__dlapi_entrystack();
 extern "C" void __dlapi_enter(uintptr_t *);
 
@@ -24,8 +21,6 @@ struct LibraryGuard {
 static LibraryGuard guard;
 
 LibraryGuard::LibraryGuard() {
-	__mlibc_initLocale();
-
 	// Parse the exec() stack.
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &__mlibc_stack_data);
 	mlibc::set_startup_data(__mlibc_stack_data.argc, __mlibc_stack_data.argv,


### PR DESCRIPTION
Move some initialisation tasks to gnu::constructor functions defined inside mlibc.