### PR TITLE
sysdeps/managarm: Detect cancellation using globalSignalFlag

### DIFF
--- a/sysdeps/managarm/generic/entry.cpp
+++ b/sysdeps/managarm/generic/entry.cpp
@@ -121,12 +121,12 @@ bool cancellationRequested() {
 	pthread_once(&has_cached_infos, &actuallyCacheInfos);
 	if (!__mlibc_cached_thread_page)
 		return false;
-	return __mlibc_cached_thread_page->cancellationRequested;
-}
-
-void resetCancellationRequested() {
-	pthread_once(&has_cached_infos, &actuallyCacheInfos);
-	__mlibc_cached_thread_page->cancellationRequested = false;
+	auto gsf = __atomic_load_n(&__mlibc_cached_thread_page->globalSignalFlag, __ATOMIC_RELAXED);
+	// Precondition: this function must only be called in a SignalGuard.
+	__ensure(gsf);
+	// globalSignalFlag == 2 means that this thread accepted a signal that is delivery at guard exit.
+	// In-flight cancellable operations must be cancelled so the guard can end.
+	return gsf == 2;
 }
 
 void setQueueHandle(HelHandle queue) {

--- a/sysdeps/managarm/include/mlibc/posix-pipe.hpp
+++ b/sysdeps/managarm/include/mlibc/posix-pipe.hpp
@@ -16,7 +16,6 @@
 #include <protocols/posix/data.hpp>
 #include <protocols/posix/supercalls.hpp>
 
-void resetCancellationRequested();
 bool cancellationRequested();
 void setQueueHandle(HelHandle queue);
 
@@ -222,9 +221,12 @@ struct Queue {
 		__atomic_fetch_or(&_queue->kernelNotify, kHelKernelNotifySqProgress, __ATOMIC_RELEASE);
 	}
 
-	frg::optional<ElementHandle> dequeueSingleUnlessCancelled() {
+private:
+	// If checkCancellation is true, return nullopt if cancellationRequested() becomes true (and do not wait for completion).
+	// Otherwise, always wait for completion (whether cancellationRequested() becomes true or not).
+	frg::optional<ElementHandle> dequeueSingle_(bool checkCancellation) {
 		while (true) {
-			auto progress = _waitProgressFutex();
+			auto progress = _waitProgressFutex(checkCancellation);
 
 			auto n = _retrieveChunk;
 			__ensure(_refCount[n]);
@@ -253,14 +255,13 @@ struct Queue {
 		}
 	}
 
+public:
+	frg::optional<ElementHandle> dequeueSingleUnlessCancelled() {
+		return dequeueSingle_(true);
+	}
+
 	ElementHandle dequeueSingle() {
-		while (true) {
-			auto result = dequeueSingleUnlessCancelled();
-			if (result)
-				return *result;
-			else
-				resetCancellationRequested();
-		}
+		return *dequeueSingle_(false);
 	}
 
 	void retire(int n) {
@@ -296,7 +297,7 @@ private:
 	};
 
 	// Postcondition: return value != FutexProgress::NONE.
-	FutexProgress _waitProgressFutex() {
+	FutexProgress _waitProgressFutex(bool checkCancellation) {
 		// userNotify bits checked by this function (these MUST be checked in the loop below!).
 		const auto relevantNotify = kHelUserNotifyCqProgress | kHelUserNotifyAlert;
 		// userNotify bits ignored by this function.
@@ -330,7 +331,7 @@ private:
 			if (!notifyToClear) {
 				__ensure(!(_pendingNotify & ~maskedNotify));
 
-				if (cancellationRequested())
+				if (checkCancellation && cancellationRequested())
 					return FutexProgress::CANCELLED;
 				int err = helDriveQueue(_handle, kHelDriveWait, maskedNotify);
 				if (err != kHelErrCancelled)
@@ -464,19 +465,15 @@ auto exchangeMsgsSyncCancellable(HelHandle descriptor, uint64_t cancelId, int fd
 
 	pushExchangeMsgsToSq(descriptor, 0, actions.data(), actions.size());
 
-	frg::optional<ElementHandle> element{};
-
-	do {
-		element = globalQueue.dequeueSingleUnlessCancelled();
-		if (!element) {
-			HEL_CHECK(helSyscall2(
-				kHelCallSuper + posix::superCancel,
-				cancelId,
-				fd
-			));
-			resetCancellationRequested();
-		}
-	} while (!element);
+	auto element = globalQueue.dequeueSingleUnlessCancelled();
+	if (!element) {
+		HEL_CHECK(helSyscall2(
+			kHelCallSuper + posix::superCancel,
+			cancelId,
+			fd
+		));
+		element = globalQueue.dequeueSingle();
+	}
 
 	void *ptr = element->data();
 
@@ -509,7 +506,6 @@ auto exchangeMsgsSyncCancelViaLane(HelHandle descriptor, MakeCancel &&makeCancel
 		auto cancelExchange = makeCancel();
 		auto cancelActions = helix_ng::chainActionArrays(cancelExchange);
 		pushExchangeMsgsToSq(descriptor, cancelContext, cancelActions.data(), cancelActions.size());
-		resetCancellationRequested();
 
 		bool cancelDone = false;
 		while (!reqElement || !cancelDone) {


### PR DESCRIPTION
This refactors cancellation to look at `globalSignalFlag`, not `cancellationRequested` in the thread page. This is simpler because it handles resetting the flag correctly in all cases.

All operations that can be canceled are in a `SignalGuard` anyway. `globalSignalFlag` is 1 when the guard is entered. It becomes 2 when a signal is accepted and it is reset together with the `SignalGuard`.

The old mechanism made is look as if cancelable operations were supported outside `SignalGuard`s, but that wouldn't have worked reliably anyway due to races.