### PR TITLE
abis/linux: expose all XSI-permitted `sys/socket.h` identifiers

### DIFF
--- a/abis/linux/socket.h
+++ b/abis/linux/socket.h
@@ -59,9 +59,9 @@ struct cmsghdr {
 
 #define SCM_RIGHTS 1
 
-#if defined(_DEFAULT_SOURCE)
+#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 #define SCM_CREDENTIALS 2
-#endif /* defined(_DEFAULT_SOURCE) */
+#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #define SHUT_RD 0
 #define SHUT_WR 1
@@ -75,11 +75,11 @@ struct cmsghdr {
 #define SOCK_RAW       3
 #define SOCK_SEQPACKET 5
 
-#if defined(_DEFAULT_SOURCE)
+#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 #define SOCK_RDM       4
 #define SOCK_DCCP      6
 #define SOCK_PACKET    10
-#endif /* defined(_DEFAULT_SOURCE) */
+#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #ifndef SOCK_CLOEXEC
 #define SOCK_CLOEXEC   02000000
@@ -222,7 +222,7 @@ struct cmsghdr {
 #endif
 #endif
 
-#if defined(_DEFAULT_SOURCE)
+#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 #ifndef SO_RCVTIMEO_OLD
 #define SO_RCVTIMEO_OLD 20
 #endif
@@ -296,11 +296,11 @@ struct cmsghdr {
 #define SCM_TXTIME              SO_TXTIME
 #define SO_BINDTOIFINDEX        62
 #define SO_DETACH_REUSEPORT_BPF 68
-#endif /* defined(_DEFAULT_SOURCE) */
+#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #define SOL_SOCKET      1
 
-#if defined(_DEFAULT_SOURCE)
+#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 #define SOL_IP          0
 #define SOL_IPV6        41
 #define SOL_ICMPV6      58
@@ -329,7 +329,7 @@ struct cmsghdr {
 #define SOL_KCM         281
 #define SOL_TLS         282
 #define SOL_XDP         283
-#endif /* defined(_DEFAULT_SOURCE) */
+#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #define SOMAXCONN       128
 
@@ -343,7 +343,7 @@ struct cmsghdr {
 #define MSG_NOSIGNAL  0x4000
 #define MSG_CMSG_CLOEXEC 0x40000000
 
-#if defined(_DEFAULT_SOURCE)
+#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 #define MSG_PROXY     0x0010
 #define MSG_DONTWAIT  0x0040
 #define MSG_FIN       0x0200
@@ -356,6 +356,6 @@ struct cmsghdr {
 #define MSG_BATCH     0x40000
 #define MSG_ZEROCOPY  0x4000000
 #define MSG_FASTOPEN  0x20000000
-#endif /* defined(_DEFAULT_SOURCE) */
+#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #endif


### PR DESCRIPTION
POSIX permits any identifiers beginning with `AF_`, `MSG_`, `PF_`, `SCM_`, `SHUT_`, `SO` to be part of the namespace of `<sys/socket.h>` under the XSI option.