### PR TITLE
sysdeps/managarm: Fix races between submission and cancellation

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1856,10 +1856,16 @@ int Sysdeps<Read>::operator()(int fd, void *data, size_t max_size, ssize_t *byte
 	req.set_size(max_size);
 	req.set_cancellation_id(allocateCancellationId());
 
-	auto [offer, send_req, imbue_creds, recv_resp, recv_data] = exchangeMsgsSyncCancellable(
+	auto [offer, send_req, imbue_creds, recv_resp, recv_data] = exchangeMsgsSyncCancelViaLane(
 	    handle,
-	    req.cancellation_id(),
-	    fd,
+	    [&] {
+	        managarm::fs::CancelOperation<SysdepsAllocator> cancelReq(getSysdepsAllocator());
+	        cancelReq.set_cancellation_id(req.cancellation_id());
+	        return helix_ng::offer(
+	            helix_ng::sendBragiHeadOnly(cancelReq, getSysdepsAllocator()),
+	            helix_ng::imbueCredentials()
+	        );
+	    },
 	    helix_ng::offer(
 	        helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()),
 	        helix_ng::imbueCredentials(),

--- a/sysdeps/managarm/include/mlibc/posix-pipe.hpp
+++ b/sysdeps/managarm/include/mlibc/posix-pipe.hpp
@@ -38,11 +38,13 @@ struct ElementHandle {
 		swap(u._queue, v._queue);
 		swap(u._n, v._n);
 		swap(u._data, v._data);
+		swap(u._context, v._context);
 	}
 
-	ElementHandle() : _queue{nullptr}, _n{-1}, _data{nullptr} {}
+	ElementHandle() : _queue{nullptr}, _n{-1}, _data{nullptr}, _context{0} {}
 
-	ElementHandle(Queue *queue, int n, void *data) : _queue{queue}, _n{n}, _data{data} {}
+	ElementHandle(Queue *queue, int n, void *data, uintptr_t context)
+	: _queue{queue}, _n{n}, _data{data}, _context{context} {}
 
 	ElementHandle(const ElementHandle &other);
 
@@ -57,12 +59,16 @@ struct ElementHandle {
 
 	void *data() { return _data; }
 
+	// Context that was passed at submission time.
+	uintptr_t context() { return _context; }
+
 	void advance(size_t size) { _data = reinterpret_cast<char *>(_data) + size; }
 
 private:
 	Queue *_queue;
 	int _n;
 	void *_data;
+	uintptr_t _context;
 };
 
 struct Queue {
@@ -242,7 +248,8 @@ struct Queue {
 			auto element = reinterpret_cast<HelElement *>(ptr);
 			_lastProgress += sizeof(HelElement) + element->length;
 			_refCount[n]++;
-			return ElementHandle{this, n, ptr + sizeof(HelElement)};
+			return ElementHandle{this, n, ptr + sizeof(HelElement),
+					reinterpret_cast<uintptr_t>(element->context)};
 		}
 	}
 
@@ -376,6 +383,7 @@ inline ElementHandle::ElementHandle(const ElementHandle &other) {
 	_queue = other._queue;
 	_n = other._n;
 	_data = other._data;
+	_context = other._context;
 
 	_queue->reference(_n);
 }

--- a/sysdeps/managarm/include/mlibc/posix-pipe.hpp
+++ b/sysdeps/managarm/include/mlibc/posix-pipe.hpp
@@ -425,22 +425,27 @@ extern thread_local Queue globalQueue;
 // This include is here because it needs ElementHandle to be declared
 #include <helix/ipc-structs.hpp>
 
+inline void pushExchangeMsgsToSq(HelHandle lane, uintptr_t context,
+		const HelAction *actions, size_t count) {
+	HelSqExchangeMsgs header;
+	header.lane = lane;
+	header.count = count;
+	header.flags = 0;
+
+	frg::array<frg::span<const std::byte>, 2> segments{
+		frg::span<const std::byte>{reinterpret_cast<const std::byte *>(&header), sizeof(header)},
+		frg::span<const std::byte>{reinterpret_cast<const std::byte *>(actions),
+		                           count * sizeof(HelAction)}
+	};
+	globalQueue.pushSq(kHelSubmitExchangeMsgs, context, segments);
+}
+
 template <typename... Args>
 auto exchangeMsgsSync(HelHandle descriptor, Args &&...args) {
 	auto results = helix_ng::createResultsTuple(args...);
 	auto actions = helix_ng::chainActionArrays(args...);
 
-	HelSqExchangeMsgs header;
-	header.lane = descriptor;
-	header.count = actions.size();
-	header.flags = 0;
-
-	frg::array<frg::span<const std::byte>, 2> segments{
-		frg::span<const std::byte>{reinterpret_cast<const std::byte *>(&header), sizeof(header)},
-		frg::span<const std::byte>{reinterpret_cast<const std::byte *>(actions.data()),
-		                           actions.size() * sizeof(HelAction)}
-	};
-	globalQueue.pushSq(kHelSubmitExchangeMsgs, 0, segments);
+	pushExchangeMsgsToSq(descriptor, 0, actions.data(), actions.size());
 
 	auto element = globalQueue.dequeueSingle();
 	void *ptr = element.data();
@@ -457,17 +462,7 @@ auto exchangeMsgsSyncCancellable(HelHandle descriptor, uint64_t cancelId, int fd
 	auto results = helix_ng::createResultsTuple(args...);
 	auto actions = helix_ng::chainActionArrays(args...);
 
-	HelSqExchangeMsgs header;
-	header.lane = descriptor;
-	header.count = actions.size();
-	header.flags = 0;
-
-	frg::array<frg::span<const std::byte>, 2> segments{
-		frg::span<const std::byte>{reinterpret_cast<const std::byte *>(&header), sizeof(header)},
-		frg::span<const std::byte>{reinterpret_cast<const std::byte *>(actions.data()),
-		                           actions.size() * sizeof(HelAction)}
-	};
-	globalQueue.pushSq(kHelSubmitExchangeMsgs, 0, segments);
+	pushExchangeMsgsToSq(descriptor, 0, actions.data(), actions.size());
 
 	frg::optional<ElementHandle> element{};
 
@@ -487,6 +482,51 @@ auto exchangeMsgsSyncCancellable(HelHandle descriptor, uint64_t cancelId, int fd
 
 	[&]<size_t... p>(std::index_sequence<p...>) {
 		(results.template get<p>().parse(ptr, *element), ...);
+	}(std::make_index_sequence<std::tuple_size_v<decltype(results)>>{});
+
+	return results;
+}
+
+// Like exchangeMsgsSync(), but allows sending a cancellation on the same lane.
+// Sending cancellation messages on the same lane guarantees ordering w.r.t. the initial request.
+template <typename MakeCancel, typename... Args>
+auto exchangeMsgsSyncCancelViaLane(HelHandle descriptor, MakeCancel &&makeCancel, Args &&...args) {
+	// Contexts that tell the request and the cancellation exchange apart on the queue.
+	constexpr uintptr_t reqContext = 1;
+	constexpr uintptr_t cancelContext = 2;
+
+	auto results = helix_ng::createResultsTuple(args...);
+	auto reqActions = helix_ng::chainActionArrays(args...);
+	pushExchangeMsgsToSq(descriptor, reqContext, reqActions.data(), reqActions.size());
+
+	// Wait for the request to complete or until cancellation is requested.
+	frg::optional<ElementHandle> reqElement = globalQueue.dequeueSingleUnlessCancelled();
+
+	// Handle cancellation if it occurred, then wait for request completion.
+	if (!reqElement) {
+		// Submit the cancellation on the same lane to guarantee ordering.
+		// Then wait for both request + cancellation to complete.
+		auto cancelExchange = makeCancel();
+		auto cancelActions = helix_ng::chainActionArrays(cancelExchange);
+		pushExchangeMsgsToSq(descriptor, cancelContext, cancelActions.data(), cancelActions.size());
+		resetCancellationRequested();
+
+		bool cancelDone = false;
+		while (!reqElement || !cancelDone) {
+			auto element = globalQueue.dequeueSingle();
+			if (element.context() == reqContext) {
+				reqElement = std::move(element);
+			} else {
+				__ensure(element.context() == cancelContext);
+				cancelDone = true;
+			}
+		}
+	}
+
+	void *ptr = reqElement->data();
+
+	[&]<size_t... p>(std::index_sequence<p...>) {
+		(results.template get<p>().parse(ptr, *reqElement), ...);
 	}(std::make_index_sequence<std::tuple_size_v<decltype(results)>>{});
 
 	return results;


### PR DESCRIPTION
Let mlibc send cancellation requests over the fs protocol (instead of doing it in posix-subsystem). This fixes a race: posix-subsystem does not know whether mlibc already got to the point where the request is submitted, so it can send cancellations out before the actual request is submitted. Sending the cancellation request from within mlibc avoids this race.