### PR TITLE
options/posix: add openpt sysdep

### DIFF
--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -492,13 +492,20 @@ char *ptsname(int fd) {
 }
 
 int posix_openpt(int flags) {
-	int fd;
-	if(int e = mlibc::sys_open("/dev/ptmx", flags, 0, &fd); e) {
-		errno = e;
-		return -1;
+	int fd, e;
+
+	if(mlibc::sys_openpt) {
+		e = mlibc::sys_openpt(flags, &fd);
+	} else {
+		e = mlibc::sys_open("/dev/ptmx", flags, 0, &fd);
 	}
 
-	return fd;
+	if (e) {
+		errno = e;
+		return -1;
+	} else {
+		return fd;
+	}
 }
 
 int unlockpt(int fd) {

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -256,6 +256,8 @@ int sys_vm_unmap(void *pointer, size_t size);
 
 [[gnu::weak]] int sys_nice(int nice, int *new_nice);
 
+[[gnu::weak]] int sys_openpt(int oflags, int *fd);
+
 } //namespace mlibc
 
 #endif // MLIBC_POSIX_SYSDEPS


### PR DESCRIPTION
`posix_openpt` was made to not hardcode the existence of `/dev/ptmx` in the POSIX spec, making it depend on that same device defeats the point. This PR adds the option for ports to use a sysdep instead.