### PR TITLE
libm: constant time fpclassifyf

### DIFF
--- a/options/ansi/musl-generic-math/__fpclassifyf.c
+++ b/options/ansi/musl-generic-math/__fpclassifyf.c
@@ -3,9 +3,13 @@
 
 int __fpclassifyf(float x)
 {
-	union {float f; uint32_t i;} u = {x};
-	int e = u.i>>23 & 0xff;
-	if (!e) return u.i<<1 ? FP_SUBNORMAL : FP_ZERO;
-	if (e==0xff) return u.i<<9 ? FP_NAN : FP_INFINITE;
-	return FP_NORMAL;
+    uint32_t m = (((uint32_t)-1) << 9) >> 9; /* mantissa mask */
+    union {float f; uint32_t i;} u = {x};
+    /* 0xff + 1 = 0, NaN(1) or Infinity(0)
+     * 0x00 + 1 = 1, Subormal(1) or Zero(0)
+     * everything else = 2 */
+    uint8_t c = (u.i>>23 & 0xff) + 1; /* exponent + 1 */
+    c = (c > 2) ? 2 : c;
+    c |= ((u.i & m) != 0) << 2; /* m i i */
+    return 1 << ((0x22312240 >> (c * 4)) & 0xf);
 }


### PR DESCRIPTION
Not tested with real world data.

tested over entire 2^32 range and it matches the original.

of course branchless != good

gcc 16.1
```x86asm
"__fpclassifyf_old":
        vmovd   edx, xmm0
        mov     eax, edx
        shr     eax, 23
        and     eax, 255
        je      .L8
        mov     ecx, 4
        cmp     eax, 255
        je      .L9
        mov     eax, ecx
        ret
.L9:
        sal     edx, 9
        mov     ecx, 1
        cmp     edx, 1
        sbb     ecx, -1
        mov     eax, ecx
        ret
.L8:
        add     edx, edx
        cmp     edx, 1
        sbb     ecx, ecx
        and     ecx, 8
        add     ecx, 8
        mov     eax, ecx
        ret
```

```x86asm
"__fpclassifyf_new":
        vmovd   ecx, xmm0
        mov     edx, 3
        mov     eax, ecx
        shr     eax, 23
        inc     eax
        cmp     al, dl
        cmovbe  edx, eax
        and     ecx, 8388607
        setne   al
        sal     eax, 2
        or      eax, edx
        mov     edx, 573645376
        movzx   eax, al
        sal     eax, 2
        sarx    edx, edx, eax
        mov     eax, 1
        and     edx, 15
        shlx    eax, eax, edx
        ret
```

clangarm
```armasm
__fpclassifyf_old:
        fmov    w1, s0
        ubfx    x2, x1, 23, 8
        cbz     w2, .L8
        mov     w0, 4
        cmp     w2, 255
        beq     .L9
        ret
.L9:
        cmp     wzr, w1, lsl 9
        cset    w0, ne
        add     w0, w0, 1
        ret
.L8:
        cmp     wzr, w1, lsl 1
        mov     w0, 16
        mov     w1, 8
        csel    w0, w0, w1, eq
        ret
```

```armasm
__fpclassifyf_new:
        fmov    w2, s0
        mov     w3, 1
        mov     w4, 3
        mov     w0, 8768
        movk    w0, 0x2231, lsl 16
        add     w1, w3, w2, lsr 23
        and     w1, w1, 255
        cmp     w1, 3
        csel    w1, w1, w4, ls
        tst     x2, 8388607
        cset    w2, ne
        orr     w1, w1, w2, lsl 2
        ubfiz   w1, w1, 2, 8
        asr     w0, w0, w1
        and     w0, w0, 15
        lsl     w0, w3, w0
        ret
```