### PR TITLE
options/posix: fix build without glibc and bsd options

### DIFF
--- a/options/posix/generic/dirent.cpp
+++ b/options/posix/generic/dirent.cpp
@@ -183,6 +183,10 @@ long telldir(DIR *) {
 	__builtin_unreachable();
 }
 
+#if __MLIBC_GLIBC_OPTION
+
 int versionsort(const struct dirent **a, const struct dirent **b) {
 	return strverscmp((*a)->d_name, (*b)->d_name);
 }
+
+#endif // __MLIBC_GLIBC_OPTION

--- a/options/posix/generic/dlfcn.cpp
+++ b/options/posix/generic/dlfcn.cpp
@@ -18,7 +18,6 @@ extern "C" void *__dlapi_open(const char *, int, void *);
 extern "C" void *__dlapi_resolve(void *, const char *, void *, const char *);
 extern "C" int __dlapi_reverse(const void *, __dlapi_symbol *);
 extern "C" int __dlapi_close(void *);
-extern "C" int __dlapi_find_object(void *__address, dl_find_object *__result);
 
 int dlclose(void *handle) {
 	return __dlapi_close(handle);

--- a/options/posix/generic/posix_stdlib.cpp
+++ b/options/posix/generic/posix_stdlib.cpp
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/ioctl.h>
 #include <sys/stat.h>
 
 #include <frg/small_vector.hpp>

--- a/options/posix/generic/sys-uio.cpp
+++ b/options/posix/generic/sys-uio.cpp
@@ -58,7 +58,7 @@ ssize_t writev(int fd, const struct iovec *iovs, int iovc) {
 	for(int i = 0; i < iovc; i++) {
 		size_t copy = frg::min(iovs[i].iov_len, to_copy);
 
-		bp = (char *)mempcpy((void *)bp, (void *)iovs[i].iov_base, copy);
+		bp = (char *)memcpy((void *)bp, (void *)iovs[i].iov_base, copy) + copy;
 
 		to_copy -= copy;
 		if(to_copy == 0)

--- a/options/posix/generic/termios.cpp
+++ b/options/posix/generic/termios.cpp
@@ -4,7 +4,6 @@
 
 #include <errno.h>
 #include <termios.h>
-#include <sys/ioctl.h>
 
 #include <bits/ensure.h>
 #include <mlibc/posix-sysdeps.hpp>
@@ -80,8 +79,10 @@ int tcgetattr(int fd, struct termios *attr) {
 }
 
 pid_t tcgetsid(int fd) {
-	int sid;
-	if(ioctl(fd, TIOCGSID, &sid) < 0) {
+	int sid, scratch;
+	MLIBC_CHECK_OR_ENOSYS(mlibc::sys_ioctl, -1);
+	if(int e = mlibc::sys_ioctl(fd, TIOCGSID, &sid, &scratch); e) {
+		errno = e;
 		return -1;
 	}
 	return sid;

--- a/options/posix/generic/unistd.cpp
+++ b/options/posix/generic/unistd.cpp
@@ -9,7 +9,6 @@
 #include <limits.h>
 #include <termios.h>
 #include <pwd.h>
-#include <sys/ioctl.h>
 #include <sys/stat.h>
 
 #include <bits/ensure.h>
@@ -19,8 +18,11 @@
 #include <mlibc/debug.hpp>
 #include <mlibc/getopt.hpp>
 #include <mlibc/posix-sysdeps.hpp>
-#include <mlibc/bsd-sysdeps.hpp>
 #include <mlibc/thread.hpp>
+
+#if __MLIBC_BSD_OPTION
+#include <mlibc/bsd-sysdeps.hpp>
+#endif
 
 #if __MLIBC_LINUX_OPTION
 #include <mlibc/linux-sysdeps.hpp>
@@ -909,15 +911,25 @@ long sysconf(int number) {
 }
 
 pid_t tcgetpgrp(int fd) {
-	int pgrp;
-	if(ioctl(fd, TIOCGPGRP, &pgrp) < 0) {
+	int pgrp, scratch;
+	MLIBC_CHECK_OR_ENOSYS(mlibc::sys_ioctl, -1);
+	if(int e = mlibc::sys_ioctl(fd, TIOCGPGRP, &pgrp, &scratch); e) {
+		errno = e;
 		return -1;
 	}
+
 	return pgrp;
 }
 
 int tcsetpgrp(int fd, pid_t pgrp) {
-	return ioctl(fd, TIOCSPGRP, &pgrp);
+	int scratch;
+	MLIBC_CHECK_OR_ENOSYS(mlibc::sys_ioctl, -1);
+	if(int e = mlibc::sys_ioctl(fd, TIOCSPGRP, &pgrp, &scratch); e) {
+		errno = e;
+		return -1;
+	}
+
+	return 0;
 }
 
 int truncate(const char *, off_t) {

--- a/options/posix/generic/utmpx.cpp
+++ b/options/posix/generic/utmpx.cpp
@@ -3,7 +3,6 @@
 #include <frg/mutex.hpp>
 #include <frg/spinlock.hpp>
 #include <mlibc/debug.hpp>
-#include <paths.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <utmpx.h>

--- a/options/posix/include/dirent.h
+++ b/options/posix/include/dirent.h
@@ -82,9 +82,9 @@ void seekdir(DIR *__dirp, long __loc);
 long telldir(DIR *__dirp);
 #endif
 
-#if defined(_GNU_SOURCE)
+#if __MLIBC_GLIBC_OPTION && defined(_GNU_SOURCE)
 int versionsort(const struct dirent **__a, const struct dirent **__b);
-#endif
+#endif /* __MLIBC_GLIBC_OPTION && defined(_GNU_SOURCE) */
 
 #endif /* !__MLIBC_ABI_ONLY */
 


### PR DESCRIPTION
This PR fixes builds with the POSIX option enabled that do not enable the BSD or glibc options. Solves #1212 and #1213 