### PR TITLE
options/posix: fix inet_pton() for embedded IPv4 with a zero octet

### DIFF
--- a/options/posix/generic/arpa-inet.cpp
+++ b/options/posix/generic/arpa-inet.cpp
@@ -301,7 +301,7 @@ int inet_pton(int af, const char *__restrict src, void *__restrict dst) {
 					if(ipv4end[0] != '.' || value0 > UINT8_MAX || src == ipv4end)
 						return 0;
 					// reject overlong segments or leading zeroes
-					if ((ipv4end - src) > 3 || (src[0] == '0' && value))
+					if ((ipv4end - src) > 3 || (src[0] == '0' && ipv4end - src > 1))
 						return 0;
 					src = ipv4end + 1;
 					if (!isdigit(*src))
@@ -311,7 +311,7 @@ int inet_pton(int af, const char *__restrict src, void *__restrict dst) {
 					if(ipv4end[0] != '.' || value1 > UINT8_MAX || src == ipv4end)
 						return 0;
 					// reject overlong segments or leading zeroes
-					if ((ipv4end - src) > 3 || (src[0] == '0' && value))
+					if ((ipv4end - src) > 3 || (src[0] == '0' && ipv4end - src > 1))
 						return 0;
 					array[i++] = htons((value0 << 8) | value1);
 					src = ipv4end + 1;
@@ -323,7 +323,7 @@ int inet_pton(int af, const char *__restrict src, void *__restrict dst) {
 					if(ipv4end[0] != '.' || value2 > UINT8_MAX || src == ipv4end)
 						return 0;
 					// reject overlong segments or leading zeroes
-					if ((ipv4end - src) > 3 || (src[0] == '0' && value))
+					if ((ipv4end - src) > 3 || (src[0] == '0' && ipv4end - src > 1))
 						return 0;
 					src = ipv4end + 1;
 					if (!isdigit(*src))
@@ -333,7 +333,7 @@ int inet_pton(int af, const char *__restrict src, void *__restrict dst) {
 					if(value3 > UINT8_MAX || src == ipv4end)
 						return 0;
 					// reject overlong segments or leading zeroes
-					if ((ipv4end - src) > 3 || (src[0] == '0' && value))
+					if ((ipv4end - src) > 3 || (src[0] == '0' && ipv4end - src > 1))
 						return 0;
 					array[i] = htons((value2 << 8) | value3);
 					end = ipv4end;

--- a/tests/posix/inet_pton.c
+++ b/tests/posix/inet_pton.c
@@ -142,6 +142,49 @@ int main() {
 		assert(!memcmp(&addr6, &test6, sizeof(addr6)));
 	}
 
+	// An embedded IPv4 address may contain zero octets.
+	{
+		struct in6_addr addr6 = {
+			.s6_addr = {
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0xFF, 0xFF, 127, 0, 0, 1,
+			},
+		};
+		int ret = inet_pton(AF_INET6, "::FFFF:127.0.0.1", &test6);
+		assert(ret == 1);
+		assert(!memcmp(&addr6, &test6, sizeof(addr6)));
+	}
+
+	{
+		struct in6_addr addr6 = {
+			.s6_addr = {
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0xFF, 0xFF, 0, 0, 0, 0,
+			},
+		};
+		int ret = inet_pton(AF_INET6, "::FFFF:0.0.0.0", &test6);
+		assert(ret == 1);
+		assert(!memcmp(&addr6, &test6, sizeof(addr6)));
+	}
+
+	{
+		struct in6_addr addr6 = {
+			.s6_addr = {
+				0x00, 0x64, 0xFF, 0x9B, 0, 0, 0, 0,
+				0, 0, 0, 0, 192, 0, 2, 1,
+			},
+		};
+		int ret = inet_pton(AF_INET6, "64:ff9b::192.0.2.1", &test6);
+		assert(ret == 1);
+		assert(!memcmp(&addr6, &test6, sizeof(addr6)));
+	}
+
+	// A zero octet is still not allowed to carry a leading zero.
+	assert(!inet_pton(AF_INET6, "::FFFF:127.00.0.1", &test6));
+	assert(!inet_pton(AF_INET6, "::FFFF:00.0.0.0", &test6));
+	assert(!inet_pton(AF_INET6, "::FFFF:01.2.3.4", &test6));
+	assert(!inet_pton(AF_INET6, "::FFFF:1.2.3.04", &test6));
+
 	assert(!inet_pton(AF_INET6, "2606:4700:4700:0000:0000:0000:0000:01111", &test6));
 	assert(!inet_pton(AF_INET6, "2606:4700:4700:0000:0000:0000:000g:1111", &test6));
 	assert(!inet_pton(AF_INET6, " 2606:4700:4700:0000:0000:0000:0000:1111", &test6));


### PR DESCRIPTION
This patch rejects "01" and "007" as before, accepts a plain "0", and
additionally rejects "00", which the old check accepted. This amtches
glibc for every form tested.

Note this only concerns IPv4 addresses embedded in an IPv6 address. IPv4
addresses are not affected.

Found via OpenSSL's tests