### PR TITLE
options/rtld: Avoid potentially mapping pages as W+X

### DIFF
--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -250,6 +250,13 @@ int sys_vm_unmap(void *pointer, size_t size) {
 	return 0;
 }
 
+int sys_vm_protect(void *pointer, size_t size, int prot) {
+	auto ret = do_syscall(SYS_mprotect, pointer, size, prot);
+	if (int e = sc_error(ret); e)
+		return e;
+	return 0;
+}
+
 // All remaining functions are disabled in ldso.
 #ifndef MLIBC_BUILDING_RTLD
 
@@ -1646,13 +1653,6 @@ gid_t sys_getegid() {
 
 int sys_kill(int pid, int sig) {
 	auto ret = do_syscall(SYS_kill, pid, sig);
-	if (int e = sc_error(ret); e)
-		return e;
-	return 0;
-}
-
-int sys_vm_protect(void *pointer, size_t size, int prot) {
-	auto ret = do_syscall(SYS_mprotect, pointer, size, prot);
 	if (int e = sc_error(ret); e)
 		return e;
 	return 0;

--- a/sysdeps/vinix/generic/generic.cpp
+++ b/sysdeps/vinix/generic/generic.cpp
@@ -423,8 +423,6 @@ int sys_vm_unmap(void *pointer, size_t size) {
 	return 0;
 }
 
-#ifndef MLIBC_BUILDING_RTLD
-
 int sys_vm_protect(void *pointer, size_t size, int prot) {
 	__syscall_ret ret = __syscall(48, pointer, size, prot);
 
@@ -433,8 +431,6 @@ int sys_vm_protect(void *pointer, size_t size, int prot) {
 
 	return 0;
 }
-
-#endif
 
 int sys_anon_allocate(size_t size, void **pointer) {
 	return sys_vm_map(NULL, size, PROT_EXEC | PROT_READ | PROT_WRITE,


### PR DESCRIPTION
This also fixes a bug where the 'Take care of removing superfluous permissions' code wouldn't do so for the entirety of mappings made when MLIBC_MAP_DSO_SEGMENTS is set, but only for the unbacked portion
