### PR TITLE
options/glibc: Stub out backtrace() function

### DIFF
--- a/options/glibc/generic/execinfo.cpp
+++ b/options/glibc/generic/execinfo.cpp
@@ -1,9 +1,11 @@
 #include <execinfo.h>
+
 #include <bits/ensure.h>
+#include <mlibc/debug.hpp>
 
 int backtrace(void **, int) {
-	__ensure(!"Not implemented");
-	__builtin_unreachable();
+	mlibc::infoLogger() << "mlibc: backtrace() is a stub!" << frg::endlog;
+	return 0;
 }
 
 char **backtrace_symbols(void *const *, int) {


### PR DESCRIPTION
This is needed for some Xorg related packages, which otherwise bail out due to the assertion here.
