### PR TITLE
options/posix: set memstreams to byte-oriented at creation

### DIFF
--- a/options/posix/generic/posix-file-io.cpp
+++ b/options/posix/generic/posix-file-io.cpp
@@ -24,7 +24,7 @@ int mem_file::determine_bufmode(buffer_mode *mode) {
 
 memstream_mem_file::memstream_mem_file(char **ptr, size_t *sizeloc, int flags, void (*do_dispose)(abstract_file *))
 : mem_file{flags, do_dispose}, _bufloc{ptr}, _sizeloc{sizeloc} {
-	// TODO(no92): set correct stream orientation
+	_orientation = stream_orientation::byte;
 	_buf.resize(1, '\0');
 }
 

--- a/tests/posix/open_memstream.c
+++ b/tests/posix/open_memstream.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <wchar.h>
 
 #define WRITE_NO 1024
 
@@ -10,6 +11,8 @@ int main() {
 
 	FILE *fp = open_memstream(&buf, &size);
 	assert(fp);
+
+	assert(fwide(fp, 0) < 0);
 
 	char c = 'A';
 	for (size_t i = 0; i < WRITE_NO; i++)


### PR DESCRIPTION
This behavior is required by POSIX.