### PR TITLE
Fix init/fini ordering in static builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,10 @@ if not headers_only
 	add_project_arguments('-Werror=misleading-indentation', language: ['c', 'cpp'])
 	add_project_arguments('-fno-rtti', '-fno-exceptions', language: 'cpp')
 
+	# mlibc uses the priority range reserved for the C library, which GCC warns about.
+	add_project_arguments(cpp_compiler.get_supported_arguments('-Wno-prio-ctor-dtor'),
+		language: 'cpp')
+
 	if get_option('buildtype').startswith('debug')
 		add_project_arguments('-D__MLIBC_DEBUG', language : ['c', 'cpp'])
 	endif

--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -14,11 +14,13 @@
 
 #include <abi-bits/fcntl.h>
 #include <frg/allocation.hpp>
+#include <frg/manual_box.hpp>
 #include <frg/mutex.hpp>
 #include <frg/scope_exit.hpp>
 #include <mlibc/all-sysdeps.hpp>
 #include <mlibc/allocator.hpp>
 #include <mlibc/file-io.hpp>
+#include <mlibc/init-priority.hpp>
 #include <mlibc/lock.hpp>
 #include <mlibc/exit.hpp>
 
@@ -626,27 +628,41 @@ int fd_file::parse_modestring(const char *mode) {
 } // namespace mlibc
 
 namespace {
-	mlibc::fd_file stdin_file{0};
-	mlibc::fd_file stdout_file{1};
-	mlibc::fd_file stderr_file{2, nullptr, true};
+	// Never destroyed: manual_box is trivially destructible, so __cxa_finalize()
+	// cannot tear the streams down while [[gnu::destructor]] functions may still
+	// use them. mlibc::flush_all_files() flushes them at exit.
+	constinit frg::manual_box<mlibc::fd_file> stdin_box;
+	constinit frg::manual_box<mlibc::fd_file> stdout_box;
+	constinit frg::manual_box<mlibc::fd_file> stderr_box;
 
-	struct stdio_guard {
-		stdio_guard() { }
+	[[gnu::constructor(MLIBC_INIT_PRIORITY_STDIO)]]
+	void init_stdio() {
+		stdin_box.initialize(0);
+		stdout_box.initialize(1);
+		stderr_box.initialize(2, nullptr, true);
 
-		~stdio_guard() {
-			// Only flush the files but do not close them.
-			for(auto it : mlibc::global_file_list()) {
-				if(int e = it->flush(); e && !mlibc::processIsExiting.load(std::memory_order_relaxed))
-					mlibc::infoLogger() << "mlibc warning: Failed to flush file before exit()"
-							<< frg::endlog;
-			}
-		}
-	} global_stdio_guard;
+		stdin = stdin_box.get();
+		stdout = stdout_box.get();
+		stderr = stderr_box.get();
+	}
 } // namespace
 
-FILE *stderr = &stderr_file;
-FILE *stdin = &stdin_file;
-FILE *stdout = &stdout_file;
+FILE *stderr;
+FILE *stdin;
+FILE *stdout;
+
+namespace mlibc {
+
+void flush_all_files() {
+	// Only flush the files but do not close them.
+	for(auto it : global_file_list()) {
+		if(int e = it->flush(); e && !processIsExiting.load(std::memory_order_relaxed))
+			infoLogger() << "mlibc warning: Failed to flush file before exit()"
+					<< frg::endlog;
+	}
+}
+
+} // namespace mlibc
 
 int fileno_unlocked(FILE *file_base) {
 	auto file = static_cast<mlibc::fd_file *>(file_base);

--- a/options/ansi/generic/stdlib.cpp
+++ b/options/ansi/generic/stdlib.cpp
@@ -199,14 +199,30 @@ int atexit(void (*func)(void)) {
 
 namespace {
 
-frg::vector<void (*)(void), MemoryAllocator> quickExitQueue{getAllocator()};
+using QuickExitQueue = frg::vector<void (*)(void), MemoryAllocator>;
+
+// Wrapper so that lazy_eternal, which default-constructs, can pass the
+// allocator. Same pattern as the exit queue in options/lsb/generic/dso_exit.cpp.
+struct QuickExitQueueWrapper {
+	QuickExitQueueWrapper() : queue{getAllocator()} { }
+	QuickExitQueue queue;
+};
+
+// Built on first use: initialising from .init_array would run after the
+// program's constructors, so at_quick_exit() from one faulted on a null allocator.
+constinit mlibc::lazy_eternal<QuickExitQueueWrapper> quickExitQueueInstance;
+
+QuickExitQueue &quickExitQueue() {
+	return quickExitQueueInstance.get().queue;
+}
+
 __mlibc_mutex quickExitQueueMutex{};
 
 } // namespace
 
 int at_quick_exit(void (*func)(void)) {
 	mlibc::thread_mutex_lock(&quickExitQueueMutex);
-	quickExitQueue.push(func);
+	quickExitQueue().push(func);
 	mlibc::thread_mutex_unlock(&quickExitQueueMutex);
 
 	return 0;
@@ -231,8 +247,8 @@ void _Exit(int status) {
 void quick_exit(int status) {
 	mlibc::thread_mutex_lock(&quickExitQueueMutex);
 
-	while (!quickExitQueue.empty()) {
-		auto func = quickExitQueue.pop();
+	while (!quickExitQueue().empty()) {
+		auto func = quickExitQueue().pop();
 		func();
 	}
 

--- a/options/ansi/include/mlibc/file-io.hpp
+++ b/options/ansi/include/mlibc/file-io.hpp
@@ -147,6 +147,10 @@ void file_dispose_cb(abstract_file *base) {
 	frg::destruct(getAllocator(), static_cast<T *>(base));
 }
 
+// Flushes every open FILE without closing it. Called from __mlibc_do_finalize()
+// after the program's destructors, so that stdio stays usable in them.
+void flush_all_files();
+
 } // namespace mlibc
 
 #endif // MLIBC_FILE_IO_HPP

--- a/options/elf/generic/startup.cpp
+++ b/options/elf/generic/startup.cpp
@@ -7,6 +7,7 @@
 #include <bits/ensure.h>
 #include <mlibc/elf/startup.h>
 #include <mlibc/environment.hpp>
+#include <mlibc/init-priority.hpp>
 #include <mlibc/rtld-config.hpp>
 #include <mlibc/debug.hpp>
 
@@ -31,7 +32,7 @@ namespace mlibc {
 
 exec_stack_data entry_stack;
 
-[[gnu::constructor]]
+[[gnu::constructor(MLIBC_INIT_PRIORITY_STARTUP)]]
 void init_libc() {
 	mlibc::parse_exec_stack(__dlapi_entrystack(), &entry_stack);
 	mlibc::set_startup_data(entry_stack.argc, entry_stack.argv, entry_stack.envp);

--- a/options/internal/include/mlibc/init-priority.hpp
+++ b/options/internal/include/mlibc/init-priority.hpp
@@ -1,0 +1,14 @@
+#ifndef MLIBC_INIT_PRIORITY_HPP
+#define MLIBC_INIT_PRIORITY_HPP
+
+// Priorities 0-100 are reserved for the C library implementation; 101 is the
+// lowest a program may use. In a static build mlibc's .init_array entries share
+// the array with the executable's, so mlibc needs its own to run first.
+
+// Startup data: environ, program_invocation_name, ...
+#define MLIBC_INIT_PRIORITY_STARTUP 50
+
+// Standard streams, after the environment is populated.
+#define MLIBC_INIT_PRIORITY_STDIO 51
+
+#endif // MLIBC_INIT_PRIORITY_HPP

--- a/options/lsb/generic/dso_exit.cpp
+++ b/options/lsb/generic/dso_exit.cpp
@@ -4,6 +4,7 @@
 
 #include <bits/ensure.h>
 #include <mlibc/allocator.hpp>
+#include <mlibc/file-io.hpp>
 
 #include <frg/eternal.hpp>
 #include <frg/vector.hpp>
@@ -90,4 +91,8 @@ void __mlibc_do_finalize() {
 	// to implement [[gnu::destructor]]. Note that C++ applications will call
 	// __cxa_finalize from here.
 	__dlapi_exit();
+
+	// The standard streams outlive __cxa_finalize(), so flush them here, once
+	// everything that could still write to them has run.
+	mlibc::flush_all_files();
 }

--- a/tests/ansi/init-fini-order.c
+++ b/tests/ansi/init-fini-order.c
@@ -1,0 +1,56 @@
+// In a static build mlibc's init/fini array entries used to be ordered after
+// the program's, leaving stdio and environ unusable in constructors and already
+// torn down in destructors.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int ctor_prio_ran;
+static int ctor_default_ran;
+static int path_seen_in_ctor;
+
+static void check_stdio(const char *phase) {
+	assert(stdout != NULL);
+	assert(fprintf(stdout, "[%s]\n", phase) > 0);
+	assert(fflush(stdout) == 0);
+}
+
+static void quick_exit_handler(void) { }
+
+// 101 is the lowest priority a program may use, so this runs before any other
+// user code.
+__attribute__((constructor(101))) static void ctor_prio(void) {
+	check_stdio("ctor(101)");
+	path_seen_in_ctor = (getenv("PATH") != NULL);
+	assert(at_quick_exit(quick_exit_handler) == 0);
+	ctor_prio_ran = 1;
+}
+
+__attribute__((constructor)) static void ctor_default(void) {
+	assert(ctor_prio_ran);
+	check_stdio("ctor(default)");
+	ctor_default_ran = 1;
+}
+
+__attribute__((destructor)) static void dtor_default(void) {
+	check_stdio("dtor(default)");
+}
+
+// Runs last: prioritised fini entries come first in the array, which is walked
+// in reverse.
+__attribute__((destructor(101))) static void dtor_prio(void) {
+	check_stdio("dtor(101)");
+}
+
+int main(void) {
+	assert(ctor_prio_ran);
+	assert(ctor_default_ran);
+	check_stdio("main");
+
+	// getenv() must work in a constructor too, not just here.
+	if (getenv("PATH") != NULL)
+		assert(path_seen_in_ctor);
+
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,6 +25,7 @@ all_test_cases = [
 	'ansi/tz',
 	'ansi/ungetc',
 	'ansi/fopen',
+	'ansi/init-fini-order',
 	'ansi/creal-cimag',
 	'ansi/fenv',
 	'ansi/qsort',


### PR DESCRIPTION
## The problem

In a static build mlibc's `.init_array` and `.fini_array` entries share the arrays with the executable's and are ordered by link order, which puts `libc.a` last.
mlibc therefore initialises after the program's constructors and, since fini arrays run in reverse, finalises before its destructors.

From a `[[gnu::constructor]]`: `printf()` faulted on an unconstructed `stdout`, `getenv()` returned `NULL` because `init_libc()` had not populated `environ` yet, and `at_quick_exit()` faulted on `quickExitQueue`'s null allocator.
`GlobalConfig` is built on first use and reads the environment, so anything reaching it that early also latched every `MLIBC_DEBUG_*` option to false for the rest of the process.

From a `[[gnu::destructor]]`: `printf()` used a `stdout` that `__cxa_finalize()` had already destroyed, ending in a pure virtual call.

```c
#include <stdio.h>

__attribute__((constructor)) void c(void) { printf("constructor\n"); }
__attribute__((destructor))  void d(void) { printf("destructor\n"); }

int main(void) { printf("hello\n"); return 0; }
```

Linked statically against mlibc this faults in the constructor; replacing the body with a raw `write(2)` gets past it and it then faults in the destructor.
The same program is fine against glibc, and fine against a dynamically linked mlibc, where `ld.so` initialises `libc.so` as a separate object before the executable.

Note that `constructor(101)` does not help: prioritised entries are placed before unprioritised ones, so the program's constructor moves even further ahead of mlibc.

## Why this is a bug rather than a limitation

Two comments in the tree already state the intent, and link order defeats both.

`__mlibc_do_finalize()` in `options/lsb/generic/dso_exit.cpp` deliberately avoids destroying mlibc's globals so that they stay "available to `[[gnu::destructor]]` functions which we invoke below".
But `__mlibc_do_destructors` is itself an entry in the fini array, and in a static build it is the last one, so it runs first.

`GlobalConfigGuard` in `options/internal/generic/global-config.cpp` forces the config to be built "during initialization of libc.so".
It is an unprioritised `.init_array` entry, so in a static build that happens after the program's constructors instead.

`mlibc-static` is also a first-class CI configuration rather than a best-effort one, and both glibc and musl initialise stdio and the environment before walking `.init_array`.

## The fix

`init_libc()` and the construction of the standard streams get priorities from the range reserved for the implementation, so they run before any constructor a program can register; 101 is the lowest a program may use.

For shutdown, rather than ordering mlibc against `__cxa_finalize()`, the standard streams live in `frg::manual_box` and are never destroyed, with `mlibc::flush_all_files()` flushing them at the end of `__mlibc_do_finalize()`.
The fini array itself is unchanged, so a program's C++ globals are still destroyed before its `[[gnu::destructor]]` functions, matching glibc.

`quickExitQueue` moves behind `lazy_eternal`, as `dso_exit.cpp` already does for the atexit queue.

## Testing

Ran the CI workflow locally with `act` on `debian:trixie`: `mlibc-static` and `mlibc-ansi-only` with gcc 14.2, and `mlibc` with clang 19.1.7, all with `-Dwerror=true` and `-Db_sanitize=undefined`.
The only failures are `posix/getaddrinfo`, which fails identically in its `host-libc` variant because the container has no DNS.
Every commit also builds on its own, and `pre-commit run --all-files` passes.

Behaviour was compared against glibc throughout: static and dynamic mlibc now produce identical output, in C and in C++.

## Follow-ups, not addressed here

Other translation units still initialise after the program's constructors, so anything a constructor reaches inside them is exposed to the same problem:

- `pthread.cpp` builds `pthread_signal_installer`, which installs the cancellation signal handler.
- `locale.cpp` has `locpaths`, `localeFiles` and `localeArchive`. The `"C"` locale path does not reach them, but loading a locale from an archive does.
- `utmpx.cpp`, and the POSIX timer context in `sysdeps/linux/generic/sysdeps.cpp`.

Each needs its own reproduction scenario, so I left them alone.

#1837 may well be the same family, but I could not reproduce it: `pthread_mutex_lock()` from a constructor works on the linux sysdep both before and after this series, so I am not claiming this fixes it.