### PR TITLE
options/ansi: add some missing functions to math.h

### DIFF
--- a/options/ansi/include/math.h
+++ b/options/ansi/include/math.h
@@ -374,11 +374,23 @@ extern int signgam;
 #define __signgam signgam
 #endif
 
+#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
+double j0(double __x);
+double j1(double __x);
+double jn(int __n, double __x);
+#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
+
 #if defined(_GNU_SOURCE)
 /* BSD floating-point classification functions - obsolete */
 int finite(double __x);
 int finitef(float __x);
 #endif
+
+#if defined(_DEFAULT_SOURCE)
+double lgamma_r(double __x, int *__signp);
+float lgammaf_r(float __x, int *__signp);
+long double lgammal_r(long double __x, int *__signp);
+#endif /* defined (_DEFAULT_SOURCE) */
 
 #endif /* !__MLIBC_ABI_ONLY */
 


### PR DESCRIPTION
Ran into implicit declaration errors when porting ruby and imagemagick