### PR TITLE
abis/linux: Fix wrong definition of the GRND_* constants on the Linux ABI

### DIFF
--- a/abis/linux/random.h
+++ b/abis/linux/random.h
@@ -1,0 +1,7 @@
+#ifndef _ABIBITS_RANDOM_H
+#define _ABIBITS_RANDOM_H
+
+#define GRND_NONBLOCK 0x0001
+#define GRND_RANDOM 0x0002
+
+#endif // _ABIBITS_RANDOM_H

--- a/abis/mlibc/random.h
+++ b/abis/mlibc/random.h
@@ -1,0 +1,7 @@
+#ifndef _ABIBITS_RANDOM_H
+#define _ABIBITS_RANDOM_H
+
+#define GRND_RANDOM 1
+#define GRND_NONBLOCK 2
+
+#endif // _ABIBITS_RANDOM_H

--- a/options/linux/include/sys/random.h
+++ b/options/linux/include/sys/random.h
@@ -6,9 +6,7 @@
 extern "C" {
 #endif
 
-#define GRND_RANDOM 1
-#define GRND_NONBLOCK 2
-
+#include <abi-bits/random.h>
 #include <bits/ssize_t.h>
 #include <bits/size_t.h>
 

--- a/sysdeps/aero/include/abi-bits/random.h
+++ b/sysdeps/aero/include/abi-bits/random.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/random.h

--- a/sysdeps/aero/meson.build
+++ b/sysdeps/aero/meson.build
@@ -66,6 +66,7 @@ if not no_headers
 		'include/abi-bits/ioctls.h',
 		'include/abi-bits/xattr.h',
 		'include/abi-bits/msg.h',
+		'include/abi-bits/random.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true
 	)

--- a/sysdeps/astral/include/abi-bits/random.h
+++ b/sysdeps/astral/include/abi-bits/random.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/random.h

--- a/sysdeps/astral/meson.build
+++ b/sysdeps/astral/meson.build
@@ -66,6 +66,7 @@ if not no_headers
 		'include/abi-bits/xattr.h',
 		'include/abi-bits/msg.h',
 		'include/abi-bits/vt.h',
+		'include/abi-bits/random.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true,
 	)

--- a/sysdeps/keyronex/include/abi-bits/random.h
+++ b/sysdeps/keyronex/include/abi-bits/random.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/random.h

--- a/sysdeps/keyronex/meson.build
+++ b/sysdeps/keyronex/meson.build
@@ -65,6 +65,7 @@ if not no_headers
 		'include/abi-bits/statvfs.h',
 		'include/abi-bits/ioctls.h',
 		'include/abi-bits/xattr.h',
+		'include/abi-bits/random.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true
 	)

--- a/sysdeps/lemon/include/abi-bits/random.h
+++ b/sysdeps/lemon/include/abi-bits/random.h
@@ -1,0 +1,1 @@
+../../../../abis/mlibc/random.h

--- a/sysdeps/lemon/meson.build
+++ b/sysdeps/lemon/meson.build
@@ -66,6 +66,7 @@ if not no_headers
 		'include/abi-bits/ioctls.h',
 		'include/abi-bits/xattr.h',
 		'include/abi-bits/msg.h',
+		'include/abi-bits/random.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true
 	)

--- a/sysdeps/linux/include/abi-bits/random.h
+++ b/sysdeps/linux/include/abi-bits/random.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/random.h

--- a/sysdeps/linux/meson.build
+++ b/sysdeps/linux/meson.build
@@ -80,6 +80,7 @@ if not no_headers
 		'include/abi-bits/ioctls.h',
 		'include/abi-bits/xattr.h',
 		'include/abi-bits/msg.h',
+		'include/abi-bits/random.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true
 	)

--- a/sysdeps/managarm/include/abi-bits/random.h
+++ b/sysdeps/managarm/include/abi-bits/random.h
@@ -1,0 +1,1 @@
+../../../../abis/linux/random.h

--- a/sysdeps/managarm/meson.build
+++ b/sysdeps/managarm/meson.build
@@ -125,6 +125,7 @@ if not no_headers
 		'include/abi-bits/xattr.h',
 		'include/abi-bits/msg.h',
 		'include/abi-bits/vt.h',
+		'include/abi-bits/random.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true
 	)


### PR DESCRIPTION
Systemd checks the values of these, and they were wrong on the Linux ABI from the start. On the mlibc ABI they remain unchanged.

Part of the systemd on Managarm project.