### PR TITLE
options/posix: move ppoll from linux to posix

### DIFF
--- a/options/linux/include/mlibc/linux-sysdeps.hpp
+++ b/options/linux/include/mlibc/linux-sysdeps.hpp
@@ -33,8 +33,6 @@ int sys_ioctl(int fd, unsigned long request, void *arg, int *result);
 [[gnu::weak]] int sys_epoll_ctl(int epfd, int mode, int fd, struct epoll_event *ev);
 [[gnu::weak]] int sys_epoll_pwait(int epfd, struct epoll_event *ev, int n,
 		int timeout, const sigset_t *sigmask, int *raised);
-[[gnu::weak]] int sys_ppoll(struct pollfd *fds, nfds_t count, const struct timespec *ts,
-		const sigset_t *mask, int *num_events);
 [[gnu::weak]] int sys_mount(const char *source, const char *target,
 		const char *fstype, unsigned long flags, const void *data);
 [[gnu::weak]] int sys_umount2(const char *target, int flags);

--- a/options/posix/generic/poll.cpp
+++ b/options/posix/generic/poll.cpp
@@ -16,10 +16,6 @@ int poll(struct pollfd *fds, nfds_t count, int timeout) {
 	return num_events;
 }
 
-#if __MLIBC_LINUX_OPTION
-
-#include <mlibc/linux-sysdeps.hpp>
-
 int ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *timeout_ts, const sigset_t *sigmask) {
 	if (mlibc::sys_ppoll) {
 		int num_events;
@@ -39,5 +35,3 @@ int ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *timeout_ts, co
 
 	return ready;
 }
-#endif // __MLIBC_LINUX_OPTION
-

--- a/options/posix/include/mlibc/posix-sysdeps.hpp
+++ b/options/posix/include/mlibc/posix-sysdeps.hpp
@@ -162,6 +162,7 @@ int sys_vm_unmap(void *pointer, size_t size);
 [[gnu::weak]] int sys_pipe(int *fds, int flags);
 [[gnu::weak]] int sys_socketpair(int domain, int type_and_flags, int proto, int *fds);
 [[gnu::weak]] int sys_poll(struct pollfd *fds, nfds_t count, int timeout, int *num_events);
+[[gnu::weak]] int sys_ppoll(struct pollfd *fds, nfds_t count, const struct timespec *ts, const sigset_t *mask, int *num_events);
 [[gnu::weak]] int sys_ioctl(int fd, unsigned long request, void *arg, int *result);
 [[gnu::weak]] int sys_getsockopt(int fd, int layer, int number,
 		void *__restrict buffer, socklen_t *__restrict size);

--- a/options/posix/include/sys/poll.h
+++ b/options/posix/include/sys/poll.h
@@ -24,10 +24,10 @@ struct pollfd {
 
 int poll(struct pollfd *__fds, nfds_t __nfds, int __timeout);
 
-#if __MLIBC_LINUX_OPTION
+#if defined(_GNU_SOURCE) || __MLIBC_POSIX2024
 int ppoll(struct pollfd *__fds, nfds_t __nfds,
 		const struct timespec *__timeout_ts, const sigset_t *__sigmask);
-#endif /* __MLIBC_LINUX_OPTION */
+#endif /* defined(_GNU_SOURCE) || __MLIBC_POSIX2024 */
 
 #endif /* !__MLIBC_ABI_ONLY */
 


### PR DESCRIPTION
`ppoll` is no longer a Linux-specific function and is available in POSIX 2024