### PR TITLE
Sink signature rework

### DIFF
--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -359,6 +359,15 @@ int fputws_unlocked(const wchar_t *__restrict ws, mlibc::abstract_file *f) {
 	return 1;
 }
 
+template <typename From, typename To = std::conditional_t<std::is_same_v<From, char>, wchar_t, char>>
+size_t convertString(To *dest, const From **__restrict src, size_t src_max, size_t dest_max, mbstate_t *__restrict ps) {
+	if constexpr (std::is_same_v<From, char>) {
+		return mbsnrtowcs(dest, src, src_max, dest_max, ps);
+	} else {
+		return wcsnrtombs(dest, src, src_max, dest_max, ps);
+	}
+}
+
 } // namespace
 
 template <typename Char>
@@ -410,48 +419,18 @@ struct StreamPrinter {
 		}
 	}
 
-	void append(const char *str, size_t n)
-	requires (std::is_same_v<Char, wchar_t>) {
-		wchar_t buf[512];
+	template <typename C>
+	void append(const C *str, size_t n)
+	requires (!std::is_same_v<Char, C>) {
+		Char buf[512];
 		mbstate_t state = { };
 
-		const char *curr = str;
-		size_t remaining = n;
+		const C *curr = str;
 
-		while (remaining > 0 && curr) {
-			const char *start = curr;
+		while (n > 0 && curr) {
+			const C *start = curr;
 
-			size_t num_wchars = mbsnrtowcs(buf, &curr, remaining, sizeof(buf), &state);
-			if (num_wchars == size_t(-1))
-				return;
-
-			append(buf, num_wchars);
-
-			if (!curr) {
-				break;
-			} else {
-				size_t consumed = curr - start;
-
-				if (consumed > remaining || !consumed)
-					break;
-
-				remaining -= consumed;
-			}
-		}
-	}
-
-	void append(const wchar_t *str, size_t n)
-	requires (std::is_same_v<Char, char>) {
-		char buf[512];
-		mbstate_t state = { };
-
-		const wchar_t *curr = str;
-		size_t remaining = n;
-
-		while (remaining > 0 && curr) {
-			const wchar_t *start = curr;
-
-			size_t num_chars = wcsnrtombs(buf, &curr, remaining, sizeof(buf), &state);
+			size_t num_chars = convertString(buf, &curr, n, sizeof(buf) / sizeof(*buf), &state);
 			if (num_chars == size_t(-1))
 				return;
 
@@ -462,17 +441,56 @@ struct StreamPrinter {
 			} else {
 				size_t consumed = curr - start;
 
-				if (consumed > remaining || !consumed)
+				if (consumed > n || !consumed)
 					break;
 
-				remaining -= consumed;
+				n -= consumed;
 			}
 		}
+	}
+
+	template <typename C>
+	void append(const C *str, size_t src_max, size_t dest_max)
+	requires (!std::is_same_v<Char, C>) {
+		Char buf[512];
+		mbstate_t state = { };
+		const C *curr = str;
+
+		while (src_max > 0 && dest_max > 0 && curr) {
+			const C *start = curr;
+
+			size_t num_chars = convertString(buf, &curr, frg::min(sizeof(buf), src_max), dest_max, &state);
+			if (num_chars == size_t(-1))
+				return;
+
+			append(buf, num_chars);
+			dest_max -= num_chars;
+
+			if (!curr) {
+				break;
+			} else {
+				size_t consumed = curr - start;
+
+				if (consumed > src_max || !consumed)
+					break;
+
+				src_max -= consumed;
+			}
+		}
+	}
+
+	void append(const Char *str, size_t src_max, size_t dest_max) {
+		append(str, frg::min(src_max, dest_max));
 	}
 
 	mlibc::abstract_file *stream;
 	size_t count;
 };
+
+static_assert(frg::SinkFor<StreamPrinter<char>>);
+static_assert(frg::SinkFor<StreamPrinter<char>, wchar_t>);
+static_assert(frg::SinkFor<StreamPrinter<wchar_t>>);
+static_assert(frg::SinkFor<StreamPrinter<wchar_t>, wchar_t>);
 
 template <typename Char>
 struct BufferPrinter {

--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -713,6 +713,10 @@ struct ResizePrinter {
 			append(str[i]);
 	}
 
+	void append(const char *str, size_t n, size_t m) {
+		return append(str, frg::min(n, m));
+	}
+
 	void append(const wchar_t *str, size_t n) {
 		char buf[512];
 		mbstate_t state = { };
@@ -746,6 +750,8 @@ struct ResizePrinter {
 	size_t limit;
 	size_t count;
 };
+
+static_assert(frg::SinkFor<ResizePrinter>);
 
 int remove(const char *filename) {
 	if(int e = mlibc::sysdep_or_enosys<Rmdir>(filename); e) {

--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -24,6 +24,8 @@
 #include <mlibc/locale.hpp>
 #include <mlibc/lock.hpp>
 #include <mlibc/stdlib.hpp>
+#include <mlibc/strings.hpp>
+#include <mlibc/wide.hpp>
 
 template<typename Char, typename F>
 struct PrintfAgent {
@@ -575,96 +577,107 @@ struct LimitedPrinter {
 		count++;
 	}
 
-	void append(const char *str) {
-		for(size_t i = 0; str[i]; i++)
-			append(str[i]);
-	}
-
-	void append(const wchar_t *ws) {
-		for(size_t i = 0; ws[i]; i++)
-			append(ws[i]);
-	}
-
-	void append(const char *str, size_t n)
-	requires (std::is_same_v<Char, char>) {
-		for(size_t i = 0; str[i] && n; i++, n--)
-			append(str[i]);
-	}
-
-	void append(const char *str, size_t n)
+	void append(char c)
 	requires (std::is_same_v<Char, wchar_t>) {
-		wchar_t buf[512];
-		mbstate_t state = { };
-
-		const char *curr = str;
-		size_t remaining = frg::min(n, limit - count);
-
-		while (remaining > 0 && curr) {
-			const char *start = curr;
-
-			size_t num_wchars = mbsnrtowcs(buf, &curr, remaining, sizeof(buf), &state);
-			if (num_wchars == size_t(-1))
-				return;
-
-			append(buf, num_wchars);
-
-			if (!curr) {
-				break;
-			} else {
-				size_t consumed = curr - start;
-
-				if (consumed > remaining)
-					break;
-
-				remaining -= consumed;
-			}
+		if (count < limit) {
+			auto ret = btowc(c);
+			if (ret != WEOF)
+				buffer[count++] = ret;
+		} else {
+			count++;
 		}
 	}
 
-	void append(const wchar_t *ws, size_t n)
-	requires (std::is_same_v<Char, wchar_t>) {
-		if (count == limit)
-			return;
-
-		for(size_t i = 0; ws[i] && n; i++, n--)
-			append(ws[i]);
-		count += n;
-	}
-
-	void append(const wchar_t *str, size_t n)
+	void append(wchar_t wc)
 	requires (std::is_same_v<Char, char>) {
-		char buf[512];
-		mbstate_t state = { };
-
-		const wchar_t *curr = str;
-		size_t remaining = frg::min(n, limit - count);
-
-		while (remaining > 0 && curr) {
-			const wchar_t *start = curr;
-
-			size_t num_chars = wcsnrtombs(buf, &curr, remaining, sizeof(buf), &state);
-			if (num_chars == size_t(-1))
-				return;
-
-			append(buf, num_chars);
-
-			if (!curr) {
-				break;
-			} else {
-				size_t consumed = curr - start;
-
-				if (consumed > remaining || !consumed)
-					break;
-
-				remaining -= consumed;
-			}
+		mbstate_t state = {};
+		if (count < limit) {
+			auto ret = wcrtomb(buffer + count, wc, &state);
+			if (ret != static_cast<size_t>(-1))
+				count += ret;
+		} else {
+			char mb[MB_CUR_MAX];
+			auto ret = wcrtomb(mb, wc, &state);
+			if (ret != static_cast<size_t>(-1))
+				count += ret;
 		}
 	}
 
+	template <typename C>
+	void append(const C *s) {
+		auto str_len = frg::generic_strlen(s);
+		append(s, str_len, SIZE_MAX);
+	}
+
+	template <typename C>
+	void append(const C *str, size_t n) {
+		append(str, n, SIZE_MAX);
+	}
+
+	void append(const char *str, size_t src_max, size_t dest_max)
+	requires (std::is_same_v<Char, char>) {
+		auto str_len = mlibc::strnlen(str, src_max);
+		auto copy_len = frg::min(str_len, frg::min(dest_max, remaining()));
+		strncpy(buffer + count, str, copy_len);
+		count += str_len;
+	}
+
+	void append(const char *str, size_t src_max, size_t dest_max)
+	requires (std::is_same_v<Char, wchar_t>) {
+		const char *src = str;
+		mbstate_t state = {};
+		size_t total = mbsnrtowcs(nullptr, &src, src_max, 0, &state);
+
+		if (count < limit) {
+			src = str;
+			state = {};
+			mbsnrtowcs(buffer + count, &src, src_max, frg::min(dest_max, remaining()), &state);
+		}
+
+		count += frg::min(total, dest_max);
+	}
+
+	void append(const wchar_t *str, size_t src_max, size_t dest_max)
+	requires (std::is_same_v<Char, char>) {
+		const wchar_t *src = str;
+		mbstate_t state = {};
+		size_t total = wcsnrtombs(nullptr, &src, src_max, 0, &state);
+
+		if (count < limit) {
+			src = str;
+			state = {};
+			wcsnrtombs(buffer + count, &src, src_max, frg::min(dest_max, remaining()), &state);
+		}
+
+		count += frg::min(total, dest_max);
+	}
+
+	void append(const wchar_t *str, size_t src_max, size_t dest_max)
+	requires (std::is_same_v<Char, wchar_t>) {
+		auto str_len = mlibc::wcsnlen(str, src_max);
+		auto copy_len = frg::min(str_len, frg::min(dest_max, remaining()));
+		wcsncpy(buffer + count, str, copy_len);
+		count += str_len;
+	}
+
+	size_t remaining() const {
+		if (count < limit)
+			return limit - count;
+		return 0;
+	}
+
+	// The number of valid bytes in the buffer is min(limit, count).
 	Char *buffer;
+	// Maximum number of charcters to output.
 	size_t limit;
+	// Tracks the number of characters that would be output.
 	size_t count;
 };
+
+static_assert(frg::SinkFor<LimitedPrinter<char>>);
+static_assert(frg::SinkFor<LimitedPrinter<char>, wchar_t>);
+static_assert(frg::SinkFor<LimitedPrinter<wchar_t>>);
+static_assert(frg::SinkFor<LimitedPrinter<wchar_t>, wchar_t>);
 
 struct ResizePrinter {
 	using char_type = char;

--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -504,83 +504,64 @@ struct BufferPrinter {
 		count++;
 	}
 
-	void append(const Char *str) {
-		for(size_t i = 0; str[i]; i++) {
-			buffer[count] = str[i];
-			count++;
-		}
-	}
-
-	void append(const Char *str, size_t n) {
-		for(size_t i = 0; i < n; i++) {
-			buffer[count] = str[i];
-			count++;
-		}
-	}
-
-	void append(const char *str, size_t n)
+	void append(char c)
 	requires (std::is_same_v<Char, wchar_t>) {
-		wchar_t buf[512];
-		mbstate_t state = { };
-
-		const char *curr = str;
-		size_t remaining = n;
-
-		while (remaining > 0 && curr) {
-			const char *start = curr;
-
-			size_t num_wchars = mbsnrtowcs(buf, &curr, remaining, sizeof(buf), &state);
-			if (num_wchars == size_t(-1))
-				return;
-
-			append(buf, num_wchars);
-
-			if (!curr) {
-				break;
-			} else {
-				size_t consumed = curr - start;
-
-				if (consumed > remaining)
-					break;
-
-				remaining -= consumed;
-			}
-		}
+		auto ret = btowc(c);
+		if (ret != WEOF)
+			buffer[count++] = ret;
 	}
 
-	void append(const wchar_t *str, size_t n)
+	void append(wchar_t wc)
 	requires (std::is_same_v<Char, char>) {
-		char buf[512];
-		mbstate_t state = { };
+		mbstate_t state = {};
+		auto ret = wcrtomb(buffer + count, wc, &state);
+		if (ret != static_cast<size_t>(-1))
+			count += ret;
+	}
 
-		const wchar_t *curr = str;
-		size_t remaining = n;
+	template <typename C>
+	void append(const C *s) {
+		auto str_len = frg::generic_strlen(s);
+		append(s, str_len, SIZE_MAX);
+	}
 
-		while (remaining > 0 && curr) {
-			const wchar_t *start = curr;
+	template <typename C>
+	void append(const C *str, size_t n) {
+		append(str, n, SIZE_MAX);
+	}
 
-			size_t num_chars = wcsnrtombs(buf, &curr, remaining, sizeof(buf), &state);
-			if (num_chars == size_t(-1))
-				return;
+	void append(const char *str, size_t src_max, size_t dest_max)
+	requires (std::is_same_v<Char, char>) {
+		auto str_len = frg::min(mlibc::strnlen(str, src_max), dest_max);
+		memcpy(buffer + count, str, str_len);
+		count += str_len;
+	}
 
-			append(buf, num_chars);
+	void append(const wchar_t *str, size_t src_max, size_t dest_max)
+	requires (std::is_same_v<Char, wchar_t>) {
+		auto str_len = frg::min(mlibc::wcsnlen(str, src_max), dest_max);
+		wcsncpy(buffer + count, str, str_len);
+		count += str_len;
+	}
 
-			if (!curr) {
-				break;
-			} else {
-				size_t consumed = curr - start;
-
-				if (consumed > remaining || !consumed)
-					break;
-
-				remaining -= consumed;
-			}
-		}
+	template <typename C>
+	void append(const C *str, size_t src_max, size_t dest_max)
+	requires (!std::is_same_v<C, Char>) {
+		const C *src = str;
+		mbstate_t state = {};
+		size_t written = convertString(buffer + count, &src, src_max, dest_max, &state);
+		if (written != static_cast<size_t>(-1))
+			count += written;
 	}
 
 	Char *buffer;
 	size_t count;
 };
+
+static_assert(frg::SinkFor<BufferPrinter<char>>);
+static_assert(frg::SinkFor<BufferPrinter<char>, wchar_t>);
+static_assert(frg::SinkFor<BufferPrinter<wchar_t>>);
+static_assert(frg::SinkFor<BufferPrinter<wchar_t>, wchar_t>);
 
 template <typename Char>
 struct LimitedPrinter {

--- a/options/ansi/generic/wchar.cpp
+++ b/options/ansi/generic/wchar.cpp
@@ -294,7 +294,10 @@ size_t wcsnrtombs(char *__restrict mbs, const wchar_t **__restrict wcsp, size_t 
 		if(n < mb_limit) // Null-terminate resulting wide string.
 			mbs[n] = 0;
 		return n;
-	} else if (e == mlibc::transcode_status::input_underflow || e == mlibc::transcode_status::input_exhausted || e == mlibc::transcode_status::output_exhausted) {
+	} else if (e == mlibc::transcode_status::input_underflow
+	           || e == mlibc::transcode_status::output_overflow
+	           || e == mlibc::transcode_status::input_exhausted
+	           || e == mlibc::transcode_status::output_exhausted) {
 		size_t n = nseq.it - mbs;
 		*wcsp = wseq.it;
 		return n;

--- a/options/ansi/include/wchar.h
+++ b/options/ansi/include/wchar.h
@@ -111,7 +111,7 @@ size_t mbsrtowcs(wchar_t *__restrict __wcs, const char **__restrict __mbs, size_
 size_t mbsnrtowcs(wchar_t *__restrict __wcs, const char **__restrict __mbs, size_t __mb_limit, size_t __wc_limit,
 		mbstate_t *__restrict __stp);
 size_t wcsrtombs(char *__restrict __mbs, const wchar_t **__restrict __wcs, size_t __mb_limit, mbstate_t *__restrict __stp);
-size_t wcsnrtombs(char *__restrict __mbs, const wchar_t **__restrict __wcs, size_t __mb_limit, size_t __wc_limit,
+size_t wcsnrtombs(char *__restrict __mbs, const wchar_t **__restrict __wcs, size_t __wc_limit, size_t __mb_limit,
 		mbstate_t *__restrict __stp);
 
 /* POSIX extensions */

--- a/options/internal/generic/wide.cpp
+++ b/options/internal/generic/wide.cpp
@@ -22,4 +22,11 @@ wctrans_t find_wctrans(frg::string_view property, mlibc::localeinfo *l) {
 	return 0;
 }
 
+size_t wcsnlen(const wchar_t *ws, size_t maxlen) {
+	const wchar_t *p = ws;
+	while (maxlen --> 0 && *p != L'\0')
+		p++;
+	return p - ws;
+}
+
 } // namespace mlibc

--- a/options/internal/include/mlibc/wide.hpp
+++ b/options/internal/include/mlibc/wide.hpp
@@ -7,4 +7,6 @@ namespace mlibc {
 
 wctrans_t find_wctrans(frg::string_view name, mlibc::localeinfo *l);
 
+size_t wcsnlen(const wchar_t *ws, size_t maxlen);
+
 } // namespace mlibc

--- a/options/posix/generic/monetary.cpp
+++ b/options/posix/generic/monetary.cpp
@@ -37,6 +37,10 @@ struct BufferSink {
 		return true;
 	}
 
+	bool append(const char *str, size_t n, size_t m) {
+		return append(str, frg::min(n, m));
+	}
+
 	std::optional<ssize_t> finalize() {
 		if (!append('\0'))
 			return std::nullopt;
@@ -45,6 +49,8 @@ struct BufferSink {
 		return usedsize - 1;
 	}
 };
+
+static_assert(frg::SinkFor<BufferSink>);
 
 ssize_t strfmon_internal(char *__restrict s, size_t maxsize, mlibc::localeinfo *locale, const char *__restrict format, va_list ap) {
 	auto stripNullTerminator = [](frg::string_view v) {

--- a/options/posix/generic/wchar.cpp
+++ b/options/posix/generic/wchar.cpp
@@ -14,6 +14,7 @@
 
 #include <mlibc/charcode.hpp>
 #include <mlibc/debug.hpp>
+#include <mlibc/wide.hpp>
 
 /*
  * The code in this anonymous namespace and the wcwidth function below
@@ -580,10 +581,7 @@ int wcscasecmp(const wchar_t *ws1, const wchar_t *ws2) {
 }
 
 size_t wcsnlen(const wchar_t *ws, size_t maxlen) {
-	const wchar_t *p = ws;
-	while (maxlen --> 0 && *p != L'\0')
-		p++;
-	return p - ws;
+	return mlibc::wcsnlen(ws, maxlen);
 }
 
 size_t wcslcat(wchar_t *__restrict dst, const wchar_t *__restrict src, size_t dstsize) {


### PR DESCRIPTION
This PR adds a `append(Char *str, size_t input_max, size_t ouput_max)` function to all sinks. This aims to allow to limit both the number of characters to input (e.g. for supplying non-zero terminated strings) and to limit the number of characters to output (e.g. for implementing precision for `%ls` in printf or %s in wprintf). This also neatly translates to the `mbsnrtowcs`/`wcsnrtombs` functions, which we use to do wide <=> mb conversion.