### PR TITLE
options/posix: revert making `TSVTX` XSI-shaded

### DIFF
--- a/options/posix/include/tar.h
+++ b/options/posix/include/tar.h
@@ -20,6 +20,7 @@
 
 #define TSUID 04000
 #define TSGID 02000
+#define TSVTX 01000
 #define TUREAD 00400
 #define TUWRITE 00200
 #define TUEXEC 00100
@@ -29,9 +30,5 @@
 #define TOREAD 00004
 #define TOWRITE 00002
 #define TOEXEC 00001
-
-#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
-#define TSVTX 01000
-#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #endif /* _TAR_H */


### PR DESCRIPTION
This is due to a misreading of the spec that musl also fell into, as evidenced by [Austin Group Issue #1236](https://austingroupbugs.net/view.php?id=1236).