### PR TITLE
fix: ignore flush errors when exiting

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -405,6 +405,7 @@ internal_sources = [
 	'options/internal/generic/debug.cpp',
 	'options/internal/generic/ensure.cpp',
 	'options/internal/generic/essential.cpp',
+	'options/internal/generic/exiting.cpp',
 	'options/internal/generic/frigg.cpp',
 	'options/internal/generic/getopt.cpp',
 	'options/internal/generic/global-config.cpp',

--- a/options/ansi/generic/stdlib.cpp
+++ b/options/ansi/generic/stdlib.cpp
@@ -22,6 +22,7 @@
 #include <mlibc/strtol.hpp>
 #include <mlibc/threads.hpp>
 #include <mlibc/global-config.hpp>
+#include <mlibc/exit.hpp>
 
 #if __MLIBC_POSIX_OPTION
 #include <pthread.h>
@@ -217,6 +218,8 @@ void exit(int status) {
 	// for concurrent calls to exit() or quick_exit(), all but the first shall block until termination
 	// see https://austingroupbugs.net/view.php?id=1845
 	mlibc::thread_mutex_lock(&exit_mutex);
+
+	mlibc::processIsExiting.store(true, std::memory_order_relaxed);
 
 	__mlibc_do_finalize();
 	mlibc::sys_exit(status);

--- a/options/internal/generic/exiting.cpp
+++ b/options/internal/generic/exiting.cpp
@@ -1,0 +1,5 @@
+#include <mlibc/exit.hpp>
+
+namespace mlibc {
+std::atomic<bool> processIsExiting = false;
+} // namespace mlibc

--- a/options/internal/include/mlibc/exit.hpp
+++ b/options/internal/include/mlibc/exit.hpp
@@ -1,0 +1,10 @@
+#ifndef MLIBC_EXIT_HPP
+#define MLIBC_EXIT_HPP
+
+#include <atomic>
+
+namespace mlibc {
+extern std::atomic<bool> processIsExiting;
+} // namespace mlibc
+
+#endif


### PR DESCRIPTION
When a process closes stdout and stderr before exiting (such as all the coreutils), mlibc complains that it cannot flush stdout stderr.
This pr adds a variable "isExiting" that gets set as true when exiting, and removes the error logs when trying to flush stdout and stderr