### PR TITLE
options/bsd: implement issetugid()

### DIFF
--- a/options/bsd/generic/bsd_unistd.cpp
+++ b/options/bsd/generic/bsd_unistd.cpp
@@ -1,0 +1,10 @@
+#include <sys/auxv.h>
+#include <unistd.h>
+
+int issetugid(void) {
+	unsigned long secure;
+	if (!peekauxval(AT_SECURE, &secure) && secure)
+		return 1;
+
+	return getuid() != geteuid() || getgid() != getegid();
+}

--- a/options/bsd/include/bits/bsd/bsd_unistd.h
+++ b/options/bsd/include/bits/bsd/bsd_unistd.h
@@ -1,0 +1,22 @@
+#ifndef _MLIBC_BSD_UNISTD_H
+#define _MLIBC_BSD_UNISTD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <mlibc-config.h>
+
+#ifndef __MLIBC_ABI_ONLY
+
+#if defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE)
+int issetugid(void);
+#endif /* defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE) */
+
+#endif /* !__MLIBC_ABI_ONLY */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MLIBC_BSD_UNISTD_H */

--- a/options/bsd/meson.build
+++ b/options/bsd/meson.build
@@ -7,6 +7,7 @@ libc_sources += files(
 	'generic/ether.cpp',
 	'generic/getopt.cpp',
 	'generic/bsd_stdlib.cpp',
+	'generic/bsd_unistd.cpp',
 	'generic/pty.cpp',
 )
 
@@ -33,6 +34,7 @@ if not no_headers
 	)
 	install_headers(
 		'include/bits/bsd/bsd_stdlib.h',
+		'include/bits/bsd/bsd_unistd.h',
 		subdir: 'bits/bsd'
 	)
 endif

--- a/options/posix/include/unistd.h
+++ b/options/posix/include/unistd.h
@@ -495,6 +495,9 @@ int getresgid(gid_t *__rgid, gid_t *__egid, gid_t *__sgid);
 }
 #endif
 
+#if __MLIBC_BSD_OPTION
+#	include <bits/bsd/bsd_unistd.h>
+#endif
 #if __MLIBC_LINUX_OPTION
 #	include <bits/linux/linux_unistd.h>
 #endif

--- a/tests/bsd/issetugid.c
+++ b/tests/bsd/issetugid.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <unistd.h>
+
+int main(void) {
+	// The tests do not run through a set-user-ID or set-group-ID binary, so the
+	// process never gained privileges it did not start with. That holds whether
+	// or not the user running them is root.
+	assert(!issetugid());
+	return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -66,6 +66,7 @@ all_test_cases = [
 	'bsd/strl',
 	'bsd/sbrk',
 	'bsd/getloadavg',
+	'bsd/issetugid',
 	'posix/sched_setscheduler',
 	'posix/inet_ntop',
 	'posix/inet_pton',
@@ -228,6 +229,7 @@ wrapped_test_cases = [
 
 host_libc_excluded_test_cases = [
 	'bsd/strl', # These functions do not exist on Linux.
+	'bsd/issetugid', # glibc has no issetugid().
 	'glibc/error', # These tests depend on mlibc error messages.
 	'glibc/error_at_line', # These tests depend on mlibc error messages.
 	'rtld/search-order', # See rtld/search-order/meson.build.
@@ -249,6 +251,7 @@ host_libc_noasan_test_cases = [
 
 cross_libc_excluded_test_cases = [
 	'ansi/fenv',
+	'bsd/issetugid', # glibc has no issetugid().
 	'posix/pthread_cancel',
 ]
 


### PR DESCRIPTION
musl, bionic, and the BSDs implement this too.