### PR TITLE
options/rtld: make __dlapi_open default to the main executable if caller can't be found

### DIFF
--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -650,8 +650,8 @@ void *__dlapi_open(const char *file, int flags, void *returnAddress) {
 			// In order to know which RUNPATH / RPATH to process, we must find the calling object.
 			SharedObject *origin = initialRepository->findCaller(returnAddress);
 			if (!origin) {
-				mlibc::panicLogger() << "rtld: unable to determine calling object of dlopen "
-					<< "(ra = " << returnAddress << ")" << frg::endlog;
+				// When we can't find the origin, assume it's the main executable (copies glibc behavior)
+				origin = executableSO;
 			}
 
 			objectResult = initialRepository->requestObjectWithName(file, origin, newScope, !isGlobal, rts);


### PR DESCRIPTION
Some programs (like OpenJDK with LWJGL 3) call `dlopen` from code that wasn't loaded by mlibc (e.g. JIT output or manually loaded code). Without this PR, this causes an mlibc panic.

The choice to default to the main executable copies glibc behavior: https://elixir.bootlin.com/glibc/glibc-2.42.9000/source/elf/dl-open.c#L879-L883.