### PR TITLE
sysdeps/managarm: handles retries for `superSigSuspend`

### DIFF
--- a/sysdeps/managarm/generic/signals.cpp
+++ b/sysdeps/managarm/generic/signals.cpp
@@ -162,7 +162,11 @@ int Sysdeps<Sigsuspend>::operator()(const sigset_t *set) {
 	    &seq
 	));
 	__ensure(err == 0);
-	HEL_CHECK(helSyscall1(kHelObserveSuperCall + posix::superSigSuspend, seq));
+
+	err = kHelErrCancelled;
+	while (err == kHelErrCancelled)
+		err = helSyscall1(kHelObserveSuperCall + posix::superSigSuspend, seq);
+
 	HEL_CHECK(helSyscall2_3(
 	    kHelObserveSuperCall + posix::superSigMask, SIG_SETMASK, former, &err, &unused, &unused
 	));
@@ -193,7 +197,10 @@ int Sysdeps<Pause>::operator()() {
 	    helSyscall2_3(kHelObserveSuperCall + posix::superSigMask, SIG_BLOCK, set, &err, &former, &seq)
 	);
 	__ensure(err == 0);
-	HEL_CHECK(helSyscall1(kHelObserveSuperCall + posix::superSigSuspend, seq));
+
+	err = kHelErrCancelled;
+	while (err == kHelErrCancelled)
+		err = helSyscall1(kHelObserveSuperCall + posix::superSigSuspend, seq);
 
 	return EINTR;
 }


### PR DESCRIPTION
This is necessary for supporting the restart of e.g. `pause()` by handling of SIGSTOP.