### PR TITLE
options/ansi: provide _setjmp and _longjmp in setjmp.h

### DIFF
--- a/options/ansi/include/setjmp.h
+++ b/options/ansi/include/setjmp.h
@@ -21,6 +21,15 @@ typedef struct __jmp_buf {
 __attribute__((__returns_twice__)) int setjmp(jmp_buf __buffer);
 __attribute__((__noreturn__)) void longjmp(jmp_buf __buffer, int __value);
 
+/* setjmp is defined as a function macro in the ISO C standard */
+#define setjmp(env) setjmp(env)
+
+#if __MLIBC_POSIX_OPTION
+__attribute__((__returns_twice__)) int _setjmp(jmp_buf __buffer);
+/* POSIX-2017.1 says _longjmp shall be declared as a function */
+__attribute__((__noreturn__)) void _longjmp(jmp_buf __buffer, int __value);
+#endif /* __MLIBC_POSIX_OPTION */
+
 #endif /* !__MLIBC_ABI_ONLY */
 
 /* POSIX Non-local jumps signal extensions */

--- a/options/internal/aarch64/setjmp.S
+++ b/options/internal/aarch64/setjmp.S
@@ -27,7 +27,10 @@ __setjmp:
 
 .global setjmp
 .type setjmp, "function"
+.global _setjmp
+.type _setjmp, "function"
 setjmp:
+_setjmp:
 	mov x2, xzr
 	b __setjmp
 
@@ -39,7 +42,10 @@ sigsetjmp:
 
 .global longjmp
 .type longjmp, "function"
+.global _longjmp
+.type _longjmp, "function"
 longjmp:
+_longjmp:
 	ldp x19, x20, [x0, #0]
 	ldp x21, x22, [x0, #16]
 	ldp x23, x24, [x0, #32]

--- a/options/internal/m68k/setjmp.S
+++ b/options/internal/m68k/setjmp.S
@@ -19,7 +19,10 @@ __setjmp:
 
 .global setjmp
 .type setjmp, "function"
+.global _setjmp
+.type _setjmp, "function"
 setjmp:
+_setjmp:
 	clr.l %d0
 	jmp __setjmp
 
@@ -31,7 +34,10 @@ sigsetjmp:
 
 .global longjmp
 .type longjmp, "function"
+.global _longjmp
+.type _longjmp, "function"
 longjmp:
+_longjmp:
 	movea.l 4(%sp),%a0
 	move.l 8(%sp),%d0
 	bne 1f

--- a/options/internal/riscv64/setjmp.S
+++ b/options/internal/riscv64/setjmp.S
@@ -1,6 +1,9 @@
 .global setjmp
 .type setjmp, "function"
+.global _setjmp
+.type _setjmp, "function"
 setjmp:
+_setjmp:
 	sd ra, 0(a0)
 	sd s0, 8(a0)
 	sd s1, 16(a0)
@@ -37,7 +40,10 @@ sigsetjmp:
 
 .global longjmp
 .type longjmp, "function"
+.global _longjmp
+.type _longjmp, "function"
 longjmp:
+_longjmp:
 	ld ra,0(a0)
 	ld s0,8(a0)
 	ld s1,16(a0)

--- a/options/internal/x86/setjmp.S
+++ b/options/internal/x86/setjmp.S
@@ -22,7 +22,10 @@ __setjmp:
 
 .global setjmp
 .type setjmp, "function"
+.global _setjmp
+.type _setjmp, "function"
 setjmp:
+_setjmp:
 	xor %edx, %edx
 	jmp __setjmp
 
@@ -34,7 +37,10 @@ sigsetjmp:
 
 .global longjmp
 .type longjmp, "function"
+.global _longjmp
+.type _longjmp, "function"
 longjmp:
+_longjmp:
 	mov 4(%esp), %ecx
 	mov 0x00(%ecx), %ebx
 	mov 0x04(%ecx), %ebp

--- a/options/internal/x86_64/setjmp.S
+++ b/options/internal/x86_64/setjmp.S
@@ -23,7 +23,10 @@ __setjmp:
 
 .global setjmp
 .type setjmp, "function"
+.global _setjmp
+.type _setjmp, "function"
 setjmp:
+_setjmp:
 	xor %rdx, %rdx
 	jmp __setjmp
 
@@ -35,7 +38,10 @@ sigsetjmp:
 
 .global longjmp
 .type longjmp, "function"
+.global _longjmp
+.type _longjmp, "function"
 longjmp:
+_longjmp:
 	mov 0x00(%rdi), %rbx
 	mov 0x08(%rdi), %rbp
 	mov 0x10(%rdi), %r12


### PR DESCRIPTION
This patch makes setjmp.h better conform to both ISO C and POSIX-2017.1 standards.

setjmp/_setjmp/longjmp/_longjmp currently act how they act in glibc systems (they both don't save the signal mask), if there is a use case for it we could also support the BSD convention (where setjmp/longjmp save the signal mask but the underscore variants don't)