### PR TITLE
options/bsd-procdesc: new option for FreeBSD-style process descriptors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -306,6 +306,7 @@ posix_option = get_option('posix_option').require(sysdep_supported_options.get('
 linux_option = get_option('linux_option').require(sysdep_supported_options.get('linux', false)).allowed()
 glibc_option = get_option('glibc_option').require(sysdep_supported_options.get('glibc', false)).allowed()
 bsd_option = get_option('bsd_option').require(sysdep_supported_options.get('bsd', false)).allowed()
+bsd_procdesc_option = sysdep_supported_options.get('bsd-procdesc', false)
 linux_epoll_option = sysdep_supported_options.get('linux-epoll', linux_option)
 linux_timerfd_option = sysdep_supported_options.get('linux-timerfd', linux_option)
 linux_signalfd_option = sysdep_supported_options.get('linux-signalfd', linux_option)
@@ -317,6 +318,7 @@ mlibc_conf.set10('__MLIBC_POSIX_OPTION', posix_option)
 mlibc_conf.set10('__MLIBC_LINUX_OPTION', linux_option)
 mlibc_conf.set10('__MLIBC_GLIBC_OPTION', glibc_option)
 mlibc_conf.set10('__MLIBC_BSD_OPTION', bsd_option)
+mlibc_conf.set10('__MLIBC_BSD_PROCDESC_OPTION', bsd_procdesc_option)
 mlibc_conf.set10('__MLIBC_LINUX_EPOLL_OPTION', linux_epoll_option)
 mlibc_conf.set10('__MLIBC_LINUX_TIMERFD_OPTION', linux_timerfd_option)
 mlibc_conf.set10('__MLIBC_LINUX_SIGNALFD_OPTION', linux_signalfd_option)
@@ -388,6 +390,11 @@ endif
 if bsd_option
 	rtld_include_dirs += include_directories('options/bsd/include')
 	libc_include_dirs += include_directories('options/bsd/include')
+endif
+
+if bsd_procdesc_option
+	rtld_include_dirs += include_directories('options/bsd-procdesc/include')
+	libc_include_dirs += include_directories('options/bsd-procdesc/include')
 endif
 
 if linux_epoll_option
@@ -536,6 +543,7 @@ subdir('options/glibc')
 subdir('options/linux-wrappers')
 subdir('options/linux')
 subdir('options/bsd')
+subdir('options/bsd-procdesc')
 subdir('options/linux-epoll')
 subdir('options/linux-timerfd')
 subdir('options/linux-signalfd')

--- a/mlibc-config.h.in
+++ b/mlibc-config.h.in
@@ -96,6 +96,7 @@
 #endif
 
 #mesondefine __MLIBC_BSD_OPTION
+#mesondefine __MLIBC_BSD_PROCDESC_OPTION
 #mesondefine __MLIBC_LINUX_EPOLL_OPTION
 #mesondefine __MLIBC_LINUX_TIMERFD_OPTION
 #mesondefine __MLIBC_LINUX_SIGNALFD_OPTION

--- a/options/bsd-procdesc/generic/sys-procdesc.cpp
+++ b/options/bsd-procdesc/generic/sys-procdesc.cpp
@@ -1,0 +1,77 @@
+
+#include <errno.h>
+#include <sys/procdesc.h>
+
+#include <bits/ensure.h>
+#include <mlibc/all-sysdeps.hpp>
+#include <mlibc/debug.hpp>
+#include <mlibc/tid.hpp>
+#include <mlibc/thread.hpp>
+
+pid_t pdfork(int *fdp, int flags) {
+	auto self = mlibc::get_current_tcb();
+	pid_t child;
+
+	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Pdfork>, -1);
+
+	auto hand = self->atforkEnd;
+	while (hand) {
+		if (hand->prepare)
+			hand->prepare();
+
+		hand = hand->prev;
+	}
+
+	if(int e = mlibc::sysdep_or_panic<Pdfork>(fdp, flags, &child); e) {
+		errno = e;
+		return -1;
+	}
+
+	// update the cached TID in the TCB
+	if (!child)
+		__atomic_store_n(&self->tid, mlibc::refetch_tid(), __ATOMIC_RELAXED);
+
+	hand = self->atforkBegin;
+	while (hand) {
+		if (!child) {
+			if (hand->child)
+				hand->child();
+		} else {
+			if (hand->parent)
+				hand->parent();
+		}
+		hand = hand->next;
+	}
+
+	return child;
+}
+
+int pdkill(int fd, int sig) {
+	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Pdkill>, -1);
+
+	if (int e = mlibc::sysdep_or_enosys<Pdkill>(fd, sig); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
+}
+
+int pdgetpid(int fd, pid_t *pidp) {
+	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Pdgetpid>, -1);
+
+	if (int e = mlibc::sysdep_or_enosys<Pdgetpid>(fd, pidp); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
+}
+
+int pdwait(int fd, int *status, int options, struct __wrusage *rusage, siginfo_t *info) {
+	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Pdwait>, -1);
+
+	if (int e = mlibc::sysdep_or_enosys<Pdwait>(fd, status, options, rusage, info); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
+}

--- a/options/bsd-procdesc/generic/sys-procdesc.cpp
+++ b/options/bsd-procdesc/generic/sys-procdesc.cpp
@@ -1,0 +1,71 @@
+
+#include <errno.h>
+#include <sys/procdesc.h>
+
+#include <bits/ensure.h>
+#include <mlibc/all-sysdeps.hpp>
+#include <mlibc/debug.hpp>
+#include <mlibc/tid.hpp>
+#include <mlibc/thread.hpp>
+
+pid_t pdfork(int *fdp, int flags) {
+	auto self = mlibc::get_current_tcb();
+	pid_t child;
+
+	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Pdfork>, -1);
+
+	auto hand = self->atforkEnd;
+	while (hand) {
+		if (hand->prepare)
+			hand->prepare();
+
+		hand = hand->prev;
+	}
+
+	if(int e = mlibc::sysdep_or_panic<Pdfork>(fdp, flags, &child); e) {
+		errno = e;
+		return -1;
+	}
+
+	// update the cached TID in the TCB
+	if (!child)
+		__atomic_store_n(&self->tid, mlibc::refetch_tid(), __ATOMIC_RELAXED);
+
+	hand = self->atforkBegin;
+	while (hand) {
+		if (!child) {
+			if (hand->child)
+				hand->child();
+		} else {
+			if (hand->parent)
+				hand->parent();
+		}
+		hand = hand->next;
+	}
+
+	return child;
+}
+
+int pdkill(int fd, int sig) {
+	if (int e = mlibc::sysdep_or_enosys<Pdkill>(fd, sig); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
+}
+
+int pdgetpid(int fd, pid_t *pidp) {
+	if (int e = mlibc::sysdep_or_enosys<Pdgetpid>(fd, pidp); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
+}
+
+int pdwait(int fd, int *status, int options, struct __wrusage *rusage, siginfo_t *info) {
+	if (int e = mlibc::sysdep_or_enosys<Pdwait>(fd, status, options, rusage, info); e) {
+		errno = e;
+		return -1;
+	}
+	return 0;
+}

--- a/options/bsd-procdesc/include/sys/procdesc.h
+++ b/options/bsd-procdesc/include/sys/procdesc.h
@@ -1,0 +1,27 @@
+#ifndef _SYS_PROCDESC_H
+#define _SYS_PROCDESC_H
+
+#include <abi-bits/procdesc.h>
+#include <abi-bits/pid_t.h>
+#include <abi-bits/signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __MLIBC_ABI_ONLY
+
+struct __wrusage;
+
+pid_t pdfork(int *__fdp, int __flags);
+int pdkill(int __fd, int __sig);
+int pdgetpid(int __fd, pid_t *__pidp);
+int pdwait(int __fd, int *__status, int __options, struct __wrusage *__wrusage, siginfo_t *__siginfo);
+
+#endif /* !__MLIBC_ABI_ONLY */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_PROCDESC_H */

--- a/options/bsd-procdesc/meson.build
+++ b/options/bsd-procdesc/meson.build
@@ -1,0 +1,15 @@
+if not bsd_procdesc_option
+	subdir_done()
+endif
+
+libc_sources += files(
+	'generic/sys-procdesc.cpp',
+)
+
+if not no_headers
+	install_headers(
+		'include/sys/procdesc.h',
+		subdir: 'sys'
+	)
+endif
+

--- a/options/internal/include/mlibc/sysdep-signatures.hpp
+++ b/options/internal/include/mlibc/sysdep-signatures.hpp
@@ -353,6 +353,13 @@ SYSDEP_FUNC(GetLoadavg, double *samples);
 SYSDEP_FUNC(Openpty, int *mfd, int *sfd, char *name, const struct termios *ios, const struct winsize *win);
 #endif // __MLIBC_BSD_OPTION
 
+#if __MLIBC_BSD_PROCDESC_OPTION
+SYSDEP_FUNC(Pdfork, int *fdp, int flags, pid_t *child);
+SYSDEP_FUNC(Pdkill, int fd, int sig);
+SYSDEP_FUNC(Pdgetpid, int fd, pid_t *pidp);
+SYSDEP_FUNC(Pdwait, int fd, int *status, int options, struct __wrusage *rusage, siginfo_t *info);
+#endif // __MLIBC_BSD_PROCDESC_OPTION
+
 #if __MLIBC_GLIBC_OPTION
 SYSDEP_FUNC(Personality, unsigned long persona, int *out);
 SYSDEP_FUNC(Ioperm, unsigned long int from, unsigned long int num, int turn_on);

--- a/options/internal/include/mlibc/sysdep-tags.hpp
+++ b/options/internal/include/mlibc/sysdep-tags.hpp
@@ -151,6 +151,24 @@ struct GetLoadavg {};
 struct Openpty {};
 #endif // __MLIBC_BSD_OPTION
 
+#if __MLIBC_BSD_PROCDESC_OPTION
+#include <abi-bits/signal.h>
+#include <sys/procdesc.h>
+
+// int sys_pdfork(int *fdp, int flags, pid_t *child);
+struct Pdfork {};
+
+// int sys_pdkill(int fd, int sig);
+struct Pdkill {};
+
+// int sys_pdgetpid(int fd, pid_t *pidp);
+struct Pdgetpid {};
+
+// int sys_pdwait(int fd, int *status, int options, struct __wrusage *rusage, siginfo_t *info);
+struct Pdwait {};
+
+#endif /* __MLIBC_BSD_PROCDESC_OPTION */
+
 #if __MLIBC_GLIBC_OPTION
 // int sys_personality(unsigned long persona, int *out);
 struct Personality {};


### PR DESCRIPTION
This adds an option for FreeBSD-style process descriptors, an FD-based interface for process creation and management.
Keyronex will use this.