### PR TITLE
tests/posix: make SHM tests more resilient to preexisting system shmids

### DIFF
--- a/tests/posix/shm.c
+++ b/tests/posix/shm.c
@@ -4,11 +4,20 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>
+#include <time.h>
 
 int main(void) {
     size_t page_size = getpagesize();
 
-    int shmid = shmget(23123123, page_size, 0644 | IPC_CREAT | IPC_EXCL);
+    srand(time(NULL));
+
+    int shmid = -1;
+    for (int i = 0; i < 10; i++) {
+        shmid = shmget((key_t)rand(), page_size, 0644 | IPC_CREAT | IPC_EXCL);
+        if (shmid != -1) {
+            break;
+        }
+    }
     assert(shmid != -1);
 
     struct shmid_ds buf;


### PR DESCRIPTION
if the system has 23123123 as a used key for a preexisting shm segment, the tests will spuriously fail. This implements a better approach.