### PR TITLE
abis/linux+options/posix: add ECN-related macros

### DIFF
--- a/abis/linux/in.h
+++ b/abis/linux/in.h
@@ -167,6 +167,7 @@ struct group_source_req {
 #define IP_MTU_DISCOVER 10
 #define IP_RECVERR 11
 #define IP_RECVTTL 12
+#define IP_RECVTOS 13
 #define IP_MTU 14
 #define IP_MULTICAST_IF 32
 #define IP_MULTICAST_TTL 33

--- a/options/posix/include/netinet/ip.h
+++ b/options/posix/include/netinet/ip.h
@@ -9,6 +9,13 @@ extern "C" {
 #include <sys/types.h>
 #include <netinet/in.h>
 
+#define IPTOS_ECN_MASK 0x3
+#define IPTOS_ECN(ecn) ((ecn) & IPTOS_ECN_MASK)
+#define IPTOS_ECN_NOT_ECT 0x0
+#define IPTOS_ECN_ECT1 0x1
+#define IPTOS_ECN_ECT0 0x2
+#define IPTOS_ECN_CE 0x3
+
 #define IPTOS_TOS_MASK 0x1E
 #define IPTOS_TOS(tos) ((tos) & IPTOS_TOS_MASK)
 #define IPTOS_LOWDELAY 0x10


### PR DESCRIPTION
Makes ngtcp2 build on Linux.