### PR TITLE
sysdeps/menix: Fix reboot.h values

### DIFF
--- a/abis/menix/reboot.h
+++ b/abis/menix/reboot.h
@@ -1,0 +1,12 @@
+#ifndef _ABIBITS_REBOOT_H
+#define _ABIBITS_REBOOT_H
+
+#define RB_AUTOBOOT    0xdeadb007
+#define RB_HALT_SYSTEM 0xdeaddead
+#define RB_ENABLE_CAD  0xdeadcad1
+#define RB_DISABLE_CAD 0xdeadcad0
+#define RB_POWER_OFF   0xdead00ff
+#define RB_SW_SUSPEND  0xdead2222
+#define RB_KEXEC       0xdeadecec
+
+#endif /* _ABIBITS_REBOOT_H */

--- a/sysdeps/menix/include/abi-bits/reboot.h
+++ b/sysdeps/menix/include/abi-bits/reboot.h
@@ -1,1 +1,1 @@
-../../../../abis/linux/reboot.h
+../../../../abis/menix/reboot.h

--- a/sysdeps/menix/meson.build
+++ b/sysdeps/menix/meson.build
@@ -68,6 +68,7 @@ if not no_headers
 		'include/abi-bits/rlim_t.h',
 		'include/abi-bits/sigevent.h',
 		'include/abi-bits/sigval.h',
+		'include/abi-bits/reboot.h',
 		subdir: 'abi-bits',
 		follow_symlinks: true,
 	)


### PR DESCRIPTION
This PR adds a missing abi-bit for the `menix` sysdep