### PR TITLE
bdwgc fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -470,6 +470,7 @@ configure_file(input: 'mlibc-config.h.in',
 
 internal_sources = [
 	'options/internal/generic/allocator.cpp',
+	'options/internal/generic/atfork.cpp',
 	'options/internal/generic/c-locale-defaults.cpp',
 	'options/internal/generic/charcode.cpp',
 	'options/internal/generic/charset.cpp',

--- a/options/bsd-procdesc/generic/sys-procdesc.cpp
+++ b/options/bsd-procdesc/generic/sys-procdesc.cpp
@@ -4,6 +4,7 @@
 
 #include <bits/ensure.h>
 #include <mlibc/all-sysdeps.hpp>
+#include <mlibc/atfork.hpp>
 #include <mlibc/debug.hpp>
 #include <mlibc/tid.hpp>
 #include <mlibc/thread.hpp>
@@ -14,33 +15,21 @@ pid_t pdfork(int *fdp, int flags) {
 
 	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Pdfork>, -1);
 
-	auto hand = self->atforkEnd;
-	while (hand) {
-		if (hand->prepare)
-			hand->prepare();
-
-		hand = hand->prev;
-	}
+	mlibc::atfork_prepare();
 
 	if(int e = mlibc::sysdep_or_panic<Pdfork>(fdp, flags, &child); e) {
+		// The parent handlers run even when the fork failed.
+		mlibc::atfork_parent();
 		errno = e;
 		return -1;
 	}
 
-	// update the cached TID in the TCB
-	if (!child)
+	if (!child) {
+		// update the cached TID in the TCB
 		__atomic_store_n(&self->tid, mlibc::refetch_tid(), __ATOMIC_RELAXED);
-
-	hand = self->atforkBegin;
-	while (hand) {
-		if (!child) {
-			if (hand->child)
-				hand->child();
-		} else {
-			if (hand->parent)
-				hand->parent();
-		}
-		hand = hand->next;
+		mlibc::atfork_child();
+	} else {
+		mlibc::atfork_parent();
 	}
 
 	return child;

--- a/options/internal/generic/atfork.cpp
+++ b/options/internal/generic/atfork.cpp
@@ -1,0 +1,79 @@
+#include <errno.h>
+
+#include <mlibc/allocator.hpp>
+#include <mlibc/atfork.hpp>
+#include <mlibc/lock.hpp>
+
+namespace mlibc {
+
+namespace {
+
+struct atfork_handler {
+	void (*prepare)(void);
+	void (*parent)(void);
+	void (*child)(void);
+
+	atfork_handler *next;
+	atfork_handler *prev;
+};
+
+atfork_handler *handler_begin = nullptr;
+atfork_handler *handler_end = nullptr;
+
+// Held from the first prepare handler until the last parent or child one, so
+// that a concurrent pthread_atfork() cannot change the list halfway through.
+constinit FutexLock handler_lock{};
+
+} // namespace
+
+int atfork_register(void (*prepare)(void), void (*parent)(void), void (*child)(void)) {
+	auto hand = frg::construct<atfork_handler>(getAllocator());
+	if (!hand)
+		return ENOMEM;
+
+	hand->prepare = prepare;
+	hand->parent = parent;
+	hand->child = child;
+	hand->next = nullptr;
+
+	handler_lock.lock();
+
+	hand->prev = handler_end;
+	if (handler_end)
+		handler_end->next = hand;
+	handler_end = hand;
+
+	if (!handler_begin)
+		handler_begin = hand;
+
+	handler_lock.unlock();
+
+	return 0;
+}
+
+void atfork_prepare(void) {
+	handler_lock.lock();
+
+	// POSIX runs the prepare handlers in the reverse order of registration.
+	for (auto hand = handler_end; hand; hand = hand->prev)
+		if (hand->prepare)
+			hand->prepare();
+}
+
+void atfork_parent(void) {
+	for (auto hand = handler_begin; hand; hand = hand->next)
+		if (hand->parent)
+			hand->parent();
+
+	handler_lock.unlock();
+}
+
+void atfork_child(void) {
+	for (auto hand = handler_begin; hand; hand = hand->next)
+		if (hand->child)
+			hand->child();
+
+	handler_lock.reset_after_fork();
+}
+
+} // namespace mlibc

--- a/options/internal/include/mlibc/atfork.hpp
+++ b/options/internal/include/mlibc/atfork.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace mlibc {
+
+int atfork_register(void (*prepare)(void), void (*parent)(void), void (*child)(void));
+
+// Run the prepare handlers and take the lock that keeps the list from changing
+// for the duration of the fork. Every call must be followed by exactly one call
+// to atfork_parent() or atfork_child(), including when the fork itself failed.
+void atfork_prepare(void);
+void atfork_parent(void);
+void atfork_child(void);
+
+} // namespace mlibc

--- a/options/internal/include/mlibc/lock.hpp
+++ b/options/internal/include/mlibc/lock.hpp
@@ -118,6 +118,16 @@ struct alignas(4) FutexLockImpl {
 			__ensure(e >= 0 || e == EACCES || e == EINVAL);
 		}
 	}
+
+	// A lock held across fork() cannot be unlocked in the child: the thread that
+	// took it has a different thread ID there, and the threads that were waiting
+	// on it do not exist at all. Since the child only runs the thread that
+	// forked, putting the lock back into the unlocked state is all there is to do.
+	void reset_after_fork() {
+		__atomic_store_n(&_state, 0, __ATOMIC_RELAXED);
+		if constexpr (Recursive)
+			_recursion = 0;
+	}
 private:
 	uint32_t _state;
 	uint32_t _recursion;

--- a/options/internal/include/mlibc/tcb.hpp
+++ b/options/internal/include/mlibc/tcb.hpp
@@ -103,18 +103,6 @@ struct Tcb {
 	mlibc::thread_exit_return returnValue;
 	TcbThreadReturnValue returnValueType;
 
-	struct AtforkHandler {
-		void (*prepare)(void);
-		void (*parent)(void);
-		void (*child)(void);
-
-		AtforkHandler *next;
-		AtforkHandler *prev;
-	};
-
-	AtforkHandler *atforkBegin;
-	AtforkHandler *atforkEnd;
-
 	struct CleanupHandler {
 		void (*func)(void *);
 		void *arg;

--- a/options/posix/generic/pthread.cpp
+++ b/options/posix/generic/pthread.cpp
@@ -21,6 +21,7 @@
 #include <frg/spinlock.hpp>
 #include <mlibc/all-sysdeps.hpp>
 #include <mlibc/allocator.hpp>
+#include <mlibc/atfork.hpp>
 #include <mlibc/debug.hpp>
 #include <mlibc/thread.hpp>
 #include <mlibc/tcb.hpp>
@@ -732,27 +733,7 @@ int pthread_cancel(pthread_t thread) {
 }
 
 int pthread_atfork(void (*prepare) (void), void (*parent) (void), void (*child) (void)) {
-	auto self = mlibc::get_current_tcb();
-
-	auto hand = frg::construct<Tcb::AtforkHandler>(getAllocator());
-	if (!hand)
-		return ENOMEM;
-
-	hand->prepare = prepare;
-	hand->parent = parent;
-	hand->child = child;
-	hand->next = nullptr;
-	hand->prev = self->atforkEnd;
-
-	if (self->atforkEnd)
-		self->atforkEnd->next = hand;
-
-	self->atforkEnd = hand;
-
-	if (!self->atforkBegin)
-		self->atforkBegin = self->atforkEnd;
-
-	return 0;
+	return mlibc::atfork_register(prepare, parent, child);
 }
 
 // ----------------------------------------------------------------------------

--- a/options/posix/generic/pthread.cpp
+++ b/options/posix/generic/pthread.cpp
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -238,19 +239,36 @@ namespace {
 			return ENOSYS;
 		}
 
+		struct rlimit limit;
+		if (getrlimit(RLIMIT_STACK, &limit)) {
+			int err = errno;
+			fclose(fp);
+			return err;
+		}
+
 		char line[256];
 		auto sp = mlibc::get_sp();
+		uintptr_t prev_to = 0;
 		while (fgets(line, 256, fp)) {
 			uintptr_t from, to;
 			if(sscanf(line, "%" SCNxPTR "-%" SCNxPTR, &from, &to) != 2)
 				continue;
 			if (sp < to && sp > from) {
+				rlim_t size = limit.rlim_cur;
+
+				// The limit can exceed the room below the stack, and it can be
+				// RLIM_INFINITY. Either way the stack cannot grow into the mapping
+				// that precedes it.
+				if (size > to - prev_to)
+					size = to - prev_to;
+
 				// We need to return the lowest byte of the stack.
-				*stack_addr = reinterpret_cast<void*>(from);
-				*stack_size = to - from;
+				*stack_addr = reinterpret_cast<void*>(to - static_cast<size_t>(size));
+				*stack_size = size;
 				fclose(fp);
 				return 0;
 			}
+			prev_to = to;
 		}
 
 		fclose(fp);

--- a/options/posix/generic/unistd.cpp
+++ b/options/posix/generic/unistd.cpp
@@ -20,6 +20,7 @@
 #include <mlibc/all-sysdeps.hpp>
 #include <mlibc/allocator.hpp>
 #include <mlibc/arch-defs.hpp>
+#include <mlibc/atfork.hpp>
 #include <mlibc/debug.hpp>
 #include <mlibc/getopt.hpp>
 #include <mlibc/thread.hpp>
@@ -1284,33 +1285,21 @@ pid_t fork(void) {
 
 	MLIBC_CHECK_OR_ENOSYS(mlibc::IsImplemented<Fork>, -1);
 
-	auto hand = self->atforkEnd;
-	while (hand) {
-		if (hand->prepare)
-			hand->prepare();
-
-		hand = hand->prev;
-	}
+	mlibc::atfork_prepare();
 
 	if(int e = mlibc::sysdep_or_panic<Fork>(&child); e) {
+		// The parent handlers run even when the fork failed.
+		mlibc::atfork_parent();
 		errno = e;
 		return -1;
 	}
 
-	// update the cached TID in the TCB
-	if (!child)
+	if (!child) {
+		// update the cached TID in the TCB
 		__atomic_store_n(&self->tid, mlibc::refetch_tid(), __ATOMIC_RELAXED);
-
-	hand = self->atforkBegin;
-	while (hand) {
-		if (!child) {
-			if (hand->child)
-				hand->child();
-		} else {
-			if (hand->parent)
-				hand->parent();
-		}
-		hand = hand->next;
+		mlibc::atfork_child();
+	} else {
+		mlibc::atfork_parent();
 	}
 
 	return child;

--- a/tests/posix/pthread_atfork.c
+++ b/tests/posix/pthread_atfork.c
@@ -19,9 +19,31 @@ static void parent2() { parent_order = 2; }
 static void child1() { child_order = 1; }
 static void child2() { child_order = 2; }
 
-int main() {
-	assert(!pthread_atfork(prepare1, parent1, child1));
-	assert(!pthread_atfork(prepare2, parent2, child2));
+static int wait_for(pid_t pid) {
+	while (1) {
+		int status = 0;
+
+		int ret = waitpid(pid, &status, 0);
+
+		if (ret == -1 && errno == EINTR)
+			continue;
+
+		assert(ret > 0);
+
+		if (WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT)
+			return 1;
+
+		return WEXITSTATUS(status);
+	}
+}
+
+// Forks and checks that the handlers ran in the order POSIX asks for: the
+// prepare ones in the reverse order of registration, the parent and child ones
+// in the order they were registered.
+static int fork_and_check(void) {
+	prepare_order = 0;
+	parent_order = 0;
+	child_order = 0;
 
 	pid_t pid = fork();
 	assert(pid >= 0);
@@ -29,26 +51,32 @@ int main() {
 	if (!pid) {
 		assert(child_order == 2);
 		exit(0);
-	} else {
-		assert(prepare_order == 1);
-		assert(parent_order == 2);
-
-		while (1) {
-			int status = 0;
-
-			int ret = waitpid(pid, &status, 0);
-
-			if (ret == -1 && errno == EINTR)
-				continue;
-
-			assert(ret > 0);
-
-			if (WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT)
-				return 1;
-
-			return WEXITSTATUS(status);
-		}
 	}
 
-	return 0;
+	assert(prepare_order == 1);
+	assert(parent_order == 2);
+
+	return wait_for(pid);
+}
+
+static void *forking_thread(void *arg) {
+	*(int *)arg = fork_and_check();
+	return NULL;
+}
+
+int main() {
+	assert(!pthread_atfork(prepare1, parent1, child1));
+	assert(!pthread_atfork(prepare2, parent2, child2));
+
+	int ret = fork_and_check();
+	if (ret)
+		return ret;
+
+	// The handlers belong to the process, so they have to run for a fork from
+	// a thread that did not register any of them either.
+	pthread_t thread;
+	assert(!pthread_create(&thread, NULL, forking_thread, &ret));
+	assert(!pthread_join(thread, NULL));
+
+	return ret;
 }

--- a/tests/posix/pthread_attr.c
+++ b/tests/posix/pthread_attr.c
@@ -4,7 +4,9 @@
 #include <alloca.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/resource.h>
 #include <signal.h>
+#include <stdint.h>
 
 static void test_detachstate() {
 	pthread_attr_t attr;
@@ -199,6 +201,30 @@ static void test_stack() {
 }
 #endif
 
+#if __MLIBC_LINUX_OPTION || defined(USE_HOST_LIBC) || defined(USE_CROSS_LIBC)
+static void test_getattr_np_stack() {
+	pthread_attr_t attr;
+	assert(!pthread_getattr_np(pthread_self(), &attr));
+
+	void *addr;
+	size_t size;
+	assert(!pthread_attr_getstack(&attr, &addr, &size));
+
+	struct rlimit limit;
+	assert(!getrlimit(RLIMIT_STACK, &limit));
+	if (limit.rlim_cur != RLIM_INFINITY)
+		assert(size > limit.rlim_cur / 2);
+
+	// Whatever it reports has to contain the stack we are running on.
+	int here;
+	uintptr_t sp = (uintptr_t)&here;
+	assert(sp >= (uintptr_t)addr);
+	assert(sp < (uintptr_t)addr + size);
+
+	assert(!pthread_attr_destroy(&attr));
+}
+#endif
+
 int main() {
 	test_detachstate();
 	test_stacksize();
@@ -210,6 +236,9 @@ int main() {
 	test_stackaddr();
 #if (!defined(USE_HOST_LIBC) && !defined(USE_CROSS_LIBC)) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 32)
 	test_stack();
+#endif
+#if __MLIBC_LINUX_OPTION || defined(USE_HOST_LIBC) || defined(USE_CROSS_LIBC)
+	test_getattr_np_stack();
 #endif
 
 	return 0;


### PR DESCRIPTION
Fixes for running the Boehm-Demers-Weiser conservative garbage collector (bdwgc, also known as bdw-gc, boehm-gc, libgc). Needed for Nix on mlibc