### PR TITLE
options/posix: added new sysdep sys_thread_sigmask and used in pthread_sigmask

### DIFF
--- a/options/posix/generic/posix_signal.cpp
+++ b/options/posix/generic/posix_signal.cpp
@@ -16,6 +16,13 @@ int sigsuspend(const sigset_t *sigmask) {
 }
 
 int pthread_sigmask(int how, const sigset_t *__restrict set, sigset_t *__restrict retrieve) {
+ 	if(mlibc::sys_thread_sigmask) {
+	 	if(int e = mlibc::sys_thread_sigmask(how, set, retrieve); e) {
+	 	 	return e;
+	 	}
+ 	 	return 0;
+ 	}
+
 	if(!mlibc::sys_sigprocmask) {
 		MLIBC_MISSING_SYSDEP();
 		return ENOSYS;

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -168,6 +168,8 @@ int sys_vm_unmap(void *pointer, size_t size);
 [[gnu::weak]] int sys_shutdown(int sockfd, int how);
 [[gnu::weak]] int sys_sigprocmask(int how, const sigset_t *__restrict set,
 		sigset_t *__restrict retrieve);
+[[gnu::weak]] int sys_thread_sigmask(int how, const sigset_t *__restrict set,
+		sigset_t *__restrict retrieve);
 [[gnu::weak]] int sys_sigaction(int, const struct sigaction *__restrict,
 		struct sigaction *__restrict);
 // NOTE: POSIX says that behavior of timeout = nullptr is unspecified. We treat this case


### PR DESCRIPTION
This should fix #1381. All automated tests seem to pass.
