### PR TITLE
Remove fixincludes support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,11 +112,6 @@ if not headers_only
 			error('could not find compiler-specific header directory')
 		endif
 
-		if c_compiler.get_id() == 'gcc' and fs.exists(ccdir / 'include-fixed')
-			rtld_include_dirs += include_directories(ccdir / 'include-fixed')
-			libc_include_dirs += include_directories(ccdir / 'include-fixed')
-		endif
-
 		rtld_include_dirs += include_directories(ccdir / 'include')
 		libc_include_dirs += include_directories(ccdir / 'include')
 	endif


### PR DESCRIPTION
The feature is generally broken, abused for unrelated things, and breaks perfectly correct headers - a fact that seems to not bother upstream GCC. We should not use this, and discourage sysdeps to use toolchains that enable it.