### PR TITLE
options/internal: initialize `GlobalConfig` while avoiding cxa_guard

### DIFF
--- a/options/ansi/generic/environment.cpp
+++ b/options/ansi/generic/environment.cpp
@@ -34,11 +34,16 @@ size_t find_environ_index(frg::string_view name) {
 	return -1;
 }
 
+struct EnvironmentVector {
+	EnvironmentVector() : vector{getAllocator()} {}
+	frg::vector<char *, MemoryAllocator> vector;
+};
+
+constinit mlibc::lazy_eternal<EnvironmentVector> global_vector;
+
 // Environment vector that is mutated by putenv() and setenv().
-// Cannot be global as it is accessed during library initialization.
 frg::vector<char *, MemoryAllocator> &get_vector() {
-	static frg::vector<char *, MemoryAllocator> vector{getAllocator()};
-	return vector;
+	return global_vector.get().vector;
 }
 
 void update_vector() {

--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -44,10 +44,11 @@ namespace {
 	// The maximum number of characters we permit the user to ungetc.
 	constexpr size_t ungetBufferSize = 8;
 
+	constinit mlibc::lazy_eternal<file_list> global_file_list_instance;
+
 	// List of files that will be flushed before exit().
 	file_list &global_file_list() {
-		static frg::eternal<file_list> list;
-		return list.get();
+		return global_file_list_instance.get();
 	};
 } // namespace
 

--- a/options/glibc/generic/shadow.cpp
+++ b/options/glibc/generic/shadow.cpp
@@ -227,10 +227,17 @@ void endspent(void) {
 	mlibc::infoLogger() << "mlibc: endspent is a stub" << frg::endlog;
 }
 
+struct SgetspentBuffer {
+	SgetspentBuffer() : string{getAllocator()} {}
+	frg::string<MemoryAllocator> string;
+};
+
+static constinit mlibc::lazy_eternal<SgetspentBuffer> globalSgetspentBuffer;
+
 struct spwd *sgetspent(const char *s) {
-	static frg::string<MemoryAllocator> buffer{getAllocator()};
 	static struct spwd sp;
 
+	auto &buffer = globalSgetspentBuffer.get().string;
 	buffer = {s, getAllocator()};
 
 	if (__parsespent(buffer.data(), &sp) == 0)

--- a/options/internal/gcc/guard-abi.cpp
+++ b/options/internal/gcc/guard-abi.cpp
@@ -6,89 +6,15 @@
 #include <mlibc/debug.hpp>
 #include <mlibc/tid.hpp>
 
-namespace {
-
-// Itanium ABI static initialization guard.
-struct Guard {
-	static constexpr uint32_t waitersBit = 0x80000000;
-	static constexpr uint32_t ownerMask = 0x3FFFFFFF;
-
-	void lock() {
-		uint32_t tid = mlibc::this_tid();
-		uint32_t expected = 0;
-
-		while (true) {
-			if (!expected) {
-				if (__atomic_compare_exchange_n(
-				        &mutex, &expected, tid, false, __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE
-				    ))
-					return;
-			} else {
-				if ((expected & ownerMask) == tid)
-					mlibc::panicLogger()
-					    << "mlibc: __cxa_guard_acquire deadlock detected!" << frg::endlog;
-
-				if (expected & waitersBit) {
-					int e = mlibc::sysdep<FutexWait>((int *)&mutex, expected, nullptr);
-					if (e && e != EAGAIN && e != EINTR)
-						mlibc::panicLogger()
-						    << "sys_futex_wait() failed with error code " << e << frg::endlog;
-					expected = 0;
-				} else {
-					uint32_t desired = expected | waitersBit;
-					if (__atomic_compare_exchange_n(
-					        &mutex, &expected, desired, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED
-					    ))
-						expected = desired;
-				}
-			}
-		}
-	}
-
-	void unlock() {
-		uint32_t state = __atomic_exchange_n(&mutex, 0, __ATOMIC_RELEASE);
-		__ensure((state & ownerMask) == mlibc::this_tid());
-		if(state & waitersBit)
-			mlibc::sysdep<FutexWake>((int *)&mutex, true);
-	}
-
-	// the first byte's meaning is fixed by the ABI.
-	// it indicates whether initialization has already been completed.
-	uint8_t complete;
-	// padding to ensure correct alignment on certain platforms.
-	uint8_t padding[3];
-
-	// we use some of the remaining bytes to implement a mutex.
-	uint32_t mutex;
-};
-
-static_assert(sizeof(Guard) == sizeof(int64_t));
-
-} // namespace
-
 extern "C" [[ gnu::visibility("hidden") ]] void __cxa_pure_virtual() {
 	mlibc::panicLogger() << "mlibc: Pure virtual function called from IP "
 			<< (void *)__builtin_return_address(0) << frg::endlog;
 }
 
-extern "C" [[ gnu::visibility("hidden") ]] int __cxa_guard_acquire(int64_t *ptr) {
-	auto guard = reinterpret_cast<Guard *>(ptr);
-	guard->lock();
-	// relaxed ordering is sufficient because
-	// Guard::complete is only modified while the mutex is held.
-	if(__atomic_load_n(&guard->complete, __ATOMIC_RELAXED)) {
-		guard->unlock();
-		return 0;
-	}else{
-		return 1;
-	}
-}
+static const char __poison_cxa_guard_acquire[]
+    __attribute__((used, section(".gnu.warning.__cxa_guard_acquire"))) =
+        "mlibc cannot use static singletons, use lazy_eternal instead";
 
-extern "C" [[ gnu::visibility("hidden") ]] void __cxa_guard_release(int64_t *ptr) {
-	auto guard = reinterpret_cast<Guard *>(ptr);
-	// do a store-release so that compiler generated code can skip calling
-	// __cxa_guard_acquire by doing a load-acquire on Guard::complete.
-	__atomic_store_n(&guard->complete, 1, __ATOMIC_RELEASE);
-	guard->unlock();
-}
-
+static const char __poison_cxa_guard_release[]
+    __attribute__((used, section(".gnu.warning.__cxa_guard_release"))) =
+        "mlibc cannot use static singletons, use lazy_eternal instead";

--- a/options/internal/generic/allocator.cpp
+++ b/options/internal/generic/allocator.cpp
@@ -13,13 +13,19 @@
 // Globals
 // --------------------------------------------------------
 
+struct AllocatorPackage {
+	AllocatorPackage()
+	: heap{virtualAllocator}, singleton{&heap} {}
+
+	VirtualAllocator virtualAllocator;
+	MemoryPool heap;
+	MemoryAllocator singleton;
+};
+
+constinit mlibc::lazy_eternal<AllocatorPackage> global_allocator_package;
+
 MemoryAllocator &getAllocator() {
-	// use frg::eternal to prevent a call to __cxa_atexit().
-	// this is necessary because __cxa_atexit() call this function.
-	static frg::eternal<VirtualAllocator> virtualAllocator;
-	static frg::eternal<MemoryPool> heap{virtualAllocator.get()};
-	static frg::eternal<MemoryAllocator> singleton{&heap.get()};
-	return singleton.get();
+	return global_allocator_package.get().singleton;
 }
 
 // --------------------------------------------------------
@@ -199,11 +205,10 @@ size_t MemoryAllocator::get_size(void *ptr) {
 	return meta->allocatedSize;
 }
 
+constinit mlibc::lazy_eternal<MemoryAllocator> global_debug_allocator;
+
 MemoryAllocator &getAllocator() {
-	// use frg::eternal to prevent a call to __cxa_atexit().
-	// this is necessary because __cxa_atexit() call this function.
-	static frg::eternal<MemoryAllocator> singleton{};
-	return singleton.get();
+	return global_debug_allocator.get();
 }
 
 #endif /* !MLIBC_DEBUG_ALLOCATOR */

--- a/options/internal/generic/charcode.cpp
+++ b/options/internal/generic/charcode.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <bits/ensure.h>
 #include <frg/string.hpp>
+#include <mlibc/allocator.hpp>
 #include <mlibc/charcode.hpp>
 #include <mlibc/debug.hpp>
 
@@ -312,9 +313,10 @@ struct polymorphic_charcode_adapter : polymorphic_charcode {
 	}
 };
 
+constinit mlibc::lazy_eternal<polymorphic_charcode_adapter<utf8_charcode>> global_charcode;
+
 polymorphic_charcode *current_charcode() {
-	static polymorphic_charcode_adapter<utf8_charcode> global_charcode;
-	return &global_charcode;
+	return &global_charcode.get();
 }
 
 transcode_status wide_charcode::promote(wchar_t nc, codepoint &wc) {

--- a/options/internal/generic/global-config.cpp
+++ b/options/internal/generic/global-config.cpp
@@ -1,8 +1,14 @@
 #include <stdlib.h>
-#include <string.h>
+#include <mlibc/allocator.hpp>
 #include <mlibc/global-config.hpp>
 
 namespace mlibc {
+
+namespace {
+
+constinit mlibc::lazy_eternal<GlobalConfig> globalConfigInstance;
+
+} // namespace
 
 struct GlobalConfigGuard {
 	GlobalConfigGuard();
@@ -12,7 +18,7 @@ GlobalConfigGuard guard;
 
 GlobalConfigGuard::GlobalConfigGuard() {
 	// Force the config to be created during initialization of libc.so.
-	mlibc::globalConfig();
+	globalConfigInstance.get();
 }
 
 static bool envEnabled(const char *env) {
@@ -27,6 +33,10 @@ GlobalConfig::GlobalConfig() {
 	debugPthreadTrace = envEnabled("MLIBC_DEBUG_PTHREAD_TRACE");
 	debugPathResolution = envEnabled("MLIBC_DEBUG_PATH_RESOLUTION");
 	debugMonetaryLengths = envEnabled("MLIBC_DEBUG_MONETARY_LENGTHS");
+}
+
+const GlobalConfig &globalConfig() {
+	return globalConfigInstance.get();
 }
 
 } // namespace mlibc

--- a/options/internal/include/mlibc/allocator.hpp
+++ b/options/internal/include/mlibc/allocator.hpp
@@ -3,6 +3,7 @@
 
 #include <mlibc/lock.hpp>
 #include <bits/ensure.h>
+#include <frg/manual_box.hpp>
 #include <frg/slab.hpp>
 #include <internal-config.h>
 
@@ -34,5 +35,35 @@ struct MemoryAllocator {
 MemoryAllocator &getAllocator();
 
 #endif // !MLIBC_DEBUG_ALLOCATOR
+
+namespace mlibc {
+
+template <typename T>
+struct lazy_eternal {
+	constexpr lazy_eternal() = default;
+
+	template <typename Self>
+	auto &get(this Self &&self) {
+		if (__atomic_load_n(&self.initialized_, __ATOMIC_ACQUIRE))
+			return *self.box_.get();
+
+		{
+			frg::unique_lock lock{self.lock_};
+			if (!__atomic_load_n(&self.initialized_, __ATOMIC_RELAXED)) {
+				self.box_.initialize();
+				__atomic_store_n(&self.initialized_, 1, __ATOMIC_RELEASE);
+			}
+		}
+
+		return *self.box_.get();
+	}
+
+private:
+	mutable uint32_t initialized_ = 0;
+	mutable FutexLock lock_;
+	mutable frg::manual_box<T> box_;
+};
+
+} // namespace mlibc
 
 #endif // MLIBC_FRIGG_ALLOC

--- a/options/internal/include/mlibc/allocator.hpp
+++ b/options/internal/include/mlibc/allocator.hpp
@@ -3,6 +3,7 @@
 
 #include <mlibc/lock.hpp>
 #include <bits/ensure.h>
+#include <frg/manual_box.hpp>
 #include <frg/slab.hpp>
 #include <internal-config.h>
 
@@ -34,5 +35,35 @@ struct MemoryAllocator {
 MemoryAllocator &getAllocator();
 
 #endif // !MLIBC_DEBUG_ALLOCATOR
+
+namespace mlibc {
+
+template <typename T>
+struct lazy_eternal {
+	constexpr lazy_eternal() = default;
+
+	template <typename Self>
+	auto &get(this Self &self) {
+		if (__atomic_load_n(&self.initialized_, __ATOMIC_ACQUIRE))
+			return *self.box_.get();
+
+		{
+			frg::unique_lock lock{self.lock_};
+			if (!__atomic_load_n(&self.initialized_, __ATOMIC_RELAXED)) {
+				self.box_.initialize();
+				__atomic_store_n(&self.initialized_, 1, __ATOMIC_RELEASE);
+			}
+		}
+
+		return *self.box_.get();
+	}
+
+private:
+	mutable uint32_t initialized_ = 0;
+	mutable FutexLock lock_;
+	mutable frg::manual_box<T> box_;
+};
+
+} // namespace mlibc
 
 #endif // MLIBC_FRIGG_ALLOC

--- a/options/internal/include/mlibc/global-config.hpp
+++ b/options/internal/include/mlibc/global-config.hpp
@@ -14,11 +14,8 @@ struct GlobalConfig {
 	bool debugMonetaryLengths;
 };
 
-inline const GlobalConfig &globalConfig() {
-	static GlobalConfig cached;
-	return cached;
-}
+const GlobalConfig &globalConfig();
 
-}
+} // namespace mlibc
 
 #endif // MLIBC_GLOBAL_CONFIG

--- a/options/internal/include/mlibc/lock.hpp
+++ b/options/internal/include/mlibc/lock.hpp
@@ -14,7 +14,7 @@
 
 template<bool Recursive>
 struct alignas(4) FutexLockImpl {
-	FutexLockImpl() : _state{0}, _recursion{0} { }
+	constexpr FutexLockImpl() : _state{0}, _recursion{0} { }
 
 	FutexLockImpl(const FutexLockImpl &) = delete;
 

--- a/options/lsb/generic/dso_exit.cpp
+++ b/options/lsb/generic/dso_exit.cpp
@@ -16,11 +16,15 @@ struct ExitHandler {
 
 using ExitQueue = frg::vector<ExitHandler, MemoryAllocator>;
 
+struct ExitQueueWrapper {
+	ExitQueueWrapper() : queue{getAllocator()} {}
+	ExitQueue queue;
+};
+
+constinit mlibc::lazy_eternal<ExitQueueWrapper> global_exit_queue;
+
 ExitQueue &getExitQueue() {
-	// use frg::eternal to prevent the compiler from scheduling the destructor
-	// by generating a call to __cxa_atexit().
-	static frg::eternal<ExitQueue> singleton(getAllocator());
-	return singleton.get();
+	return global_exit_queue.get().queue;
 }
 
 extern "C" int __cxa_atexit(void (*function)(void *), void *argument, void *handle) {


### PR DESCRIPTION
LLVM's `libc++` uses pthread mutexes for the `__cxa_guard_{acquire,release}` functions. As `globalConfig` was a static variable, this used the guard, which in turn was used by our pthread mutex implementation. This resulted in unbounded recursion.