### PR TITLE
options/internal: fix bits/null.h C++ definitions

### DIFF
--- a/options/internal/include/bits/null.h
+++ b/options/internal/include/bits/null.h
@@ -9,7 +9,11 @@
 #ifndef __cplusplus
 #  define NULL ((void *)0)
 #else
-#  define NULL 0
+#  if __cplusplus >= 201103L
+#    define NULL nullptr
+#  else
+#    define NULL 0L
+#  endif
 #endif
 
 #endif /* MLIBC_NULL_H */

--- a/sysdeps/astral/generic/generic.cpp
+++ b/sysdeps/astral/generic/generic.cpp
@@ -316,12 +316,12 @@ namespace mlibc {
 
 	int sys_gethostname(char *buffer, size_t bufsize) {
 		long ret;
-		return syscall(SYSCALL_HOSTNAME, &ret, NULL, 0, (uint64_t)buffer, bufsize);
+		return syscall(SYSCALL_HOSTNAME, &ret, 0, 0, (uint64_t)buffer, bufsize);
 	}
 
 	int sys_sethostname(const char *buffer, size_t bufsize) {
 		long ret;
-		return syscall(SYSCALL_HOSTNAME, &ret, (uint64_t)buffer, bufsize, NULL, 0);
+		return syscall(SYSCALL_HOSTNAME, &ret, (uint64_t)buffer, bufsize, 0, 0);
 	}
 
 	int sys_uname(struct utsname *buf) {
@@ -833,7 +833,7 @@ namespace mlibc {
 
 	int sys_futex_wake(int *pointer) {
 		long ret;
-		return syscall(SYSCALL_FUTEX, &ret, (uint64_t)pointer, FUTEX_WAKE, INT_MAX, NULL);
+		return syscall(SYSCALL_FUTEX, &ret, (uint64_t)pointer, FUTEX_WAKE, INT_MAX, 0);
 	}
 
 	int sys_anon_allocate(size_t size, void **pointer) {

--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -2866,7 +2866,7 @@ int sys_fstatfs(int fd, struct statfs *buf) {
 	if (resp.error() != managarm::posix::Errors::SUCCESS)
 		return resp.error() | toErrno;
 
-	memset(buf, NULL, sizeof(struct statfs));
+	memset(buf, 0, sizeof(struct statfs));
 	buf->f_type = resp.fstype();
 	return 0;
 }
@@ -2985,7 +2985,7 @@ int sys_statfs(const char *path, struct statfs *buf) {
 	if (resp.error() != managarm::posix::Errors::SUCCESS)
 		return resp.error() | toErrno;
 
-	memset(buf, NULL, sizeof(struct statfs));
+	memset(buf, 0, sizeof(struct statfs));
 	buf->f_type = resp.fstype();
 	return 0;
 }


### PR DESCRIPTION
This fixes the C++ definition of NULL in bits/null.h
The old definition caused an assert failure in OpenJDK 17.