### PR TITLE
options/ansi: track the access mode of files

### DIFF
--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -104,12 +104,24 @@ void abstract_file::dispose() {
 	_do_dispose(this);
 }
 
+void abstract_file::set_access_mode(int flags) {
+	_readable = (flags & O_ACCMODE) != O_WRONLY;
+	_writable = (flags & O_ACCMODE) != O_RDONLY;
+}
+
 // Note that read() and write() are asymmetric:
 // While read() can trigger a write-back, write() can never trigger a read-ahead().
 // This peculiarity is reflected in their code.
 
 int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 	__ensure(max_size);
+
+	// [C11-7.21.5.3] Reading from a stream that was not opened for reading is an error.
+	// Note that this must not set the EOF bit.
+	if(!_readable) {
+		__status_bits |= __MLIBC_ERROR_BIT;
+		return EBADF;
+	}
 
 	if(_init_bufmode())
 		return -1;
@@ -186,6 +198,14 @@ int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 
 int abstract_file::write(const char *buffer, size_t max_size, size_t *actual_size) {
 	__ensure(max_size);
+
+	// [C11-7.21.5.3] Writing to a stream that was not opened for writing is an error.
+	// This has to be caught here rather than in io_write(), as buffered writes would
+	// otherwise succeed until the buffer is flushed.
+	if(!_writable) {
+		__status_bits |= __MLIBC_ERROR_BIT;
+		return EBADF;
+	}
 
 	if(_init_bufmode())
 		return -1;
@@ -464,8 +484,10 @@ void abstract_file::_ensure_allocation() {
 // fd_file implementation.
 // --------------------------------------------------------------------------------------
 
-fd_file::fd_file(int fd, void (*do_dispose)(abstract_file *), bool force_unbuffered)
-: abstract_file{do_dispose}, _fd{fd}, _force_unbuffered{force_unbuffered} { }
+fd_file::fd_file(int fd, int flags, void (*do_dispose)(abstract_file *), bool force_unbuffered)
+: abstract_file{do_dispose}, _fd{fd}, _force_unbuffered{force_unbuffered} {
+	set_access_mode(flags);
+}
 
 int fd_file::fd() {
 	return _fd;
@@ -515,6 +537,7 @@ int fd_file::reopen(const char *path, const char *mode) {
 	_fd = fd;
 	_orientation = stream_orientation::none;
 	_mbstate = {};
+	set_access_mode(mode_flags);
 
 	if(mode_flags & O_APPEND) {
 		seek(0, SEEK_END);
@@ -646,9 +669,9 @@ namespace {
 
 	[[gnu::constructor(MLIBC_INIT_PRIORITY_STDIO)]]
 	void init_stdio() {
-		stdin_box.initialize(0);
-		stdout_box.initialize(1);
-		stderr_box.initialize(2, nullptr, true);
+		stdin_box.initialize(0, O_RDONLY);
+		stdout_box.initialize(1, O_WRONLY);
+		stderr_box.initialize(2, O_WRONLY, nullptr, true);
 
 		stdin = stdin_box.get();
 		stdout = stdout_box.get();
@@ -694,7 +717,7 @@ FILE *fopen(const char *path, const char *mode) {
 		return nullptr;
 	}
 
-	return frg::construct<mlibc::fd_file>(getAllocator(), fd,
+	return frg::construct<mlibc::fd_file>(getAllocator(), fd, flags,
 			mlibc::file_dispose_cb<mlibc::fd_file>);
 }
 

--- a/options/ansi/generic/file-io.cpp
+++ b/options/ansi/generic/file-io.cpp
@@ -123,8 +123,8 @@ int abstract_file::read(char *buffer, size_t max_size, size_t *actual_size) {
 		return EBADF;
 	}
 
-	if(_init_bufmode())
-		return -1;
+	if(int e = _init_bufmode(); e)
+		return e;
 
 	size_t unget_length = 0;
 	if (__unget_ptr != __buffer_ptr) {
@@ -207,8 +207,8 @@ int abstract_file::write(const char *buffer, size_t max_size, size_t *actual_siz
 		return EBADF;
 	}
 
-	if(_init_bufmode())
-		return -1;
+	if(int e = _init_bufmode(); e)
+		return e;
 	if(globallyDisableBuffering || _bufmode == buffer_mode::no_buffer) {
 		// As we do not buffer, nothing can be dirty.
 		__ensure(__dirty_begin == __dirty_end);
@@ -390,8 +390,8 @@ int abstract_file::_init_bufmode() {
 	if(_bufmode != buffer_mode::unknown)
 		return 0;
 
-	if(determine_bufmode(&_bufmode))
-		return -1;
+	if(int e = determine_bufmode(&_bufmode); e)
+		return e;
 	__ensure(_bufmode != buffer_mode::unknown);
 	return 0;
 }
@@ -581,7 +581,7 @@ int fd_file::determine_bufmode(buffer_mode *mode) {
 	}else{
 		mlibc::infoLogger() << "mlibc: sys_isatty() failed while determining whether"
 				" stream is interactive" << frg::endlog;
-		return -1;
+		return e;
 	}
 }
 

--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -195,11 +195,10 @@ size_t fwrite_unlocked_ignore_orientation(const void *buffer, size_t size, size_
 		size_t progress = 0;
 		while(progress < count) {
 			size_t chunk;
-			if(file->write((const char *)buffer + progress,
-					count - progress, &chunk)) {
-				// TODO: Handle I/O errors.
-				mlibc::infoLogger() << "mlibc: fwrite() I/O errors are not handled"
-						<< frg::endlog;
+			if(int e = file->write((const char *)buffer + progress,
+					count - progress, &chunk); e) {
+				// TODO: e can be -1.
+				errno = e;
 				break;
 			}else if(!chunk) {
 				// TODO: Handle eof.
@@ -215,11 +214,10 @@ size_t fwrite_unlocked_ignore_orientation(const void *buffer, size_t size, size_
 			size_t progress = 0;
 			while(progress < size) {
 				size_t chunk;
-				if(file->write((const char *)buffer + i * size + progress,
-						size - progress, &chunk)) {
-					// TODO: Handle I/O errors.
-					mlibc::infoLogger() << "mlibc: fwrite() I/O errors are not handled"
-							<< frg::endlog;
+				if(int e = file->write((const char *)buffer + i * size + progress,
+						size - progress, &chunk); e) {
+					// TODO: e can be -1.
+					errno = e;
 					break;
 				}else if(!chunk) {
 					// TODO: Handle eof.
@@ -795,7 +793,8 @@ FILE *tmpfile(void) {
 		return nullptr;
 	}
 
-	return frg::construct<mlibc::fd_file>(getAllocator(), fd, mlibc::file_dispose_cb<mlibc::fd_file>);
+	return frg::construct<mlibc::fd_file>(getAllocator(), fd, O_RDWR,
+			mlibc::file_dispose_cb<mlibc::fd_file>);
 
 }
 

--- a/options/ansi/generic/stdio.cpp
+++ b/options/ansi/generic/stdio.cpp
@@ -197,7 +197,7 @@ size_t fwrite_unlocked_ignore_orientation(const void *buffer, size_t size, size_
 			size_t chunk;
 			if(int e = file->write((const char *)buffer + progress,
 					count - progress, &chunk); e) {
-				// TODO: e can be -1.
+				// TODO: ferror() may stay clear even on a real error.
 				errno = e;
 				break;
 			}else if(!chunk) {
@@ -216,7 +216,7 @@ size_t fwrite_unlocked_ignore_orientation(const void *buffer, size_t size, size_
 				size_t chunk;
 				if(int e = file->write((const char *)buffer + i * size + progress,
 						size - progress, &chunk); e) {
-					// TODO: e can be -1.
+					// TODO: ferror() may stay clear even on a real error.
 					errno = e;
 					break;
 				}else if(!chunk) {

--- a/options/ansi/include/mlibc/file-io.hpp
+++ b/options/ansi/include/mlibc/file-io.hpp
@@ -83,6 +83,8 @@ public:
 	bool check_orientation(stream_orientation orientation);
 
 protected:
+	void set_access_mode(int flags);
+
 	virtual int determine_type(stream_type *type) = 0;
 	virtual int determine_bufmode(buffer_mode *mode) = 0;
 	virtual int io_read(char *buffer, size_t max_size, size_t *actual_size) = 0;
@@ -104,6 +106,9 @@ private:
 	buffer_mode _bufmode;
 	void (*_do_dispose)(abstract_file *);
 
+	bool _readable = true;
+	bool _writable = true;
+
 public:
 	buffer_mode bufmode() const {
 		return _bufmode;
@@ -119,7 +124,9 @@ public:
 };
 
 struct fd_file : abstract_file {
-	fd_file(int fd, void (*do_dispose)(abstract_file *) = nullptr, bool force_unbuffered = false);
+	// From `flags` only the access mode is used.
+	fd_file(int fd, int flags, void (*do_dispose)(abstract_file *) = nullptr,
+			bool force_unbuffered = false);
 
 	int fd();
 

--- a/options/posix/generic/posix-file-io.cpp
+++ b/options/posix/generic/posix-file-io.cpp
@@ -271,6 +271,6 @@ FILE *fdopen(int fd, const char *mode) {
 
 	// TODO: We may need to activate line buffered mode for terminals.
 
-	return frg::construct<mlibc::fd_file>(getAllocator(), fd,
+	return frg::construct<mlibc::fd_file>(getAllocator(), fd, flags,
 			mlibc::file_dispose_cb<mlibc::fd_file>);
 }

--- a/options/posix/generic/posix_stdio.cpp
+++ b/options/posix/generic/posix_stdio.cpp
@@ -16,8 +16,8 @@
 #include <mlibc/posix-file-io.hpp>
 
 struct popen_file : mlibc::fd_file {
-	popen_file(int fd, void (*do_dispose)(abstract_file *) = nullptr)
-		: fd_file(fd, do_dispose) {}
+	popen_file(int fd, int flags, void (*do_dispose)(abstract_file *) = nullptr)
+		: fd_file(fd, flags, do_dispose) {}
 
 	pid_t get_popen_pid() {
 		return _popen_pid;
@@ -141,6 +141,7 @@ FILE *popen(const char *command, const char *typestr) {
 		ret = frg::construct<popen_file>(
 			getAllocator(),
 			fds[parent_end],
+			is_write ? O_WRONLY : O_RDONLY,
 			mlibc::file_dispose_cb<popen_file>
 		);
 		__ensure(ret);
@@ -202,7 +203,7 @@ int dprintf(int fd, const char *format, ...) {
 }
 
 int vdprintf(int fd, const char *format, __builtin_va_list args) {
-	mlibc::fd_file file{fd};
+	mlibc::fd_file file{fd, O_WRONLY};
 	int ret = vfprintf(&file, format, args);
 	file.flush();
 	return ret;

--- a/options/posix/include/mlibc/posix-file-io.hpp
+++ b/options/posix/include/mlibc/posix-file-io.hpp
@@ -9,7 +9,9 @@
 namespace mlibc {
 
 struct mem_file : abstract_file {
-	mem_file(int flags, void (*do_dispose)(abstract_file *) = nullptr) : abstract_file{do_dispose}, _flags{flags} { };
+	mem_file(int flags, void (*do_dispose)(abstract_file *) = nullptr) : abstract_file{do_dispose}, _flags{flags} {
+		set_access_mode(flags);
+	};
 
 	int reopen(const char *path, const char *mode) override;
 protected:
@@ -79,7 +81,9 @@ private:
 
 struct cookie_file : abstract_file {
 	cookie_file(void *cookie, int flags, cookie_io_functions_t funcs, void (*do_dispose)(abstract_file *) = nullptr)
-		: abstract_file{do_dispose}, _cookie{cookie}, _flags{flags}, _funcs{funcs} { }
+		: abstract_file{do_dispose}, _cookie{cookie}, _flags{flags}, _funcs{funcs} {
+			set_access_mode(flags);
+		}
 
 	int close() override;
 	int reopen(const char *path, const char *mode) override;

--- a/tests/ansi/fopen.c
+++ b/tests/ansi/fopen.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 
 #ifdef USE_HOST_LIBC
@@ -51,6 +52,45 @@ int main() {
 	assert(fread(buffer2, 1, sizeof(completestr) - 1, file));
 	assert(!strcmp(buffer2, completestr));
 	fclose(file);
+
+	// Writing to a stream that was not opened for writing must fail even though the
+	// write would otherwise just land in the buffer.
+	file = fopen(TEST_FILE, "r");
+	assert(file);
+	errno = 0;
+	assert(fwrite(str, 1, sizeof(str) - 1, file) == 0);
+	assert(errno == EBADF);
+	assert(ferror(file));
+	clearerr(file);
+	errno = 0;
+	assert(fputc('x', file) == EOF);
+	assert(errno == EBADF);
+	assert(ferror(file));
+	fclose(file);
+
+	// Likewise, reading from a stream that was not opened for reading fails and,
+	// unlike a short read, must not set the EOF indicator.
+	file = fopen(TEST_FILE, "w");
+	assert(file);
+	errno = 0;
+	assert(fread(buffer, 1, sizeof(buffer), file) == 0);
+	assert(errno == EBADF);
+	assert(ferror(file));
+	assert(!feof(file));
+	fclose(file);
+
+	// The standard streams carry an access mode as well.
+	errno = 0;
+	assert(fwrite(str, 1, 1, stdin) == 0);
+	assert(errno == EBADF);
+	assert(ferror(stdin));
+	clearerr(stdin);
+
+	errno = 0;
+	assert(fread(buffer, 1, 1, stdout) == 0);
+	assert(errno == EBADF);
+	assert(ferror(stdout));
+	clearerr(stdout);
 
 	// Check that stdout, stdin and stderr can be closed by the application (issue #12).
 	fclose(stdout);


### PR DESCRIPTION
abstract_file never recorded whether a stream was opened for reading,
writing or both, so a write to a read-only stream silently landed in the
buffer and only failed later at flush time. If the buffer was never
filled, it did not fail at all. Reads from a write-only stream had the
mirrored problem.

Record the access mode from the O_* flags the stream was opened with and
reject the operation with EBADF in abstract_file::{read,write}(), setting
the error indicator but not the EOF indicator.

Closes #1251, however there appears to be another printf bug that MPFR tests have caught, so we are not yet done with MPFR tests.