### PR TITLE
various fixes for failing GMP tests

### DIFF
--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -292,7 +292,9 @@ int abstract_file::tell(off_t *current_offset) {
 	if(int e = io_seek(0, SEEK_CUR, &seek_offset); e)
 		return e;
 
-	*current_offset = seek_offset + (off_t(__offset) - off_t(__io_offset));
+	*current_offset = seek_offset
+		+ (off_t(__offset) - off_t(__io_offset))
+		+ (off_t(__unget_ptr) - off_t(__buffer_ptr));
 	return 0;
 }
 

--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -934,7 +934,10 @@ int fputc(int c, FILE *stream) {
 }
 
 int fputs_unlocked(const char *__restrict string, FILE *__restrict stream) {
-	if(fwrite_unlocked(string, strlen(string), 1, stream) != 1)
+	// fwrite with a length of 0 will return 0, so we need to explicitly allow
+	// zero length strings.
+	size_t length = strlen(string);
+	if (length != 0 && fwrite_unlocked(string, length, 1, stream) != 1)
 		return EOF;
 	return 1;
 }

--- a/options/internal/generic/locale.cpp
+++ b/options/internal/generic/locale.cpp
@@ -81,6 +81,10 @@ char *nl_langinfo(nl_item item) {
 		return const_cast<char *>("%I:%M:%S %p");
 	}else if(item == D_T_FMT) {
 		return const_cast<char *>("%a %b %e %T %Y");
+	} else if (item == RADIXCHAR) {
+		return const_cast<char *>(".");
+	} else if (item == THOUSEP) {
+		return const_cast<char *>("");
 	}else if(item == YESEXPR) {
 		return const_cast<char *>("^[yY]");
 	}else if(item == NOEXPR) {

--- a/options/internal/include/bits/nl_item.h
+++ b/options/internal/include/bits/nl_item.h
@@ -69,7 +69,9 @@ typedef int nl_item;
 #define CRNCYSTR 0x40000
 
 #define RADIXCHAR 0x50000
+#define DECIMAL_POINT RADIXCHAR
 #define THOUSEP 0x50001
+#define THOUSANDS_SEP THOUSEP
 
 #define YESEXPR 0x70000
 #define NOEXPR 0x70001

--- a/tests/ansi/fputs.c
+++ b/tests/ansi/fputs.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef USE_HOST_LIBC
+#define TEST_FILE "fputs-host-libc.tmp"
+#else
+#define TEST_FILE "fputs.tmp"
+#endif
+
+int main() {
+	FILE *file;
+	char str[] = "mlibc fputs test";
+	char buffer[100];
+
+	// Clear the buffer to zero.
+	memset(buffer, 0, sizeof(buffer));
+
+	// Open the file for writing.
+	file = fopen(TEST_FILE, "w");
+	assert(file);
+
+	// Verify that we can write an empty string.
+	assert(fputs("", file) != EOF);
+
+	// Write string, flush and close.
+	assert(fputs(str, file) != EOF);
+	fflush(file);
+	fclose(file);
+
+	// Open the file for reading.
+	file = fopen(TEST_FILE, "r");
+	assert(file);
+
+	// Verify that we read back the written string and close.
+	assert(fread(buffer, 1, sizeof(str) - 1, file));
+	assert(!strcmp(buffer, str));
+	fclose(file);
+
+	return 0;
+}

--- a/tests/ansi/ftell.c
+++ b/tests/ansi/ftell.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef USE_HOST_LIBC
+#define TEST_FILE "ftell-host-libc.tmp"
+#else
+#define TEST_FILE "ftell.tmp"
+#endif
+
+int main() {
+	FILE *file;
+	char str[] = "mlibc ftell test";
+	size_t str_size = sizeof(str) - 1;
+	char buffer[20];
+
+	// Clear buffer to zero
+	memset(buffer, 0, sizeof(buffer));
+
+	// Open the file for writing in binary mode, because ftell is unspecified
+	// in text mode.
+	file = fopen(TEST_FILE, "wb");
+	assert(file);
+
+	// Write string minus null terminator, flush and close.
+	assert(fwrite(str, 1, str_size, file) == str_size);
+	fflush(file);
+	fclose(file);
+
+	// Open the file for reading in binary mode.
+	file = fopen(TEST_FILE, "rb");
+	assert(file);
+
+	// Check position indicator at the start of the file.
+	assert(ftell(file) == 0);
+
+	// Read 4 bytes and check fread and ftell.
+	assert(fread(buffer, 1, 4, file) == 4);
+	assert(ftell(file) == 4);
+
+	// Rewind and check position indicator at the start of the file.
+	rewind(file);
+	assert(ftell(file) == 0);
+
+	// Read the entire file and check fread and ftell.
+	assert(fread(buffer, 1, str_size, file) == str_size);
+	assert((size_t) ftell(file) == str_size);
+
+	// Rewind and check how ftell interacts with getc.
+	rewind(file);
+	assert(fgetc(file) == 'm');
+	assert(ftell(file) == 1);
+	assert(fgetc(file) == 'l');
+	assert(ftell(file) == 2);
+	assert(fgetc(file) == 'i');
+	assert(ftell(file) == 3);
+
+	// Check whether ftell is decremented after ungetc
+	assert(ungetc('X', file) == 'X');
+	int ftell_after_ungetc = ftell(file);
+	fprintf(stderr, "ftell_after_ungetc: %d\n", ftell_after_ungetc);
+	assert(ftell_after_ungetc == 2);
+	ungetc('Y', file);
+	assert(ftell(file) == 1);
+
+	// Check if rewind undoes ungetc's effects on ftell
+	rewind(file);
+	assert(ftell(file) == 0);
+
+	fclose(file);
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,7 @@ all_test_cases = [
 	'ansi/strxfrm',
 	'ansi/calloc',
 	'ansi/fgetpos',
+	'ansi/fputs',
 	'ansi/ftell',
 	'bsd/ns_get_put',
 	'bsd/reallocarray',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,7 @@ all_test_cases = [
 	'ansi/strxfrm',
 	'ansi/calloc',
 	'ansi/fgetpos',
+	'ansi/ftell',
 	'bsd/ns_get_put',
 	'bsd/reallocarray',
 	'bsd/strl',


### PR DESCRIPTION
Fixes ftell behaviour after ungetc, and adds a simple test for ftell's functionality which also acts as a simple reproducible test case for the failing GMP tests documented in #1221. This test used to fail because our behaviour when checking ftell after a ungetc didn't match glibc.

Adds support for RADIXCHAR and THOUSEP in nl_langinfo, and adds some glibc aliases (not sure if they should be gated or available for all posix targets)

Fixes empty string handling in fputs and adds a simple test for fputs.

Fixes #1221.