### PR TITLE
options/ansi: support strftime's `%U` format

### DIFF
--- a/options/ansi/generic/time.cpp
+++ b/options/ansi/generic/time.cpp
@@ -433,6 +433,14 @@ size_t strftime(char *__restrict dest, size_t max_size,
 		case 'X': {
 			return strftime(dest, max_size, mlibc::nl_langinfo(T_FMT), tm);
 		}
+		case 'U': {
+			chunk = snprintf(p, space, "%02d", (tm->tm_yday + 7 - tm->tm_wday) / 7);
+			if(chunk >= space)
+				return 0;
+			p += chunk;
+			c++;
+			break;
+		}
 		case '\0': {
 			chunk = snprintf(p, space, "%%");
 			if(chunk >= space)

--- a/tests/ansi/strftime.c
+++ b/tests/ansi/strftime.c
@@ -67,5 +67,10 @@ int main() {
 	strftime(timebuf, sizeof(timebuf), "%z", &tm);
 	assert(!strcmp(timebuf, "+0100"));
 
+	memset(timebuf, 0, sizeof(timebuf));
+	strftime(timebuf, sizeof(timebuf), "%U", &tm);
+	fprintf(stderr, "'%s'\n", timebuf);
+	assert(!strcmp(timebuf, "06"));
+
 	return 0;
 }


### PR DESCRIPTION
Fixes #1429.