### PR TITLE
options/posix: fix bug with mkostemp

### DIFF
--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -216,7 +216,7 @@ int mkostemps(char *pattern, int suffixlen, int flags) {
 }
 
 int mkostemp(char *pattern, int flags) {
-	return mkostemps(pattern, flags, 0);
+	return mkostemps(pattern, 0, flags);
 }
 
 int mkstemp(char *path) {


### PR DESCRIPTION
mkostemp would previously pass 0 to flags and flags to suffixlen when forwarding its parameters to the mkostemps function. This commit should fix that.