### PR TITLE
options/posix+abis/linux: expose gated `sys/resource.h` XSI declarations

### DIFF
--- a/abis/linux/resource.h
+++ b/abis/linux/resource.h
@@ -13,7 +13,6 @@ extern "C" {
 #define PRIO_MAX 20
 #endif /* defined(_GNU_SOURCE) */
 
-#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 #define PRIO_PROCESS 0
 #define PRIO_PGRP 1
 #define PRIO_USER 2
@@ -22,8 +21,6 @@ extern "C" {
 #define RUSAGE_CHILDREN -1
 
 #define RLIMIT_CPU 0
-#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
-
 #define RLIMIT_FSIZE 1
 #define RLIMIT_DATA 2
 #define RLIMIT_STACK 3
@@ -44,7 +41,6 @@ extern "C" {
 #define RLIMIT_NLIMITS 16
 #endif
 
-#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 struct rusage {
 	struct timeval ru_utime;
 	struct timeval ru_stime;
@@ -63,7 +59,6 @@ struct rusage {
 	long ru_nvcsw;
 	long ru_nivcsw;
 };
-#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 #ifdef __cplusplus
 }

--- a/options/posix/include/sys/resource.h
+++ b/options/posix/include/sys/resource.h
@@ -31,12 +31,10 @@ struct rlimit {
 
 #ifndef __MLIBC_ABI_ONLY
 
-#if defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN
 int getpriority(int __which, id_t __who);
 int setpriority(int __which, id_t __who, int __prio);
 
 int getrusage(int __who, struct rusage *__usage);
-#endif /* defined(_DEFAULT_SOURCE) || __MLIBC_XOPEN */
 
 int getrlimit(int __resource, struct rlimit *__rlim);
 int setrlimit(int __resource, const struct rlimit *__rlim);


### PR DESCRIPTION
These declarations were gated where neither glibc nor musl gates them.

Caught when compiling zstd for linux against mlibc. Introduces namespace pollution that was previously fixed but it's namespace pollution that zstd expects under linux. Possibly the gating could be relaxed but only for Linux in order to not introduce namespace pollution under other other targets.