### PR TITLE
options/rtld: Skip objects w/o dynamic sections in resolveSymbol

### DIFF
--- a/options/rtld/generic/linker.cpp
+++ b/options/rtld/generic/linker.cpp
@@ -1751,6 +1751,9 @@ frg::optional<ObjectSymbol> Scope::resolveSymbol(frg::string_view string,
 		uint64_t skipRts, ResolveFlags flags,
 		frg::optional<SymbolVersion> version) {
 	for (auto object : _objects) {
+		if(object->dynamic == nullptr)
+			continue;
+
 		if((flags & resolveCopy) && object->isMainObject)
 			continue;
 		if((flags & skipGlobalAfterRts) && object->globalRts > skipRts) {


### PR DESCRIPTION
This fixes dlsym() and such panicking with statically linked executables

Other parts (e.g. linkObjects) do seemingly have this check (?)

Also, I couldn't test this on Linux