### PR TITLE
options/posix: Remove incorect `__USE_MISC` guard

### DIFF
--- a/options/posix/include/syslog.h
+++ b/options/posix/include/syslog.h
@@ -58,7 +58,7 @@ extern "C" {
 #define LOG_DEBUG 7
 
 #if __MLIBC_BSD_OPTION
-#if defined(SYSLOG_NAMES) && defined (__USE_MISC)
+#if defined(SYSLOG_NAMES)
 #define INTERNAL_NOPRI 0x10
 #define INTERNAL_MARK LOG_MAKEPRI(LOG_NFACILITIES << 3, 0)
 
@@ -66,13 +66,13 @@ typedef struct _code {
 	char *c_name;
 	int c_val;
 } CODE;
-#endif /* SYSLOG_NAMES && __USE_MISC */
+#endif /* SYSLOG_NAMES */
 #endif /* __MLIBC_BSD_OPTION */
 
 #ifndef __MLIBC_ABI_ONLY
 
 #if __MLIBC_BSD_OPTION
-#if defined(SYSLOG_NAMES) && defined (__USE_MISC)
+#if defined(SYSLOG_NAMES)
 CODE prioritynames[] = {
 	{ "alert", LOG_ALERT },
 	{ "crit", LOG_CRIT },
@@ -114,7 +114,7 @@ CODE facilitynames[] = {
 	{ "local7", LOG_LOCAL7 },
 	{ NULL, -1 }
 };
-#endif /* SYSLOG_NAMES && __USE_MISC */
+#endif /* SYSLOG_NAMES */
 #endif /* __MLIBC_BSD_OPTION */
 
 void closelog(void);


### PR DESCRIPTION
The `__USE_MISC` define is a GLIBC thing for BSD 4.x extensions and holds no weight in mlibc since it's already gated behind `__MLIBC_BSD_OPTION`.