### PR TITLE
build: Disable frigg's build_tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,10 @@ if not headers_only
 
 	frigg_dep = dependency(
 		'frigg',
-		default_options: ['frigg_no_install=true'],
+		default_options: [
+                  'frigg_no_install=true',
+                  'build_tests=disabled'
+                ],
 		fallback: ['frigg', 'frigg_dep'],
 	)
 	libc_deps += frigg_dep


### PR DESCRIPTION
Building frigg's tests does not make sense in mlibc, it creates packaging issues (due to the dependency on gtest) and unnecessary stuff being done in CI (probably negligible, but frigg has it's own CI so we don't need to do that here)