### PR TITLE
options/posix: Fix some bugs in read_dns_name and a leak in getservby{name,port}

### DIFF
--- a/options/posix/generic/lookup.cpp
+++ b/options/posix/generic/lookup.cpp
@@ -54,7 +54,7 @@ static frg::string<MemoryAllocator> read_dns_name(char *buf, char *&it) {
 		char code = *it++;
 		if ((code & 0xC0) == 0xC0) {
 			// pointer
-			uint8_t offset = ((code & 0x3F) << 8) | *it++;
+			uint16_t offset = (static_cast<uint8_t>(code & 0x3F) << 8) | static_cast<uint8_t>(*it++);
 			auto offset_it = buf + offset;
 			return res + read_dns_name(buf, offset_it);
 		} else if (!(code & 0xC0)) {
@@ -146,7 +146,7 @@ int lookup_name_dns(struct lookup_result &buf, const char *name,
 		return -EAI_SYSTEM;
 	}
 
-	char response[256];
+	char response[512];
 	int num_ans = 0;
 	int fds_ready;
 	struct timespec start_time;
@@ -159,7 +159,7 @@ int lookup_name_dns(struct lookup_result &buf, const char *name,
 		mlibc::panicLogger() << "mlibc: sys_clock_get() failed with error code: " << e << frg::endlog;
 
 	while ((fds_ready = poll(&pollfd, 1, get_poll_timeout(&start_time))) > 0) {
-		ssize_t rlen = recvfrom(fd, response, 256, 0, nullptr, nullptr);
+		ssize_t rlen = recvfrom(fd, response, sizeof(response), 0, nullptr, nullptr);
 		if (rlen < 0) {
 			mlibc::infoLogger() << "lookup_name_dns(): recvfrom() failed" << frg::endlog;
 			return -EAI_SYSTEM;
@@ -186,16 +186,18 @@ int lookup_name_dns(struct lookup_result &buf, const char *name,
 			struct dns_addr_buf buffer;
 			auto dns_name = read_dns_name(response, it);
 
-			uint16_t rr_type = (it[0] << 8) | it[1];
-			uint16_t rr_class = (it[2] << 8) | it[3];
-			uint16_t rr_length = (it[8] << 8) | it[9];
+			uint16_t rr_type = (static_cast<uint8_t>(it[0]) << 8) | static_cast<uint8_t>(it[1]);
+			uint16_t rr_class = (static_cast<uint8_t>(it[2]) << 8) | static_cast<uint8_t>(it[3]);
+			uint16_t rr_length = (static_cast<uint8_t>(it[8]) << 8) | static_cast<uint8_t>(it[9]);
 			it += 10;
 			(void)rr_class;
 
 			switch (rr_type) {
 				case RECORD_A:
-					if (family != AF_UNSPEC && family != AF_INET)
+					if (family != AF_UNSPEC && family != AF_INET) {
+						it += rr_length;
 						continue;
+					}
 
 					memcpy(buffer.addr, it, rr_length);
 					it += rr_length;
@@ -204,8 +206,10 @@ int lookup_name_dns(struct lookup_result &buf, const char *name,
 					buf.buf.push(std::move(buffer));
 					break;
 				case RECORD_AAAA:
-					if (family != AF_UNSPEC && family != AF_INET6)
+					if (family != AF_UNSPEC && family != AF_INET6) {
+						it += rr_length;
 						continue;
+					}
 
 					memcpy(buffer.addr, it, rr_length);
 					it += rr_length;
@@ -220,6 +224,7 @@ int lookup_name_dns(struct lookup_result &buf, const char *name,
 				default:
 					mlibc::infoLogger() << "lookup_name_dns: unknown rr type "
 						<< rr_type << frg::endlog;
+					it += rr_length;
 					break;
 			}
 		}
@@ -355,12 +360,11 @@ int lookup_addr_dns(frg::span<char> name, frg::array<uint8_t, 16> &addr, int fam
 			struct dns_addr_buf buffer;
 			auto dns_name = read_dns_name(response, it);
 
-			uint16_t rr_type = (it[0] << 8) | it[1];
-			uint16_t rr_class = (it[2] << 8) | it[3];
-			uint16_t rr_length = (it[8] << 8) | it[9];
+			uint16_t rr_type = (static_cast<uint8_t>(it[0]) << 8) | static_cast<uint8_t>(it[1]);
+			uint16_t rr_class = (static_cast<uint8_t>(it[2]) << 8) | static_cast<uint8_t>(it[3]);
+			uint16_t rr_length = (static_cast<uint8_t>(it[8]) << 8) | static_cast<uint8_t>(it[9]);
 			it += 10;
 			(void)rr_class;
-			(void)rr_length;
 
 			(void)dns_name;
 
@@ -376,6 +380,7 @@ int lookup_addr_dns(frg::span<char> name, frg::array<uint8_t, 16> &addr, int fam
 				default:
 					mlibc::infoLogger() << "lookup_addr_dns: unknown rr type "
 						<< rr_type << frg::endlog;
+					it += rr_length;
 					break;
 			}
 			num_ans += ntohs(response_header->no_ans);

--- a/options/posix/generic/netdb.cpp
+++ b/options/posix/generic/netdb.cpp
@@ -597,9 +597,14 @@ struct servent *getservbyname(const char *name, const char *proto) {
 		free(ret.s_name);
 		ret.s_name = nullptr;
 
-		for (char **alias = ret.s_aliases; *alias != nullptr; alias++) {
-			free(*alias);
-			*alias = nullptr;
+		if (ret.s_aliases) {
+			for (char **alias = ret.s_aliases; *alias != nullptr; alias++) {
+				free(*alias);
+				*alias = nullptr;
+			}
+
+			free(ret.s_aliases);
+			ret.s_aliases = nullptr;
 		}
 
 		free(ret.s_proto);
@@ -658,9 +663,14 @@ struct servent *getservbyport(int port, const char *proto) {
 		free(ret.s_name);
 		ret.s_name = nullptr;
 
-		for (char **alias = ret.s_aliases; *alias != nullptr; alias++) {
-			free(*alias);
-			*alias = nullptr;
+		if (ret.s_aliases) {
+			for (char **alias = ret.s_aliases; *alias != nullptr; alias++) {
+				free(*alias);
+				*alias = nullptr;
+			}
+
+			free(ret.s_aliases);
+			ret.s_aliases = nullptr;
 		}
 
 		free(ret.s_proto);


### PR DESCRIPTION
- Change the dns pointer to be of the proper type and cast the arguments to prevent unwanted sign extension.
- Change the dns response buffer size to 512 bytes which is the recommended minimum to prevent truncated/split dns packets.
- Increment `it` properly when skipping a record.
- Free aliases array in `getservby{name,port}` to prevent leaking memory.