### PR TITLE
rtld: Use DTV indexes, not pointers as __tls_get_addr argument

### DIFF
--- a/options/lsb/generic/tls.cpp
+++ b/options/lsb/generic/tls.cpp
@@ -1,17 +1,7 @@
 #include <internal-config.h>
-#include <mlibc/thread.hpp>
 #include <mlibc/rtld-abi.hpp>
 
-#if (defined(__riscv) || defined(__m68k__) || defined(__loongarch64)) && defined(MLIBC_STATIC_BUILD)
-	// On RISC-V, m68k and loongarch64, linker optimisation is not guaranteed and so we may
-	// still get calls to this function in statically linked binaries.
-	// TODO: This will break dlopen calls from statically linked programs.
-	extern "C" void *__tls_get_addr(struct __abi_tls_entry *entry) {
-		Tcb *tcbPtr = mlibc::get_current_tcb();
-		auto dtvPtr = reinterpret_cast<char *>(tcbPtr->dtvPointers[0]);
-		return reinterpret_cast<void *>(dtvPtr + entry->offset + TLS_DTV_OFFSET);
-	}
-#elif defined(__i386__)
+#if defined(__i386__)
 	extern "C" __attribute__((regparm(1))) void *___tls_get_addr(struct __abi_tls_entry *entry) {
 		return __dlapi_get_tls(entry);
 	}

--- a/options/rtld/generic/linker.cpp
+++ b/options/rtld/generic/linker.cpp
@@ -1198,7 +1198,7 @@ SharedObject::SharedObject(const char *name, frg::string<MemoryAllocator> path,
 		lazyExplicitAddend(false), symbolicResolution(false),
 		eagerBinding(false), haveStaticTls(false),
 		dependencies(getAllocator()), tlsModel(TlsModel::null),
-		tlsOffset(0), globalRts(0), wasLinked(false),
+		tlsIndex(0), tlsOffset(0), globalRts(0), wasLinked(false),
 		scheduledForInit(false), onInitStack(false),
 		wasInitialized(false) { }
 
@@ -1393,7 +1393,10 @@ void doDestruct(SharedObject *object) {
 // --------------------------------------------------------
 
 RuntimeTlsMap::RuntimeTlsMap()
-: initialPtr{0}, initialLimit{0}, indices{getAllocator()}, tcbs{getAllocator()} { }
+: initialPtr{0}, initialLimit{0}, indices{getAllocator()}, tcbs{getAllocator()} {
+	// Reserve index zero: the psABI uses it to denote the absence of a TLS module.
+	indices.push_back(nullptr);
+}
 
 void initTlsObjects(Tcb *tcb, const frg::vector<SharedObject *, MemoryAllocator> &objects, bool checkInitialized) {
 	// Initialize TLS segments that follow the static model.
@@ -1478,7 +1481,7 @@ Tcb *allocateTcb() {
 	tcb_ptr->dtvSize = runtimeTlsMap->indices.size();
 	tcb_ptr->dtvPointers = frg::construct_n<void *>(getAllocator(), runtimeTlsMap->indices.size());
 	memset(tcb_ptr->dtvPointers, 0, sizeof(void *) * runtimeTlsMap->indices.size());
-	for(size_t i = 0; i < runtimeTlsMap->indices.size(); ++i) {
+	for(size_t i = 1; i < runtimeTlsMap->indices.size(); ++i) {
 		auto object = runtimeTlsMap->indices[i];
 		if(object->tlsModel == TlsModel::initial) {
 			if constexpr (tlsAboveTp) {
@@ -1500,12 +1503,13 @@ Tcb *allocateTcb() {
 	return tcb_ptr;
 }
 
-void *accessDtv(SharedObject *object) {
+void *accessDtvIndex(size_t index) {
 	Tcb *tcb_ptr = mlibc::get_current_tcb();
 	size_t size = __atomic_load_n(&tcb_ptr->dtvSize, __ATOMIC_ACQUIRE);
-	__ensure(object->tlsIndex < size);
+	__ensure(index);
+	__ensure(index < size);
 	void **pointers = __atomic_load_n(&tcb_ptr->dtvPointers, __ATOMIC_ACQUIRE);
-	void *ptr = pointers[object->tlsIndex];
+	void *ptr = pointers[index];
 	__ensure(ptr);
 	return (void *)((char *)ptr + TLS_DTV_OFFSET);
 }
@@ -1514,7 +1518,7 @@ void *tryAccessDtv(SharedObject *object) {
 	Tcb *tcb_ptr = mlibc::get_current_tcb();
 
 	size_t size = __atomic_load_n(&tcb_ptr->dtvSize, __ATOMIC_ACQUIRE);
-	if (object->tlsIndex >= size)
+	if (!object->tlsIndex || object->tlsIndex >= size)
 		return nullptr;
 	void **pointers = __atomic_load_n(&tcb_ptr->dtvPointers, __ATOMIC_ACQUIRE);
 	void *ptr = pointers[object->tlsIndex];
@@ -1914,6 +1918,10 @@ size_t Loader::_buildTlsMaps() {
 			object->tlsIndex = runtimeTlsMap->indices.size();
 			runtimeTlsMap->indices.push_back(object);
 
+			// Linkers resolve the module index of the main executable to 1 statically,
+			// hence it has to be the first index that we hand out.
+			__ensure(!object->isMainObject || object->tlsIndex == 1);
+
 			object->tlsModel = TlsModel::initial;
 
 			if constexpr (tlsAboveTp) {
@@ -2168,17 +2176,19 @@ void Loader::_processRelocations(Relocation &rel) {
 	// DTPMOD and DTPREL are dynamic TLS relocations (for __tls_get_addr()).
 	// TPOFF is a relocation to the initial TLS model.
 	case R_TLS_DTPMOD: {
-		// sets the first `sizeof(uintptr_t)` bytes of `struct __abi_tls_entry`
-		// this means that we can just use the `SharedObject *` to resolve whatever we need
+		// Sets the module index of `struct __abi_tls_entry`. Linkers omit this relocation
+		// whenever they can determine the index themselves, so it has to match the ABI.
 		__ensure(!rel.addend_rel());
 		if(rel.symbol_index()) {
 			__ensure(p);
-			rel.relocate(elf_addr(p->object()));
+			__ensure(p->object()->tlsIndex);
+			rel.relocate(p->object()->tlsIndex);
 		}else{
 			if(rtldConfig.debugVerbose)
 				mlibc::infoLogger() << "rtld: Warning: TLS_DTPMOD64 with no symbol in object "
 					<< rel.object()->name << frg::endlog;
-			rel.relocate(elf_addr(rel.object()));
+			__ensure(rel.object()->tlsIndex);
+			rel.relocate(rel.object()->tlsIndex);
 		}
 	} break;
 	case R_TLS_DTPREL: {

--- a/options/rtld/generic/linker.cpp
+++ b/options/rtld/generic/linker.cpp
@@ -1525,7 +1525,9 @@ void *tryAccessDtv(SharedObject *object) {
 	if (!ptr)
 		return nullptr;
 
-	return (void *)((char *)ptr + TLS_DTV_OFFSET);
+	// Unlike accessDtvIndex(), this returns the start of the TLS block:
+	// the caller wants the segment itself and not an address that DTPREL offsets are relative to.
+	return ptr;
 }
 
 // --------------------------------------------------------

--- a/options/rtld/generic/linker.hpp
+++ b/options/rtld/generic/linker.hpp
@@ -351,7 +351,8 @@ struct RuntimeTlsMap {
 	// Size of the inital TLS segment.
 	size_t initialLimit;
 
-	// TLS indices.
+	// TLS indices. These are the module indices of the psABI and hence 1-based:
+	// index zero is reserved and never handed out to an object.
 	frg::vector<SharedObject *, MemoryAllocator> indices;
 
 	// Track all allocated TCBs.
@@ -363,7 +364,7 @@ extern frg::manual_box<RuntimeTlsMap> runtimeTlsMap;
 
 Tcb *allocateTcb();
 void initTlsObjects(Tcb *tcb, const frg::vector<SharedObject *, MemoryAllocator> &objects, bool checkInitialized);
-void *accessDtv(SharedObject *object);
+void *accessDtvIndex(size_t index);
 // Tries to access the DTV, if not allocated, or object doesn't have
 // PT_TLS, return nullptr.
 void *tryAccessDtv(SharedObject *object);

--- a/options/rtld/generic/main.cpp
+++ b/options/rtld/generic/main.cpp
@@ -701,7 +701,7 @@ const char *__dlapi_error() {
 
 extern "C" [[ gnu::visibility("default") ]]
 void *__dlapi_get_tls(struct __abi_tls_entry *entry) {
-	return reinterpret_cast<char *>(accessDtv(entry->object)) + entry->offset;
+	return reinterpret_cast<char *>(accessDtvIndex(entry->index)) + entry->offset;
 }
 
 extern "C" [[ gnu::visibility("default") ]]
@@ -1097,10 +1097,7 @@ int __dlapi_iterate_phdr(int (*callback)(struct dl_phdr_info *, size_t, void*), 
 		info.dlpi_phnum = object->phdrCount;
 		info.dlpi_adds = rtsCounter;
 		info.dlpi_subs = 0; // TODO(geert): implement dlclose().
-		if (object->tlsModel != TlsModel::null)
-			info.dlpi_tls_modid = object->tlsIndex;
-		else
-			info.dlpi_tls_modid = 0;
+		info.dlpi_tls_modid = object->tlsIndex;
 		info.dlpi_tls_data = tryAccessDtv(object);
 
 		last_return = callback(&info, sizeof(struct dl_phdr_info), data);

--- a/options/rtld/include/mlibc/rtld-abi.hpp
+++ b/options/rtld/include/mlibc/rtld-abi.hpp
@@ -5,8 +5,10 @@
 
 #if defined(__x86_64__) || defined(__aarch64__) || defined(__i386__) || defined(__riscv) || defined (__m68k__) || defined(__loongarch64)
 
+// This is the psABI's tls_index: a TLS module index and an offset into that module's TLS block.
+// Both words are ABI: linkers resolve them statically (to 1) for symbols that live in the main executable.
 struct __abi_tls_entry {
-	struct SharedObject *object;
+	size_t index;
 	size_t offset;
 };
 static_assert(sizeof(__abi_tls_entry) == sizeof(size_t) * 2, "Bad __abi_tls_entry size");

--- a/tests/rtld/meson.build
+++ b/tests/rtld/meson.build
@@ -16,6 +16,7 @@ rtld_test_cases = [
 	'scope5',
 	'search-order',
 	'tls_align',
+	'tls_modid',
 	'dlopen-tls-relocation',
 	'relr',
 	'symver',

--- a/tests/rtld/tls_modid/meson.build
+++ b/tests/rtld/tls_modid/meson.build
@@ -1,0 +1,1 @@
+# This test needs no additional DSOs.

--- a/tests/rtld/tls_modid/test.c
+++ b/tests/rtld/tls_modid/test.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+#include <link.h>
+#include <stddef.h>
+#include <string.h>
+
+// Gives the executable a PT_TLS segment.
+__thread int exe_tls = 42;
+
+struct result {
+	int found_self;
+};
+
+static const ElfW(Phdr) *find_tls_phdr(struct dl_phdr_info *info) {
+	for (size_t i = 0; i < info->dlpi_phnum; i++) {
+		if (info->dlpi_phdr[i].p_type == PT_TLS)
+			return &info->dlpi_phdr[i];
+	}
+	return NULL;
+}
+
+static int callback(struct dl_phdr_info *info, size_t size, void *data) {
+	assert(size == sizeof(struct dl_phdr_info));
+	struct result *found = (struct result *) data;
+
+	// A module index of zero means that the object has no TLS segment.
+	const ElfW(Phdr) *tls_phdr = find_tls_phdr(info);
+	assert(!info->dlpi_tls_modid == !tls_phdr);
+
+	if (strcmp("", info->dlpi_name))
+		return 0;
+	found->found_self++;
+
+	// Linkers resolve the module index of the executable's own TLS symbols statically
+	// to one, hence the runtime has to agree on that assignment.
+	assert(info->dlpi_tls_modid == 1);
+
+	// Check that the index really does select the executable's own TLS block.
+	assert(tls_phdr);
+	char *block = info->dlpi_tls_data;
+	assert(block);
+	assert((char *)&exe_tls >= block);
+	assert((char *)&exe_tls + sizeof(exe_tls) <= block + tls_phdr->p_memsz);
+	return 0;
+}
+
+int main() {
+	assert(exe_tls == 42);
+
+	struct result found = { 0 };
+	assert(!dl_iterate_phdr(callback, &found));
+	assert(found.found_self == 1);
+	return 0;
+}


### PR DESCRIPTION
Prior to this change, mlibc resolved relocations of the first `__abi_tls_entry` word to a pointer to our internal `SharedObject` struct and `__tls_get_addr` used that struct to find the TLS offset.

However, it turns out that linkers may not always generate relocations for `__abi_tls_entry`. In particular, if a dynamic TLS object is statically linked into an executable, the linker will hard code `1` as the first `__abi_tls_entry` word. This is not visible on x86_64 and aarch64 where the whole `__tls_get_addr` call is eliminated in that case, but it faults on RISC-V.