### PR TITLE
sysdeps/managarm: Drop the fd argument of superCancel

### DIFF
--- a/sysdeps/managarm/generic/file.cpp
+++ b/sysdeps/managarm/generic/file.cpp
@@ -1163,7 +1163,6 @@ int Sysdeps<Poll>::operator()(struct pollfd *fds, nfds_t count, int timeout, int
 	auto [offer, send_req, send_tail, recv_resp] = exchangeMsgsSyncCancellable(
 	    getPosixLane(),
 	    req.cancellation_id(),
-	    -1,
 	    helix_ng::offer(
 	        helix_ng::want_lane,
 	        helix_ng::sendBragiHeadTail(req, getSysdepsAllocator()),
@@ -1248,7 +1247,6 @@ int Sysdeps<Ppoll>::operator()(
 	auto [offer, send_req, send_tail, recv_resp] = exchangeMsgsSyncCancellable(
 	    getPosixLane(),
 	    req.cancellation_id(),
-	    -1,
 	    helix_ng::offer(
 	        helix_ng::want_lane,
 	        helix_ng::sendBragiHeadTail(req, getSysdepsAllocator()),

--- a/sysdeps/managarm/generic/fork-exec.cpp
+++ b/sysdeps/managarm/generic/fork-exec.cpp
@@ -88,7 +88,6 @@ int Sysdeps<Waitpid>::operator()(pid_t pid, int *status, int flags, struct rusag
 	auto [offer, send_head, recv_resp] = exchangeMsgsSyncCancellable(
 	    getPosixLane(),
 	    req.cancellation_id(),
-	    -1,
 	    helix_ng::offer(
 	        helix_ng::sendBragiHeadOnly(req, getSysdepsAllocator()), helix_ng::recvInline()
 	    )

--- a/sysdeps/managarm/include/mlibc/posix-pipe.hpp
+++ b/sysdeps/managarm/include/mlibc/posix-pipe.hpp
@@ -459,7 +459,7 @@ auto exchangeMsgsSync(HelHandle descriptor, Args &&...args) {
 }
 
 template <typename... Args>
-auto exchangeMsgsSyncCancellable(HelHandle descriptor, uint64_t cancelId, int fd, Args &&...args) {
+auto exchangeMsgsSyncCancellable(HelHandle descriptor, uint64_t cancelId, Args &&...args) {
 	auto results = helix_ng::createResultsTuple(args...);
 	auto actions = helix_ng::chainActionArrays(args...);
 
@@ -467,10 +467,9 @@ auto exchangeMsgsSyncCancellable(HelHandle descriptor, uint64_t cancelId, int fd
 
 	auto element = globalQueue.dequeueSingleUnlessCancelled();
 	if (!element) {
-		HEL_CHECK(helSyscall2(
+		HEL_CHECK(helSyscall1(
 			kHelCallSuper + posix::superCancel,
-			cancelId,
-			fd
+			cancelId
 		));
 		element = globalQueue.dequeueSingle();
 	}


### PR DESCRIPTION
This argument has been dropped at the Managarm side already.