### PR TITLE
options/internal: let allocations fail instead of aborting

### DIFF
--- a/options/ansi/generic/stdlib.cpp
+++ b/options/ansi/generic/stdlib.cpp
@@ -566,6 +566,8 @@ void free(void *ptr) {
 
 void *malloc(size_t size) {
 	auto nptr = getAllocator().allocate(size);
+	if (!nptr)
+		errno = ENOMEM;
 	// TODO: Print PID only if POSIX option is enabled.
 	if (mlibc::globalConfig().debugMalloc)
 		mlibc::infoLogger() << "mlibc (PID ?): malloc() returns "
@@ -575,6 +577,8 @@ void *malloc(size_t size) {
 
 void *realloc(void *ptr, size_t size) {
 	auto nptr = getAllocator().reallocate(ptr, size);
+	if (!nptr && size)
+		errno = ENOMEM;
 	// TODO: Print PID only if POSIX option is enabled.
 	if (mlibc::globalConfig().debugMalloc)
 		mlibc::infoLogger() << "mlibc (PID ?): realloc() on "

--- a/options/internal/generic/allocator.cpp
+++ b/options/internal/generic/allocator.cpp
@@ -34,7 +34,8 @@ MemoryAllocator &getAllocator() {
 
 uintptr_t VirtualAllocator::map(size_t length) {
 	void *ptr;
-	__ensure(!mlibc::sysdep<AnonAllocate>(length, &ptr));
+	if (mlibc::sysdep<AnonAllocate>(length, &ptr))
+		return 0;
 	return (uintptr_t)ptr;
 }
 

--- a/tests/ansi/alloc_oom.c
+++ b/tests/ansi/alloc_oom.c
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+#include <assert.h>
+#include <stdint.h>
+#include <errno.h>
+
+int main() {
+	void *p;
+
+	// An allocation the system cannot possibly satisfy has to fail by returning
+	// NULL, not by aborting the process.
+	errno = 0;
+	p = malloc(SIZE_MAX / 4);
+	assert(p == NULL);
+	assert(errno == ENOMEM);
+
+	errno = 0;
+	p = realloc(NULL, SIZE_MAX / 4);
+	assert(p == NULL);
+	assert(errno == ENOMEM);
+
+	// The allocator has to stay usable afterwards.
+	p = malloc(64);
+	assert(p != NULL);
+	free(p);
+
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,6 +2,7 @@ timeout_sec = 10
 
 all_test_cases = [
 	'ansi/alloc',
+	'ansi/alloc_oom',
 	'ansi/sscanf',
 	'ansi/sprintf',
 	'ansi/snprintf',
@@ -234,6 +235,7 @@ host_libc_excluded_test_cases = [
 	'rtld/fail-load', # glibc gives non-deterministic errors
 ]
 host_libc_noasan_test_cases = [
+	'ansi/alloc_oom', # purposefully allocates huge amounts
 	'posix/pthread_cancel',
 	'posix/pthread_attr', # does some stack overflowing to check stack size
 	'posix/posix_memalign',


### PR DESCRIPTION
frg::slab_pool already treats a zero return from the policy's map() as an
allocation failure and passes it on as a null pointer, so reporting the
error is all that is needed.

Found via OpenSSL's mem_alloc_test.