### PR TITLE
options/posix: include <sys/stat.h> from <ftw.h>

### DIFF
--- a/options/posix/include/ftw.h
+++ b/options/posix/include/ftw.h
@@ -2,7 +2,7 @@
 #ifndef _FTW_H
 #define _FTW_H
 
-#include <bits/posix/stat.h>
+#include <sys/stat.h>
 
 #define FTW_F 1
 #define FTW_D 2


### PR DESCRIPTION
POSIX says the inclusion of <ftw.h> may also make visible symbols from <sys/stat.h>. Out in the wild, libcap-ng seems to depend on this behaviour.