### PR TITLE
options/ansi: Keep pipe seek failures out of ferror()

### DIFF
--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -324,13 +324,14 @@ int abstract_file::seek(off_t offset, int whence) {
 	if(whence == SEEK_CUR) {
 		auto seek_offset = offset + (off_t(__offset) - off_t(__io_offset));
 		if(int e = io_seek(seek_offset, whence, &new_offset); e) {
-			__status_bits |= __MLIBC_ERROR_BIT;
+			// A pure seek failure is not a read/write error. In particular,
+			// ESPIPE on a pipe must not set ferror(); glibc keeps the stream
+			// error indicator clear in this case, so match glibc here.
 			return e;
 		}
 	}else{
 		__ensure(whence == SEEK_SET || whence == SEEK_END);
 		if(int e = io_seek(offset, whence, &new_offset); e) {
-			__status_bits |= __MLIBC_ERROR_BIT;
 			return e;
 		}
 	}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -87,6 +87,7 @@ all_test_cases = [
 	'posix/pthread_spin',
 	'posix/pwd',
 	'posix/fdopen',
+	'posix/fseek-pipe',
 	'posix/fopencookie',
 	'posix/fmemopen',
 	'posix/getaddrinfo',

--- a/tests/posix/fseek-pipe.c
+++ b/tests/posix/fseek-pipe.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void) {
+	int pipe_fds[2];
+	assert(!pipe(pipe_fds));
+
+	FILE *stream = fdopen(pipe_fds[1], "w");
+	assert(stream);
+
+	errno = 0;
+	assert(fseek(stream, 0, SEEK_CUR) == -1);
+	assert(errno == ESPIPE);
+	assert(!ferror(stream));
+
+	assert(!fclose(stream));
+	assert(!close(pipe_fds[0]));
+	return 0;
+}


### PR DESCRIPTION
Part of the Compiling GCC on Managarm project.