### PR TITLE
sysdeps/managarm: Pass ManagarmProcessData size to supercall

### DIFF
--- a/sysdeps/managarm/generic/entry.cpp
+++ b/sysdeps/managarm/generic/entry.cpp
@@ -37,7 +37,7 @@ thread_local pthread_once_t has_cached_infos = PTHREAD_ONCE_INIT;
 void actuallyCacheInfos() {
 	posix::ManagarmProcessData data;
 	HEL_CHECK(
-	    helSyscall1(kHelCallSuper + posix::superGetProcessData, reinterpret_cast<HelWord>(&data))
+	    helSyscall2(kHelCallSuper + posix::superGetProcessData, reinterpret_cast<HelWord>(&data), sizeof(posix::ManagarmProcessData))
 	);
 
 	__mlibc_posix_lane = data.posixLane;

--- a/sysdeps/managarm/rtld-generic/support.cpp
+++ b/sysdeps/managarm/rtld-generic/support.cpp
@@ -35,7 +35,7 @@ void cacheFileTable() {
 
 	posix::ManagarmProcessData data;
 	HEL_CHECK(
-	    helSyscall1(kHelCallSuper + posix::superGetProcessData, reinterpret_cast<HelWord>(&data))
+	    helSyscall2(kHelCallSuper + posix::superGetProcessData, reinterpret_cast<HelWord>(&data), sizeof(posix::ManagarmProcessData))
 	);
 	posixLane = data.posixLane;
 	fileTable = data.fileTable;


### PR DESCRIPTION
Simple change to provide forward compatibility when Managarm changes `ManagarmProcessData`.