### PR TITLE
options/ansi: use tgkill for raise if supported by sysdep

### DIFF
--- a/options/ansi/generic/signal.cpp
+++ b/options/ansi/generic/signal.cpp
@@ -5,6 +5,7 @@
 
 #include <mlibc/all-sysdeps.hpp>
 #include <mlibc/debug.hpp>
+#include <mlibc/tid.hpp>
 
 __sighandler signal(int sn, __sighandler handler) {
 	struct sigaction sa;
@@ -20,10 +21,10 @@ __sighandler signal(int sn, __sighandler handler) {
 }
 
 int raise(int sig) {
-	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<GetPid> && mlibc::IsImplemented<Kill>, -1);
-	pid_t pid = mlibc::sysdep_or_panic<GetPid>();
+	int e;
 
-	if (int e = mlibc::sysdep_or_panic<Kill>(pid, sig)) {
+	pid_t pid = mlibc::sysdep_or_panic<GetPid>();
+	if (e = mlibc::sysdep_or_enosys<Tgkill>(pid, mlibc::this_tid(), sig); e) {
 		errno = e;
 		return -1;
 	}
@@ -39,4 +40,3 @@ int sigprocmask(int how, const sigset_t *__restrict set, sigset_t *__restrict re
 	}
 	return 0;
 }
-

--- a/options/internal/include/mlibc/sysdep-signatures.hpp
+++ b/options/internal/include/mlibc/sysdep-signatures.hpp
@@ -89,6 +89,7 @@ SYSDEP_FUNC(Execve, const char *path, char *const argv[], char *const envp[]);
 SYSDEP_FUNC_RET(void, Yield);
 SYSDEP_FUNC_RET(pid_t, GetPid);
 SYSDEP_FUNC(Kill, pid_t, int);
+SYSDEP_FUNC(Tgkill, int tgid, int tid, int sig);
 
 #if MLIBC_BUILDING_RTLD
 SYSDEP_FUNC(VmReadahead, void *pointer, size_t size);
@@ -209,7 +210,6 @@ SYSDEP_FUNC(GetEntropy, void *buffer, size_t length);
 SYSDEP_FUNC(Mknodat, int dirfd, const char *path, int mode, int dev);
 SYSDEP_FUNC(Umask, mode_t mode, mode_t *old);
 SYSDEP_FUNC(BeforeCancellableSyscall, ucontext_t *uctx);
-SYSDEP_FUNC(Tgkill, int tgid, int tid, int sig);
 SYSDEP_FUNC(Fchownat, int dirfd, const char *pathname, uid_t owner, gid_t group, int flags);
 SYSDEP_FUNC(Sigaltstack, const stack_t *ss, stack_t *oss);
 SYSDEP_FUNC(Sigsuspend, const sigset_t *set);

--- a/options/internal/include/mlibc/sysdep-tags.hpp
+++ b/options/internal/include/mlibc/sysdep-tags.hpp
@@ -101,6 +101,8 @@ struct Yield {};
 struct GetPid {};
 // int sys_kill(pid_t, int);
 struct Kill {};
+// int sys_tgkill(int tgid, int tid, int sig);
+struct Tgkill {};
 
 // int sys_tcb_set(void *pointer);
 struct TcbSet {};
@@ -436,8 +438,6 @@ struct Mknodat {};
 struct Umask {};
 // int sys_before_cancellable_syscall(ucontext_t *uctx);
 struct BeforeCancellableSyscall {};
-// int sys_tgkill(int tgid, int tid, int sig);
-struct Tgkill {};
 // int sys_fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flags);
 struct Fchownat {};
 // int sys_sigaltstack(const stack_t *ss, stack_t *oss);

--- a/sysdeps/linux/generic/sysdeps.cpp
+++ b/sysdeps/linux/generic/sysdeps.cpp
@@ -672,6 +672,13 @@ int Sysdeps<Kill>::operator()(pid_t pid, int sig) {
 	return 0;
 }
 
+int Sysdeps<Tgkill>::operator()(int tgid, int tid, int sig) {
+	auto ret = do_syscall(SYS_tgkill, tgid, tid, sig);
+	if (int e = sc_error(ret); e)
+		return e;
+	return 0;
+}
+
 #if !MLIBC_BUILDING_RTLD
 #if __MLIBC_POSIX_OPTION
 int Sysdeps<Readv>::operator()(int fd, const struct iovec *iovs, int iovc, ssize_t *bytes_read) {
@@ -1652,13 +1659,6 @@ int Sysdeps<BeforeCancellableSyscall>::operator()(ucontext_t *uct) {
 	if (pc < __mlibc_syscall_begin || pc > __mlibc_syscall_end)
 		return 0;
 	return 1;
-}
-
-int Sysdeps<Tgkill>::operator()(int tgid, int tid, int sig) {
-	auto ret = do_syscall(SYS_tgkill, tgid, tid, sig);
-	if (int e = sc_error(ret); e)
-		return e;
-	return 0;
 }
 
 int Sysdeps<Fchownat>::operator()(int dirfd, const char *pathname, uid_t owner, gid_t group, int flags) {

--- a/sysdeps/linux/include/mlibc/sysdeps.hpp
+++ b/sysdeps/linux/include/mlibc/sysdeps.hpp
@@ -118,7 +118,6 @@ struct LinuxSysdepTags :
 	Mknodat,
 	Umask,
 	BeforeCancellableSyscall,
-	Tgkill,
 	Fchownat,
 	Sigaltstack,
 	Sigsuspend,
@@ -322,7 +321,8 @@ struct LinuxSysdepTags :
 	Execve,
 	Yield,
 	GetPid,
-	Kill
+	Kill,
+	Tgkill
 {};
 
 template<typename Tag>

--- a/tests/ansi/raise.c
+++ b/tests/ansi/raise.c
@@ -1,0 +1,80 @@
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <threads.h>
+
+static _Thread_local int thread_idx = -1;
+
+static int *signal_counts;
+
+static void sig_handler(int sig) {
+	assert(thread_idx != -1);
+	int expected_sig = thread_idx + SIGRTMIN;
+	assert(sig == expected_sig);
+	__atomic_fetch_add(&signal_counts[thread_idx], 1, __ATOMIC_RELAXED);
+}
+
+static int worker(void *arg) {
+	int idx = *(int *)arg;
+	thread_idx = idx;
+
+	int sig = idx + SIGRTMIN;
+	int ret = raise(sig);
+	assert(ret == 0);
+
+	return 0;
+}
+
+int main(void) {
+	// Test that out of range signal numbers return EINVAL in raise()
+	errno = 0;
+	int res = raise(-1);
+	assert(res != 0);
+	assert(errno == EINVAL);
+
+	errno = 0;
+	res = raise(1000000);
+	assert(res != 0);
+	assert(errno == EINVAL);
+
+	int num_threads = SIGRTMAX - SIGRTMIN;
+	assert(num_threads > 0);
+
+	signal_counts = calloc(num_threads, sizeof(int));
+	assert(signal_counts != NULL);
+
+	for (int i = 0; i < num_threads; i++) {
+		int sig = SIGRTMIN + i;
+		void (*ret)(int) = signal(sig, sig_handler);
+		assert(ret != SIG_ERR);
+	}
+
+	thrd_t *threads = malloc(num_threads * sizeof(thrd_t));
+	int *indices = malloc(num_threads * sizeof(int));
+	assert(threads != NULL);
+	assert(indices != NULL);
+
+	for (int i = 0; i < num_threads; i++) {
+		indices[i] = i;
+		int ret = thrd_create(&threads[i], worker, &indices[i]);
+		assert(ret == thrd_success);
+	}
+
+	for (int i = 0; i < num_threads; i++) {
+		int thread_res = -1;
+		int ret = thrd_join(threads[i], &thread_res);
+		assert(ret == thrd_success);
+		assert(thread_res == 0);
+	}
+
+	for (int i = 0; i < num_threads; i++) {
+		int count = __atomic_load_n(&signal_counts[i], __ATOMIC_RELAXED);
+		assert(count == 1);
+	}
+
+	free(threads);
+	free(indices);
+	free(signal_counts);
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,6 +29,7 @@ all_test_cases = [
 	'ansi/creal-cimag',
 	'ansi/fenv',
 	'ansi/qsort',
+	'ansi/raise',
 	'ansi/freopen',
 	'ansi/strxfrm',
 	'ansi/calloc',


### PR DESCRIPTION
This fixes raise() to match the behavior expected by POSIX:

```
The raise() function shall send the signal sig to the executing thread or process. 
If a signal handler is called, the raise() function shall not return until after the signal handler does.

If the implementation supports the Threads option, the effect of the raise() function shall be equivalent to calling:

pthread_kill(pthread_self(), sig);

Otherwise, the effect of the raise() function shall be equivalent to calling:

kill(getpid(), sig);
```

I have hit issues related to this while debugging webkit, where it would hit a ``ud2`` on abort because the signal went to another thread.