### PR TITLE
[ABI BREAK] options/ansi: correctly set `math_errhandling`

### DIFF
--- a/ABI_BREAKS.md
+++ b/ABI_BREAKS.md
@@ -30,6 +30,7 @@ This document lists the ABI breaks that were made in each mlibc major version.
 - [#1544](https://github.com/managarm/mlibc/pull/1544): extend `jmp_buf` so that it matches the definition of `sigjmp_buf`
 - [#1621](https://github.com/managarm/mlibc/pull/1621): make `sigaction->sa_flags` an `int` as per POSIX
 - [#1647](https://github.com/managarm/mlibc/pull/1647): all `_PC_*` constants are aligned to Linux kernel ABI
+- [#1743](https://github.com/managarm/mlibc/pull/1743): change the value of `math_errhandling` from `MATH_ERRNO|MATH_ERREXCEPT` to `MATH_ERREXCEPT`, as our libm does not set errno.
 
 ## Version 6
 

--- a/options/ansi/include/math.h
+++ b/options/ansi/include/math.h
@@ -44,7 +44,7 @@ typedef float float_t;
 
 #define MATH_ERRNO 1
 #define MATH_ERREXCEPT 2
-#define math_errhandling 3
+#define math_errhandling MATH_ERREXCEPT
 
 /* [C11/7.12.3 Classification macros] */
 


### PR DESCRIPTION
We should not set `MATH_ERRNO`, as our math functions do not touch `errno` at all. This was detected by os-test's `basic/math` tests.