### PR TITLE
[ABI BREAK] abis/linux: make sa_flags POSIX-compliant

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -28,6 +28,7 @@ This document lists the ABI breaks that were made in each mlibc major version.
 - [#1492](https://github.com/managarm/mlibc/pull/1492): changes the values of `LC_*` macros and `nl_item` values to match glibc, so that glibc locale files can be consumed.
 - [#1492](https://github.com/managarm/mlibc/pull/1492): fix `struct epoll_event` alignment on x86
 - [#1544](https://github.com/managarm/mlibc/pull/1544): extend `jmp_buf` so that it matches the definition of `sigjmp_buf`
+- [#1621](https://github.com/managarm/mlibc/pull/1621): make `sigaction->sa_flags` an `int` as per POSIX
 
 ## Version 6
 

--- a/abis/linux/signal.h
+++ b/abis/linux/signal.h
@@ -219,7 +219,7 @@ struct sigaction {
 		void (*sa_handler)(int);
 		void (*sa_sigaction)(int, siginfo_t *, void *);
 	} __sa_handler;
-	unsigned long sa_flags;
+	int sa_flags;
 	void (*sa_restorer)(void);
 	sigset_t sa_mask;
 };


### PR DESCRIPTION
This does not change the struct size or alignment, but on 64-bit architectures the member is smaller and this implicitly adds padding.