### PR TITLE
Rtld promotion fix

### DIFF
--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -729,7 +729,12 @@ void *__dlapi_open(const char *file, int flags, void *returnAddress) {
 	// TODO: Thread-safety!
 	auto rts = rtsCounter++;
 
-	SharedObject *object = initialRepository->findLoadedObject(file);
+	auto objectName = frg::string_view{file};
+	auto lastSlash = objectName.find_last('/');
+	if (lastSlash != static_cast<size_t>(-1))
+		objectName = objectName.sub_string(lastSlash + 1, objectName.size() - (lastSlash + 1));
+
+	SharedObject *object = initialRepository->findLoadedObject(objectName);
 	if (object && object->globalRts == 0 && (flags & RTLD_GLOBAL)) {
 		// The object was opened with RTLD_LOCAL, but we are called with RTLD_GLOBAL.
 		// According to the man page, we should promote to the global scope here.

--- a/tests/rtld/promote-lib/meson.build
+++ b/tests/rtld/promote-lib/meson.build
@@ -8,3 +8,7 @@ test_depends = [libone, libtwo]
 libtwo_native = shared_library('native-two', 'libtwo.c', native: true, link_args: mlibc_link_args)
 libone_native = shared_library('native-one', 'libone.c', native: true, link_args: test_additional_link_args + mlibc_link_args)
 test_native_depends = [libone_native, libtwo_native]
+
+test_dir = meson.global_build_root() / 'tests' / 'rtld' / test_name
+test_env += ['MLIBC_RTLD_PROMOTE_LIB_DIR=' + test_dir]
+test_native_env += ['MLIBC_RTLD_PROMOTE_LIB_DIR=' + test_dir]

--- a/tests/rtld/promote-lib/test.c
+++ b/tests/rtld/promote-lib/test.c
@@ -1,5 +1,7 @@
 #include <dlfcn.h>
 #include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 #include <stdio.h>
 
 #ifdef USE_HOST_LIBC
@@ -10,15 +12,33 @@
 #define LIBTWO "libtwo.so"
 #endif
 
-int main() {
-    printf("dlopen'ing libtwo with RTLD_LOCAL...\n");
-    void *libtwo_local = dlopen(LIBTWO, RTLD_LOCAL | RTLD_NOW);
-    assert(libtwo_local);
+static char *library_path(const char *name) {
+	const char *dir = getenv("MLIBC_RTLD_PROMOTE_LIB_DIR");
+	assert(dir);
 
-    printf("dlopen'ing libtwo with RTLD_GLOBAL...\n");
-    void *libtwo_global = dlopen(LIBTWO, RTLD_GLOBAL | RTLD_NOW);
+	size_t size = strlen(dir) + 1 + strlen(name) + 1;
+	char *path = malloc(size);
+	assert(path);
+
+	snprintf(path, size, "%s/%s", dir, name);
+	return path;
+}
+
+int main() {
+    char *libtwo_path = library_path(LIBTWO);
+
+    printf("dlopen'ing libtwo by path with RTLD_LOCAL...\n");
+    void *libtwo_local = dlopen(libtwo_path, RTLD_LOCAL | RTLD_NOW);
+    assert(libtwo_local);
+    assert(dlopen(libtwo_path, RTLD_NOLOAD | RTLD_NOW) == libtwo_local);
+
+    printf("dlopen'ing libtwo by path with RTLD_GLOBAL...\n");
+    void *libtwo_global = dlopen(libtwo_path, RTLD_GLOBAL | RTLD_NOW);
     assert(libtwo_global);
     assert(libtwo_local == libtwo_global);
+    assert(dlopen(libtwo_path, RTLD_NOLOAD | RTLD_GLOBAL | RTLD_NOW) == libtwo_local);
+
+    assert(dlsym(RTLD_DEFAULT, "libtwo_symbol") != NULL);
 
     printf("dlopen'ing libone...\n");
     void *libone = dlopen(LIBONE, RTLD_NOW);
@@ -36,6 +56,7 @@ int main() {
     printf("libone_entry returned %d\n", result);
     assert(result == 42);
 
+    free(libtwo_path);
     dlclose(libone);
     dlclose(libtwo_global);
 


### PR DESCRIPTION
Fixes a regression on shared object promotion, which breaks it on absolute paths. Also changes the tests to use an absolute path for libtwo.