### PR TITLE
options/ansi: Preserve file descriptors across freopen()

### DIFF
--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -502,9 +502,10 @@ int fd_file::reopen(const char *path, const char *mode) {
 			getAllocator().free(const_cast<char *>(reopen_path));
 	});
 
-	// glibc and musl preserve the original file descriptor across freopen().
-	// Keep it open until dup2() atomically replaces it: closing it before opening
-	// the replacement would let an unrelated thread reuse and then lose old_fd.
+	// Deliberately deviate from POSIX's close-before-open ordering to match glibc
+	// and musl, which preserve the original descriptor across freopen(). Keep it
+	// open until dup2() atomically replaces it: closing it before opening the
+	// replacement would let an unrelated thread reuse and then lose old_fd.
 	int old_fd = _fd;
 	bool old_fd_is_open = true;
 	// POSIX requires freopen() to proceed even if flushing the old stream fails.

--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -376,6 +376,11 @@ int abstract_file::_init_bufmode() {
 	return 0;
 }
 
+void abstract_file::_reset_type_and_bufmode() {
+	_type = stream_type::unknown;
+	_bufmode = buffer_mode::unknown;
+}
+
 int abstract_file::_write_back() {
 	if(int e = _init_type(); e)
 		return e;
@@ -481,8 +486,6 @@ int fd_file::close() {
 }
 
 int fd_file::reopen(const char *path, const char *mode) {
-	flush();
-
 	int mode_flags = parse_modestring(mode);
 	const char *reopen_path = path;
 
@@ -499,22 +502,67 @@ int fd_file::reopen(const char *path, const char *mode) {
 			getAllocator().free(const_cast<char *>(reopen_path));
 	});
 
-	int fd;
-	if(int e = sysdep<Open>(reopen_path, mode_flags, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH, &fd); e) {
-		return e;
+	// glibc and musl preserve the original file descriptor across freopen().
+	// Keep it open until dup2() atomically replaces it: closing it before opening
+	// the replacement would let an unrelated thread reuse and then lose old_fd.
+	int old_fd = _fd;
+	bool old_fd_is_open = true;
+	// POSIX requires freopen() to proceed even if flushing the old stream fails.
+	// The buffered data is discarded below when we reset the stream state.
+	flush();
+	int reopen_error = 0;
+	int fd = -1;
+	if (int e = sysdep<Open>(reopen_path, mode_flags,
+				S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH, &fd); e)
+		reopen_error = e;
+
+	if (!reopen_error && fd != old_fd) {
+#if __MLIBC_POSIX_OPTION
+		if constexpr (IsImplemented<Dup2>) {
+			if (int e = sysdep<Dup2>(fd, mode_flags & O_CLOEXEC, old_fd); e) {
+				reopen_error = e;
+			} else {
+				old_fd_is_open = false;
+				sysdep<Close>(fd);
+				fd = old_fd;
+			}
+		} else {
+			// fd_file can still implement freopen() without Dup2, but cannot
+			// preserve the descriptor number in that configuration.
+			close();
+			old_fd_is_open = false;
+		}
+#else
+		close();
+		old_fd_is_open = false;
+#endif
 	}
 
-	close();
+	if (reopen_error) {
+		if (fd >= 0 && fd != old_fd)
+			sysdep<Close>(fd);
+		if (old_fd_is_open)
+			close();
+		_fd = -1;
+	}
+
 	if (__buffer_ptr)
 		getAllocator().deallocate(__buffer_ptr - ungetBufferSize, __buffer_size + ungetBufferSize);
 
 	__buffer_ptr = nullptr;
 	__unget_ptr = nullptr;
 	__buffer_size = 4096;
-	_reset();
-	_fd = fd;
+	purge();
+	__io_mode = 0;
+	__status_bits = 0;
+	_reset_type_and_bufmode();
 	_orientation = stream_orientation::none;
 	_mbstate = {};
+
+	if (reopen_error)
+		return reopen_error;
+
+	_fd = fd;
 
 	if(mode_flags & O_APPEND) {
 		seek(0, SEEK_END);
@@ -820,4 +868,3 @@ void __fpurge(FILE *file_base) {
 	file->purge();
 }
 #endif
-

--- a/options/ansi/include/mlibc/file-io.hpp
+++ b/options/ansi/include/mlibc/file-io.hpp
@@ -90,6 +90,7 @@ protected:
 	virtual int io_seek(off_t offset, int whence, off_t *new_offset) = 0;
 	virtual int post_flush();
 
+	void _reset_type_and_bufmode();
 	int _reset();
 private:
 	int _init_type();

--- a/tests/ansi/freopen.c
+++ b/tests/ansi/freopen.c
@@ -2,6 +2,15 @@
 #include <stdio.h>
 #include <string.h>
 
+// This test is also built for the ANSI-only mlibc configuration. In that
+// configuration neither fileno() nor unlink() is available.
+#if defined(USE_HOST_LIBC) || __MLIBC_POSIX_OPTION
+#include <unistd.h>
+#define TEST_HAS_POSIX 1
+#else
+#define TEST_HAS_POSIX 0
+#endif
+
 #ifdef USE_HOST_LIBC
 #define TEST_FILE "freopen-host-libc.tmp"
 #elif defined(USE_CROSS_LIBC)
@@ -11,10 +20,24 @@
 #endif
 
 int main() {
+	// POSIX requires freopen() to ignore errors while flushing the old stream.
+	FILE *full = fopen("/dev/full", "w");
+	assert(full);
+	assert(fwrite("x", 1, 1, full) == 1);
+	assert(freopen("/dev/null", "w", full));
+	assert(fclose(full) == 0);
+
 	FILE *file = fopen(TEST_FILE, "w");
 	assert(file);
 
+#if TEST_HAS_POSIX
+	int original_fd = fileno(file);
+#endif
 	assert(freopen("/dev/null", "w", file));
+
+#if TEST_HAS_POSIX
+	assert(fileno(file) == original_fd);
+#endif
 
 	char str[] = "mlibc freopen test";
 	fwrite(str, 1, sizeof(str) - 1, file);
@@ -46,6 +69,8 @@ int main() {
 	fprintf(stderr, "buffer content '%s'\n", buf);
 	assert(!strcmp(buf, "mlibc freopen test"));
 	fclose(file);
+
+	assert(remove(TEST_FILE) == 0);
 
 	return 0;
 }

--- a/tests/ansi/freopen.c
+++ b/tests/ansi/freopen.c
@@ -5,6 +5,9 @@
 // This test is also built for the ANSI-only mlibc configuration. In that
 // configuration neither fileno() nor unlink() is available.
 #if defined(USE_HOST_LIBC) || __MLIBC_POSIX_OPTION
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #define TEST_HAS_POSIX 1
 #else
@@ -19,6 +22,34 @@
 #define TEST_FILE "freopen.tmp"
 #endif
 
+#if TEST_HAS_POSIX
+static void test_descriptor_limit(void) {
+	struct rlimit saved_limit;
+	assert(getrlimit(RLIMIT_NOFILE, &saved_limit) == 0);
+
+	FILE *file = fopen("/dev/null", "w");
+	assert(file);
+
+	struct rlimit limited = saved_limit;
+	limited.rlim_cur = fileno(file) + 1;
+	assert(setrlimit(RLIMIT_NOFILE, &limited) == 0);
+
+	errno = 0;
+	assert(freopen("/dev/null", "w", file) == NULL);
+	assert(errno == EMFILE);
+
+	assert(setrlimit(RLIMIT_NOFILE, &saved_limit) == 0);
+}
+
+static void test_close_on_exec(void) {
+	FILE *file = fopen("/dev/null", "w");
+	assert(file);
+	assert(freopen("/dev/null", "we", file));
+	assert(fcntl(fileno(file), F_GETFD) & FD_CLOEXEC);
+	assert(fclose(file) == 0);
+}
+#endif
+
 int main() {
 	// POSIX requires freopen() to ignore errors while flushing the old stream.
 	FILE *full = fopen("/dev/full", "w");
@@ -26,6 +57,11 @@ int main() {
 	assert(fwrite("x", 1, 1, full) == 1);
 	assert(freopen("/dev/null", "w", full));
 	assert(fclose(full) == 0);
+
+#if TEST_HAS_POSIX
+	test_descriptor_limit();
+	test_close_on_exec();
+#endif
 
 	FILE *file = fopen(TEST_FILE, "w");
 	assert(file);


### PR DESCRIPTION
Part of the Compiling GCC on Managarm project.