### PR TITLE
posix/posix_string: add missing wchar.h include

### DIFF
--- a/options/posix/generic/posix_string.cpp
+++ b/options/posix/generic/posix_string.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <strings.h>
 #include <signal.h>
+#include <wchar.h>
 
 #include <mlibc/debug.hpp>
 #include <mlibc/strings.hpp>


### PR DESCRIPTION
Adds a missing include as to not rely on transitive includes.

Commit was pushed from Astral, BTW :)