### PR TITLE
options/posix: do not log on `_SC_GETGR_R_SIZE_MAX`

### DIFF
--- a/options/posix/generic/unistd.cpp
+++ b/options/posix/generic/unistd.cpp
@@ -984,7 +984,6 @@ long sysconf(int number) {
 		case _SC_GETPW_R_SIZE_MAX:
 			return NSS_BUFLEN_PASSWD;
 		case _SC_GETGR_R_SIZE_MAX:
-			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_GETGR_R_SIZE_MAX) returns fallback value 1024\e[39m" << frg::endlog;
 			return 1024;
 		case _SC_CHILD_MAX:
 			mlibc::infoLogger() << "\e[31mmlibc: sysconf(_SC_CHILD_MAX) returns fallback value 25\e[39m" << frg::endlog;


### PR DESCRIPTION
This is a lib-level buffer size recommendation, and probably shouldn't be handled by sysdeps; the fallback is the expected use-case. As such, we shoudl avoid polluting output.