### PR TITLE
sysdeps/managarm: Add EBADF handling to sys_fsync

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2636,7 +2636,10 @@ int sys_gethostname(char *buffer, size_t bufsize) {
 	return 0;
 }
 
-int sys_fsync(int) {
+int sys_fsync(int fd) {
+	auto handle = getHandleForFd(fd);
+	if (!handle)
+		return EBADF;
 	mlibc::infoLogger() << "mlibc: fsync is a stub" << frg::endlog;
 	return 0;
 }


### PR DESCRIPTION
`glib` testsuite expects this for invalid `fd` in `fsync`, and it matches spec. Return EBADF in fsync on closed fd's.