### PR TITLE
options/glibc: add support for `strto*_l` functions

### DIFF
--- a/options/glibc/generic/stdlib.cpp
+++ b/options/glibc/generic/stdlib.cpp
@@ -1,3 +1,5 @@
+#include <mlibc/locale.hpp>
+#include <mlibc/strtol.hpp>
 #include <stdlib.h>
 
 int rpmatch(const char *resp) {
@@ -8,4 +10,24 @@ int rpmatch(const char *resp) {
 	if(resp[0] == 'n' || resp[0] == 'N')
 		return 0;
 	return -1;
+}
+
+long strtol_l(const char *__restrict string, char **__restrict end, int base, locale_t loc) {
+	auto l = static_cast<mlibc::localeinfo *>(loc);
+	return mlibc::stringToInteger<long, char>(string, end, base, l);
+}
+
+long long strtoll_l(const char *__restrict string, char **__restrict end, int base, locale_t loc) {
+	auto l = static_cast<mlibc::localeinfo *>(loc);
+	return mlibc::stringToInteger<long long, char>(string, end, base, l);
+}
+
+unsigned long strtoul_l(const char *__restrict string, char **__restrict end, int base, locale_t loc) {
+	auto l = static_cast<mlibc::localeinfo *>(loc);
+	return mlibc::stringToInteger<unsigned long, char>(string, end, base, l);
+}
+
+unsigned long long strtoull_l(const char *__restrict string, char **__restrict end, int base, locale_t loc) {
+	auto l = static_cast<mlibc::localeinfo *>(loc);
+	return mlibc::stringToInteger<unsigned long long, char>(string, end, base, l);
 }

--- a/options/glibc/include/bits/glibc/glibc_stdlib.h
+++ b/options/glibc/include/bits/glibc/glibc_stdlib.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <mlibc-config.h>
+#include <bits/posix/locale_t.h>
 
 typedef int (*comparison_fn_t) (const void *__a, const void *__b);
 
@@ -14,6 +15,15 @@ typedef int (*comparison_fn_t) (const void *__a, const void *__b);
 #if defined(_DEFAULT_SOURCE)
 int rpmatch(const char *__resp);
 #endif
+
+#if defined(_GNU_SOURCE)
+
+long strtol_l(const char *__restrict __string, char **__restrict __end, int __base, locale_t __loc);
+long long strtoll_l(const char *__restrict __string, char **__restrict __end, int __base, locale_t __loc);
+unsigned long strtoul_l(const char *__restrict __string, char **__restrict __end, int __base, locale_t __loc);
+unsigned long long strtoull_l(const char *__restrict __string, char **__restrict __end, int __base, locale_t __loc);
+
+#endif /* defined(_GNU_SOURCE) */
 
 #endif /* !__MLIBC_ABI_ONLY */
 

--- a/options/internal/generic/ctype.cpp
+++ b/options/internal/generic/ctype.cpp
@@ -51,4 +51,12 @@ int iswascii(int nc) {
 	return cp <= 0x7F;
 }
 
+int iswspace_l(wint_t nc, localeinfo *loc) {
+	auto cc = mlibc::platform_wide_charcode();
+	mlibc::codepoint cp;
+	if(auto e = cc->promote(nc, cp); e != mlibc::transcode_status::input_exhausted)
+		return 0;
+	return mlibc::current_charset()->is_space(cp, static_cast<mlibc::localeinfo *>(loc));
+}
+
 } // namespace mlibc

--- a/options/internal/include/mlibc/ctype.hpp
+++ b/options/internal/include/mlibc/ctype.hpp
@@ -12,5 +12,6 @@ int isxdigit_l(int c, localeinfo *l);
 int tolower_l(int c, localeinfo *l);
 
 int iswascii(int nc);
+int iswspace_l(wint_t nc, localeinfo *l);
 
 } // namespace mlibc

--- a/options/internal/include/mlibc/strtol.hpp
+++ b/options/internal/include/mlibc/strtol.hpp
@@ -1,11 +1,14 @@
-#ifndef MLIBC_STRTOL_HPP
-#define MLIBC_STRTOL_HPP
+#pragma once
 
-#include <type_traits>
 #include <ctype.h>
 #include <errno.h>
-#include <wctype.h>
 #include <limits.h>
+#include <mlibc/ctype.hpp>
+#include <mlibc/charcode.hpp>
+#include <mlibc/charset.hpp>
+#include <mlibc/locale.hpp>
+#include <type_traits>
+#include <wctype.h>
 
 namespace mlibc {
 
@@ -39,7 +42,7 @@ template<typename T> struct char_detail {};
 
 template<>
 struct char_detail<char> {
-	static bool isSpace(char c) { return isspace(c); }
+	static bool isSpace(char c, localeinfo *l) { return mlibc::isspace_l(c, l); }
 	static bool isDigit(char c) { return isdigit(c); }
 	static bool isHexDigit(char c) { return isxdigit(c); }
 	static bool isLower(char c) { return islower(c); }
@@ -48,7 +51,7 @@ struct char_detail<char> {
 
 template<>
 struct char_detail<wchar_t> {
-	static bool isSpace(wchar_t c) { return iswspace(c); }
+	static bool isSpace(wchar_t wc, localeinfo *l) { return mlibc::iswspace_l(wc, l); }
 	static bool isDigit(wchar_t c) { return iswdigit(c); }
 	static bool isHexDigit(wchar_t c) { return iswxdigit(c); }
 	static bool isLower(wchar_t c) { return iswlower(c); }
@@ -58,7 +61,7 @@ struct char_detail<wchar_t> {
 template<typename Char> Char widen(char c) { return static_cast<Char>(c); }
 
 template<typename Return, typename Char>
-Return stringToInteger(const Char *__restrict nptr, Char **__restrict endptr, int baseInt) {
+Return stringToInteger(const Char *__restrict nptr, Char **__restrict endptr, int baseInt, localeinfo *l = getActiveLocale()) {
 	using UnsignedReturn = std::make_unsigned_t<Return>;
 
 	auto base = static_cast<Return>(baseInt);
@@ -70,7 +73,7 @@ Return stringToInteger(const Char *__restrict nptr, Char **__restrict endptr, in
 		return 0;
 	}
 
-	while (char_detail<Char>::isSpace(*s))
+	while (char_detail<Char>::isSpace(*s, l))
 		s++;
 
 	bool negative = false;
@@ -98,7 +101,7 @@ Return stringToInteger(const Char *__restrict nptr, Char **__restrict endptr, in
 		base = 2;
 	} else if ((base == 0 || base == 8) && hasOctalPrefix) {
 		base = 8;
-	} else if (base == 0) { 
+	} else if (base == 0) {
 		base = 10;
 	}
 
@@ -159,6 +162,4 @@ Return stringToInteger(const Char *__restrict nptr, Char **__restrict endptr, in
 	return negative ? -totalValue : totalValue;
 }
 
-}
-
-#endif // MLIBC_STRTOL_HPP
+} // namespace mlibc


### PR DESCRIPTION
Supersedes #1378, as these were the only functions from that PR not yet implemented. This should mean that building libc++ with locale support should work now (untested).