### PR TITLE
tests/rtld: new search-order test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
                 apt-get update
                 apt-get install -y ninja-build qemu-user \
                                 python3-setuptools python3-jsonschema \
-                                python3-pexpect python3-pip netbase clang lld
+                                python3-pexpect python3-pip netbase clang lld \
+                                patchelf
                 pip install --break-system-packages -U xbstrap pyexpect meson
           - name: Prepare directories
             run: |

--- a/options/rtld/generic/linker.hpp
+++ b/options/rtld/generic/linker.hpp
@@ -70,6 +70,8 @@ struct ObjectRepository {
 	frg::expected<LinkerError, SharedObject *> requestObjectAtPath(frg::string_view path,
 			Scope *localScope, bool createScope, uint64_t rts);
 
+	void discoverDependenciesFromLoadedObject(SharedObject *object);
+
 	SharedObject *findCaller(void *address);
 
 	SharedObject *findLoadedObject(frg::string_view name);
@@ -79,6 +81,9 @@ struct ObjectRepository {
 
 	// Used by dl_iterate_phdr: stores objects in the order they are loaded.
 	frg::vector<SharedObject *, MemoryAllocator> loadedObjects;
+
+	// Used for breadth-first searching dependencies.
+	frg::vector<SharedObject *, MemoryAllocator> dependencyQueue;
 
 private:
 	void _fetchFromPhdrs(SharedObject *object, void *phdr_pointer,
@@ -225,6 +230,8 @@ struct SharedObject {
 	bool wasInitialized;
 
 	bool wasDestroyed = false;
+
+	bool wasVisited = false;
 
 	// PHDR related stuff, we only set these for the main executable
 	void *phdrPointer = nullptr;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -131,6 +131,7 @@ wrapped_test_cases = [
 
 host_libc_excluded_test_cases = [
 	'bsd/strl', # These functions do not exist on Linux.
+	'rtld/search-order', # See rtld/search-order/meson.build.
 ]
 host_libc_noasan_test_cases = [
 	'posix/pthread_cancel',

--- a/tests/rtld/ld_library_path/meson.build
+++ b/tests/rtld/ld_library_path/meson.build
@@ -5,8 +5,8 @@
 test_rpath = '$ORIGIN/'
 
 test_ld_path = meson.build_root() / 'tests' / 'rtld' / test_name
-test_env += ['LD_LIBRARY_PATH=' + test_ld_path]
-test_native_env += ['LD_LIBRARY_PATH=' + test_ld_path]
+test_env.set('LD_LIBRARY_PATH', test_ld_path)
+test_native_env.set('LD_LIBRARY_PATH', test_ld_path)
 
 libfoo = shared_library('foo', 'libfoo.c',
 	dependencies: libc_dep,

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -33,9 +33,24 @@ foreach test_name : rtld_test_cases
 	test_native_link_with = []
 	test_native_depends = []
 	test_additional_link_args = []
+	test_skipped = false
 
 	# Build the needed DSOs for the test. This sets the variables above.
 	subdir(test_name)
+
+	if test_skipped
+		exec = executable('rtld-' + test_name, ['skipped.c', test_sources],
+			dependencies: libc_dep,
+			override_options: test_override_options,
+			c_args: test_c_args,
+			link_args: test_link_args,
+		)
+		test(test_name, exec, suite: 'rtld')
+		if build_tests_host_libc and not host_libc_excluded_test_cases.contains(test_name)
+			test(test_name, exec, suite: ['host-libc', 'rtld'])
+		endif
+		continue
+	endif
 
 	exec = executable('rtld-' + test_name, [test_name / 'test.c', test_sources],
 		link_with: test_link_with,

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -13,6 +13,7 @@ rtld_test_cases = [
 	'scope3',
 	'scope4',
 	'scope5',
+	'search-order',
 	'tls_align',
 	'relr',
 	'symver',
@@ -48,7 +49,7 @@ foreach test_name : rtld_test_cases
 			link_args: test_link_args,
 		)
 		test(test_name, exec, suite: 'rtld')
-		if build_tests_host_libc and not host_libc_excluded_test_cases.contains(test_name)
+		if build_tests_host_libc and not host_libc_excluded_test_cases.contains('rtld' / test_name)
 			test(test_name, exec, suite: ['host-libc', 'rtld'])
 		endif
 		continue
@@ -66,7 +67,7 @@ foreach test_name : rtld_test_cases
 	# importantly LD_LIBRARY_PATH which is used by a few tests.
 	test(test_name, env, args: test_env + exec, suite: 'rtld', depends: test_depends)
 
-	if build_tests_host_libc and not host_libc_excluded_test_cases.contains(test_name)
+	if build_tests_host_libc and not host_libc_excluded_test_cases.contains('rtld' / test_name)
 		if test_name in host_libc_rtld_nosan_test_cases
 			host_libc_rtld_sanitize_options = 'b_sanitize=none'
 		else

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -22,6 +22,8 @@ host_libc_rtld_nosan_test_cases = [
 	'preinit',
 ]
 
+env = find_program('env')
+
 foreach test_name : rtld_test_cases
 	test_rpath = meson.build_root() / 'tests' / 'rtld' / test_name / ''
 	test_rpath += ':$ORIGIN/' # Workaround old and buggy qemu-user on CI
@@ -60,7 +62,9 @@ foreach test_name : rtld_test_cases
 		c_args: test_c_args,
 		link_args: test_link_args + test_additional_link_args,
 	)
-	test(test_name, exec, env: test_env, suite: 'rtld', depends: test_depends)
+	# wrap with `env` so we can overwrite variables passed by  meson, most
+	# importantly LD_LIBRARY_PATH which is used by a few tests.
+	test(test_name, env, args: test_env + exec, suite: 'rtld', depends: test_depends)
 
 	if build_tests_host_libc and not host_libc_excluded_test_cases.contains(test_name)
 		if test_name in host_libc_rtld_nosan_test_cases
@@ -80,6 +84,6 @@ foreach test_name : rtld_test_cases
 			link_args: ['-ldl'] + test_additional_link_args,
 			native: true,
 		)
-		test(test_name, exec, env: test_native_env, suite: ['host-libc', 'rtld'], depends: test_native_depends)
+		test(test_name, env, args: test_native_env + exec, suite: ['host-libc', 'rtld'], depends: test_native_depends)
 	endif
 endforeach

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -23,16 +23,14 @@ host_libc_rtld_nosan_test_cases = [
 	'preinit',
 ]
 
-env = find_program('env')
-
 foreach test_name : rtld_test_cases
 	test_rpath = meson.build_root() / 'tests' / 'rtld' / test_name / ''
 	test_rpath += ':$ORIGIN/' # Workaround old and buggy qemu-user on CI
 
-	test_env = []
+	test_env = environment()
 	test_link_with = []
 	test_depends = []
-	test_native_env = []
+	test_native_env = environment()
 	test_native_link_with = []
 	test_native_depends = []
 	test_additional_link_args = []
@@ -63,9 +61,7 @@ foreach test_name : rtld_test_cases
 		c_args: test_c_args,
 		link_args: test_link_args + test_additional_link_args,
 	)
-	# wrap with `env` so we can overwrite variables passed by  meson, most
-	# importantly LD_LIBRARY_PATH which is used by a few tests.
-	test(test_name, env, args: test_env + exec, suite: 'rtld', depends: test_depends)
+	test(test_name, exec, env: test_env, suite: 'rtld', depends: test_depends)
 
 	if build_tests_host_libc and not host_libc_excluded_test_cases.contains('rtld' / test_name)
 		if test_name in host_libc_rtld_nosan_test_cases
@@ -85,6 +81,6 @@ foreach test_name : rtld_test_cases
 			link_args: ['-ldl'] + test_additional_link_args,
 			native: true,
 		)
-		test(test_name, env, args: test_native_env + exec, suite: ['host-libc', 'rtld'], depends: test_native_depends)
+		test(test_name, exec, env: test_native_env, suite: ['host-libc', 'rtld'], depends: test_native_depends)
 	endif
 endforeach

--- a/tests/rtld/search-order/libbar.c
+++ b/tests/rtld/search-order/libbar.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <dlfcn.h>
+
+#ifdef USE_HOST_LIBC
+#define LIBFOO "libnative-foo.so"
+#else
+#define LIBFOO "libfoo.so"
+#endif
+
+int foo(void);
+
+int bar(void) {
+	return foo();
+}
+
+[[gnu::constructor]] void init(void) {
+	void *libfoo = dlopen(LIBFOO, RTLD_LOCAL | RTLD_NOW);
+	assert(libfoo);
+}

--- a/tests/rtld/search-order/libfoo.c
+++ b/tests/rtld/search-order/libfoo.c
@@ -1,0 +1,3 @@
+int foo(void) {
+	return 0xCAFEBABE;
+}

--- a/tests/rtld/search-order/meson.build
+++ b/tests/rtld/search-order/meson.build
@@ -9,8 +9,8 @@ if patchelf.found()
 	# Overwrite LD_LIBRARY_PATH to make meson not fix our shenanigans
 	# Otherwise, meson's LD_LIBRARY_PATH makes this test useless because libfoo
 	# will be found through it instead of failing when libfoo is not found
-	test_env += ['LD_LIBRARY_PATH=']
-	test_native_env += ['LD_LIBRARY_PATH=']
+	test_env.unset('LD_LIBRARY_PATH')
+	test_native_env.unset('LD_LIBRARY_PATH')
 
 	libfoo = shared_library('foo', 'libfoo.c')
 	libbar_unpatched = shared_library('bar-unpatched', 'libbar.c',

--- a/tests/rtld/search-order/meson.build
+++ b/tests/rtld/search-order/meson.build
@@ -1,0 +1,29 @@
+# meson does not have native custom_target, so when cross compiling it gets
+# unhappy that we're trying to link a "host" library (which is actually built
+# for the build machine) to a build executable. This means we can't patchelf
+# native libraries if we want cross compilation to work.
+
+patchelf = find_program('patchelf', required: false)
+
+if patchelf.found()
+	# Overwrite LD_LIBRARY_PATH to make meson not fix our shenanigans
+	# Otherwise, meson's LD_LIBRARY_PATH makes this test useless because libfoo
+	# will be found through it instead of failing when libfoo is not found
+	test_env += ['LD_LIBRARY_PATH=']
+	test_native_env += ['LD_LIBRARY_PATH=']
+
+	libfoo = shared_library('foo', 'libfoo.c')
+	libbar_unpatched = shared_library('bar-unpatched', 'libbar.c',
+		dependencies: libc_dep, link_with: libfoo)
+	libbar = custom_target('patch-libbar',
+		command: [patchelf,
+			'--remove-rpath',
+			'--set-soname', 'libbar.so',
+			libbar_unpatched,
+			'--output', '@OUTPUT0@'],
+		output: ['libbar.so'],
+	)
+	test_link_with = [libbar, libfoo]
+else
+	test_skipped = true
+endif

--- a/tests/rtld/search-order/test.c
+++ b/tests/rtld/search-order/test.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <dlfcn.h>
+
+#ifdef USE_HOST_LIBC
+#define LIBBAR "libnative-bar.so"
+#else
+#define LIBBAR "libbar.so"
+#endif
+
+int foo();
+int bar();
+
+int main() {
+	void *libbar = dlopen(LIBBAR, RTLD_LOCAL | RTLD_NOW);
+	assert(libbar);
+
+	assert(foo() == (int) 0xCAFEBABE);
+	assert(bar() == (int) 0xCAFEBABE);
+
+	return 0;
+}

--- a/tests/rtld/skipped.c
+++ b/tests/rtld/skipped.c
@@ -1,0 +1,3 @@
+int main() {
+	return 77;
+}


### PR DESCRIPTION
Is blocked by mesonbuild/meson#14293 so had to be split from #1238.

Adds a new test for the search order behavior fixed in #1238.