### PR TITLE
options/glibc: fix null dereference when calling dlerror

### DIFF
--- a/options/glibc/generic/execinfo.cpp
+++ b/options/glibc/generic/execinfo.cpp
@@ -58,7 +58,8 @@ int backtrace(void **buffer, int size) {
 	if (!libgccHandle) {
 		libgccHandle = dlopen("libgcc_s.so.1", RTLD_LAZY | RTLD_LOCAL);
 		if (!libgccHandle || libgccHandle.value() == nullptr) {
-			mlibc::infoLogger() << "Failed to load libgcc_s.so.1: " << (dlerror() ? dlerror() : "") << frg::endlog;
+			auto error = dlerror();
+			mlibc::infoLogger() << "Failed to load libgcc_s.so.1: " << (error ? error : "") << frg::endlog;
 			return 0;
 		}
 


### PR DESCRIPTION
Calling `dlerror()` resets the internal string to a `nullptr`. By calling `dlerror()` twice, the returned pointer first contains the actual string, but on the second invocation it returns `nullptr`, which then gets printed.