### PR TITLE
Avoid asserting on unknown ioctls or getsockopt options

### DIFF
--- a/sysdeps/managarm/generic/ioctl.cpp
+++ b/sysdeps/managarm/generic/ioctl.cpp
@@ -1217,8 +1217,8 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result) {
 	                    << " type: 0x" << frg::hex_fmt(_IOC_TYPE(request)) << ", number: 0x"
 	                    << frg::hex_fmt(_IOC_NR(request))
 	                    << " (raw request: " << frg::hex_fmt(request) << ")" << frg::endlog;
-	__ensure(!"Illegal ioctl request");
-	__builtin_unreachable();
+
+	return ENOSYS;
 }
 
 } // namespace mlibc

--- a/sysdeps/managarm/generic/socket.cpp
+++ b/sysdeps/managarm/generic/socket.cpp
@@ -329,9 +329,9 @@ sys_getsockopt(int fd, int layer, int number, void *__restrict buffer, socklen_t
 
 		return resp.error() | toErrno;
 	} else {
-		mlibc::panicLogger() << "\e[31mmlibc: Unexpected getsockopt() call, layer: " << layer
-		                     << " number: " << number << "\e[39m" << frg::endlog;
-		__builtin_unreachable();
+		mlibc::infoLogger() << "\e[31mmlibc: Unexpected getsockopt() call, layer: " << layer
+		                    << " number: " << number << "\e[39m" << frg::endlog;
+		return EINVAL;
 	}
 }
 
@@ -560,9 +560,9 @@ int sys_setsockopt(int fd, int layer, int number, const void *buffer, socklen_t 
 		  << frg::endlog;
 		return ENOSYS;
 	} else {
-		mlibc::panicLogger() << "\e[31mmlibc: Unexpected setsockopt() call, layer: " << layer
-		                     << " number: " << number << "\e[39m" << frg::endlog;
-		__builtin_unreachable();
+		mlibc::infoLogger() << "\e[31mmlibc: Unexpected setsockopt() call, layer: " << layer
+		                    << " number: " << number << "\e[39m" << frg::endlog;
+		return EINVAL;
 	}
 }
 


### PR DESCRIPTION
These patches are enough to successfully run [os-test](https://sortix.org/os-test/) without crashing, at least what patching concerns the mlibc sysdep side of managarm.