### PR TITLE
release prep

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -2,6 +2,10 @@
 
 This document lists the ABI breaks that were made in each mlibc major version.
 
+## Version 5, 6
+
+Numerous ABI breaks. These were not properly logged, and are therefore missing here. Pending update, if one ever comes.
+
 ## Version 4
 
 - [#814](https://github.com/managarm/mlibc/pull/814): `struct timex`'s `long int tai` changed to the correct `int tai`, and `int __padding[11]` got appended to the struct.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -18,8 +18,11 @@ Releases are tagged off of their respective major version branches once they are
 Major versions get a new, dedicated branch, which is created from `master` when deemed
 necessary, usually shortly before the tagging of the first release in the new major version
 branch. This branch is called `vN.x`, where `N` is the number of the major version
-(and `x` is just a literal "x"). The first tag on the major version branch is the `vN.0.0`
-release.
+(and `x` is just a literal "x").
+
+Submodules are fixed to specific commits when a major version branch is created.
+
+The first tag on the major version branch is the `vN.0.0` release.
 
 Minor versions and patch versions are tagged on their respective major version branches
 after the necessary commits are backported onto said branch from `master`.


### PR DESCRIPTION
- **docs: RELEASE_PROCEDURE.md: Mention fixing of submodule commits**
- **docs: ABI_BREAKS.md: Mention versions 5 and 6 were not logged**
